### PR TITLE
feat: open avatar editor in world

### DIFF
--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -84,6 +84,8 @@ export const PREVIEW: boolean = !!(global as any).preview
 export const EDITOR: boolean = !!(global as any).isEditor
 export const WORLD_EXPLORER = !EDITOR && !PREVIEW
 
+export const OPEN_AVATAR_EDITOR = location.search.indexOf('OPEN_AVATAR_EDITOR') !== -1 && WORLD_EXPLORER
+
 export const STATIC_WORLD = location.search.indexOf('STATIC_WORLD') !== -1 || !!(global as any).staticWorld || EDITOR
 
 // Development

--- a/kernel/packages/entryPoints/unity.ts
+++ b/kernel/packages/entryPoints/unity.ts
@@ -7,6 +7,7 @@ import { lastPlayerPosition, teleportObservable } from '../shared/world/position
 import { HUD, startUnityParcelLoading } from '../unity-interface/dcl'
 import { initializeUnity } from '../unity-interface/initializer'
 import { experienceStarted } from '../shared/loading/types'
+import { OPEN_AVATAR_EDITOR } from '../config/index'
 
 const container = document.getElementById('gameContainer')
 
@@ -19,7 +20,7 @@ initializeUnity(container)
     HUD.Minimap.configure({ active: true, visible: true })
     HUD.Avatar.configure({ active: true, visible: true })
     HUD.Notification.configure({ active: true, visible: true })
-    HUD.AvatarEditor.configure({ active: true, visible: false })
+    HUD.AvatarEditor.configure({ active: true, visible: OPEN_AVATAR_EDITOR })
 
     global['globalStore'].dispatch(signalRendererInitialized())
     await startUnityParcelLoading()


### PR DESCRIPTION
WHAT: Load Explorer as usual and as user would gain control open Avatar Edit.

WHY: avatars.decentraland.org is not on feature parity with client, so we need to redirect those users to the World Explorer.
