### PR TITLE
fix: limit raycast queries per frame

### DIFF
--- a/kernel/packages/decentraland-ecs/src/decentraland/PhysicsCast.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/PhysicsCast.ts
@@ -88,12 +88,14 @@ export interface RaycastHitAvatars extends RaycastHit {
  * @public
  */
 export interface IPhysicsCast {
-  hitFirst: (ray: Ray, hitCallback: (event: RaycastHitEntity) => void) => void
-  hitAll: (ray: Ray, hitCallback: (event: RaycastHitEntities) => void) => void
+  hitFirst(ray: Ray, hitCallback: (event: RaycastHitEntity) => void): void
+  hitAll(ray: Ray, hitCallback: (event: RaycastHitEntities) => void): void
+  hitFirst(ray: Ray, hitCallback: (event: RaycastHitEntity) => void, id: number): void
+  hitAll(ray: Ray, hitCallback: (event: RaycastHitEntities) => void, id: number): void
   /** @internal */
-  hitFirstAvatar: (ray: Ray, hitCallback: (event: RaycastHitAvatar) => void) => void
+  hitFirstAvatar(ray: Ray, hitCallback: (event: RaycastHitAvatar) => void): void
   /** @internal */
-  hitAllAvatars: (ray: Ray, hitCallback: (event: RaycastHitAvatars) => void) => void
+  hitAllAvatars(ray: Ray, hitCallback: (event: RaycastHitAvatars) => void): void
 }
 
 /** @internal */
@@ -147,16 +149,16 @@ export class PhysicsCast implements IPhysicsCast {
     return ray
   }
 
-  public hitFirst(ray: Ray, hitCallback: (event: RaycastHitEntity) => void) {
-    const queryId = uuid()
+  public hitFirst(ray: Ray, hitCallback: (event: RaycastHitEntity) => void, id?: number) {
+    const queryId = typeof id === 'number' ? 'rqhf' + id : uuid()
 
     this.queries[queryId] = hitCallback as (event: RaycastHit) => void
 
     dcl && dcl.query('raycast', { queryId, queryType: 'HitFirst', ray })
   }
 
-  public hitAll(ray: Ray, hitCallback: (event: RaycastHitEntities) => void) {
-    const queryId = uuid()
+  public hitAll(ray: Ray, hitCallback: (event: RaycastHitEntities) => void, id?: number) {
+    const queryId = typeof id === 'number' ? 'rqha' + id : uuid()
 
     this.queries[queryId] = hitCallback as (event: RaycastHit) => void
 

--- a/kernel/packages/decentraland-ecs/src/decentraland/PhysicsCast.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/PhysicsCast.ts
@@ -14,7 +14,7 @@ export type QueryType = 'HitFirst' | 'HitAll' | 'HitFirstAvatar' | 'HitAllAvatar
 /**
  * @internal
  */
-export enum QueryPrefix {
+enum QueryPrefix {
   HitFirst = 'rqhf',
   HitAll = 'rqha'
 }

--- a/kernel/packages/decentraland-ecs/src/decentraland/PhysicsCast.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/PhysicsCast.ts
@@ -14,6 +14,14 @@ export type QueryType = 'HitFirst' | 'HitAll' | 'HitFirstAvatar' | 'HitAllAvatar
 /**
  * @internal
  */
+export enum QueryPrefix {
+  HitFirst = 'rqhf',
+  HitAll = 'rqha'
+}
+
+/**
+ * @internal
+ */
 export interface RaycastQuery {
   queryId: string
   queryType: QueryType
@@ -88,10 +96,8 @@ export interface RaycastHitAvatars extends RaycastHit {
  * @public
  */
 export interface IPhysicsCast {
-  hitFirst(ray: Ray, hitCallback: (event: RaycastHitEntity) => void): void
-  hitAll(ray: Ray, hitCallback: (event: RaycastHitEntities) => void): void
-  hitFirst(ray: Ray, hitCallback: (event: RaycastHitEntity) => void, id: number): void
-  hitAll(ray: Ray, hitCallback: (event: RaycastHitEntities) => void, id: number): void
+  hitFirst(ray: Ray, hitCallback: (event: RaycastHitEntity) => void, id?: number): void
+  hitAll(ray: Ray, hitCallback: (event: RaycastHitEntities) => void, id?: number): void
   /** @internal */
   hitFirstAvatar(ray: Ray, hitCallback: (event: RaycastHitAvatar) => void): void
   /** @internal */
@@ -150,7 +156,7 @@ export class PhysicsCast implements IPhysicsCast {
   }
 
   public hitFirst(ray: Ray, hitCallback: (event: RaycastHitEntity) => void, id?: number) {
-    const queryId = typeof id === 'number' ? 'rqhf' + id : uuid()
+    const queryId = typeof id === 'number' ? QueryPrefix.HitFirst + id : uuid()
 
     this.queries[queryId] = hitCallback as (event: RaycastHit) => void
 
@@ -158,7 +164,7 @@ export class PhysicsCast implements IPhysicsCast {
   }
 
   public hitAll(ray: Ray, hitCallback: (event: RaycastHitEntities) => void, id?: number) {
-    const queryId = typeof id === 'number' ? 'rqha' + id : uuid()
+    const queryId = typeof id === 'number' ? QueryPrefix.HitAll + id : uuid()
 
     this.queries[queryId] = hitCallback as (event: RaycastHit) => void
 

--- a/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
@@ -54,7 +54,7 @@ export type DecentralandInterface = {
 
   // QUERY
 
-  query(queryId: string, payload: any): void
+  query(queryType: string, payload: any): void
 
   // COMPONENTS
 

--- a/kernel/packages/scene-system/scene.system.ts
+++ b/kernel/packages/scene-system/scene.system.ts
@@ -160,11 +160,13 @@ export default class GamekitScene extends Script {
       const html = await fetch(url)
 
       if (html.ok) {
-        return html.text()
+        return [bootstrapData.sceneId, await html.text()] as const
       } else {
         throw new Error(`SDK: Error while loading ${url} (${mappingName} -> ${mapping})`)
       }
     }
+
+    throw new Error(`No bootstrap data`)
   }
 
   fireEvent(event: any) {
@@ -182,7 +184,7 @@ export default class GamekitScene extends Script {
     this.devToolsAdapter = new DevToolsAdapter(this.devTools)
 
     try {
-      const source = await this.loadProject()
+      const [sceneId, source] = await this.loadProject()
 
       if (!source) {
         throw new Error('Received empty source.')
@@ -240,7 +242,7 @@ export default class GamekitScene extends Script {
           if (componentNameRE.test(componentName)) {
             that.events.push({
               type: 'UpdateEntityComponent',
-              tag: entityId + '_' + classId,
+              tag: sceneId + '_' + entityId + '_' + classId,
               payload: {
                 entityId,
                 classId,
@@ -296,7 +298,7 @@ export default class GamekitScene extends Script {
         query(queryType: QueryType, payload: any) {
           that.events.push({
             type: 'Query',
-            tag: payload.queryId,
+            tag: sceneId + '_' + payload.queryId,
             payload: {
               queryId: queryType,
               payload

--- a/kernel/packages/scene-system/scene.system.ts
+++ b/kernel/packages/scene-system/scene.system.ts
@@ -293,11 +293,12 @@ export default class GamekitScene extends Script {
         },
 
         /** queries for a specific system with a certain query configuration */
-        query(queryId: QueryType, payload: any) {
+        query(queryType: QueryType, payload: any) {
           that.events.push({
             type: 'Query',
+            tag: payload.queryId,
             payload: {
-              queryId,
+              queryId: queryType,
               payload
             } as QueryPayload
           })

--- a/kernel/public/test-scenes/-100.50.raycasting/game.ts
+++ b/kernel/public/test-scenes/-100.50.raycasting/game.ts
@@ -114,7 +114,7 @@ class RaycastingSystem implements ISystem {
           }
         }
       }
-    })
+    }, 0)
 
     // For the camera ray, we cast a hit all
     PhysicsCast.instance.hitAll(rayFromCamera, (e) => {
@@ -125,7 +125,7 @@ class RaycastingSystem implements ISystem {
           }
         }
       }
-    })
+    }, 0)
   }
 }
 

--- a/unity-client/Assets/Resources/Prefabs/SceneController.prefab
+++ b/unity-client/Assets/Resources/Prefabs/SceneController.prefab
@@ -409,6 +409,8 @@ MonoBehaviour:
   debugSceneCoords: {x: 63, y: -63}
   ignoreGlobalScenes: 0
   msgStepByStep: 0
+  deferredMessagesDecoding: 1
+  scenesSortedByDistance: []
 --- !u!114 &1210811942730548506
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1069,6 +1071,16 @@ PrefabInstance:
     - target: {fileID: 6782600336347656692, guid: 343005e32016c60479b0584c59812b4b,
         type: 3}
       propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6782600336347656692, guid: 343005e32016c60479b0584c59812b4b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 1371
+      objectReference: {fileID: 0}
+    - target: {fileID: 6782600336347656692, guid: 343005e32016c60479b0584c59812b4b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9015994244967614587, guid: 343005e32016c60479b0584c59812b4b,

--- a/unity-client/Assets/Resources/Prefabs/SceneController.prefab
+++ b/unity-client/Assets/Resources/Prefabs/SceneController.prefab
@@ -410,7 +410,6 @@ MonoBehaviour:
   ignoreGlobalScenes: 0
   msgStepByStep: 0
   deferredMessagesDecoding: 1
-  scenesSortedByDistance: []
 --- !u!114 &1210811942730548506
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1076,7 +1075,7 @@ PrefabInstance:
     - target: {fileID: 6782600336347656692, guid: 343005e32016c60479b0584c59812b4b,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 1371
+      value: 1028
       objectReference: {fileID: 0}
     - target: {fileID: 6782600336347656692, guid: 343005e32016c60479b0584c59812b4b,
         type: 3}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/PhysicsCast/Tests/PhysicsCastTest.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/PhysicsCast/Tests/PhysicsCastTest.cs
@@ -26,18 +26,6 @@ public class PhysicsCast_Tests : TestsBase
         alreadyInitialized = true;
     }
 
-    void InstantiateEntityWithShape(Vector3 pos, Vector3 scale, out DecentralandEntity entity, out BoxShape shape)
-    {
-        shape = TestHelpers.InstantiateEntityWithShape<BoxShape, BoxShape.Model>(
-            scene,
-            DCL.Models.CLASS_ID.BOX_SHAPE,
-            Vector3.zero,
-            out entity,
-            new BoxShape.Model() { });
-
-        TestHelpers.SetEntityTransform(scene, entity, pos, Quaternion.identity, scale);
-    }
-
     private void ConfigureRaycastQuery(string queryType)
     {
         DCLCharacterController.i.SetPosition(startPos);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/PhysicsCast/Tests/PhysicsCastTest.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/PhysicsCast/Tests/PhysicsCastTest.cs
@@ -101,44 +101,22 @@ public class PhysicsCast_Tests : TestsBase
         response.payload.entity = new WebInterface.HitEntityInfo();
         response.payload.entity.entityId = entities[0].entityId;
 
-        string targetEventType = "SceneEvent";
         var sceneEvent = new WebInterface.SceneEvent<WebInterface.RaycastHitFirstResponse>();
-        sceneEvent.sceneId = scene.sceneData.id;
-        sceneEvent.payload = response;
-        sceneEvent.eventType = "raycastResponse";
 
         bool eventTriggered = false;
         int responseCount = 0;
 
-        yield return TestHelpers.WaitForEventFromEngine(targetEventType, sceneEvent,
-            () =>
-            {
-                sceneController.SendSceneMessage(System.Convert.ToBase64String(sendSceneMessage.ToByteArray()));
-                sceneController.SendSceneMessage(System.Convert.ToBase64String(sendSceneMessage.ToByteArray()));
-                sceneController.SendSceneMessage(System.Convert.ToBase64String(sendSceneMessage.ToByteArray()));
-            },
+        yield return SendRaycastQueryMessage<WebInterface.RaycastHitFirstResponse, WebInterface.RaycastHitEntity>(
+            sceneEvent, response,
             (raycastResponse) =>
             {
                 responseCount++;
                 Assert.IsTrue(responseCount == 1, "This raycast query should be lossy and therefore excecuted once.");
                 Assert.IsTrue(raycastResponse != null);
-                Assert.IsTrue(raycastResponse.eventType == sceneEvent.eventType);
-                Assert.IsTrue(raycastResponse.sceneId == sceneEvent.sceneId);
-                Assert.IsTrue(raycastResponse.payload.queryId == sceneEvent.payload.queryId);
-                Assert.IsTrue(raycastResponse.payload.queryType == sceneEvent.payload.queryType);
-                Assert.IsTrue(raycastResponse.payload.payload.ray.distance == sceneEvent.payload.payload.ray.distance);
-                Assert.IsTrue(raycastResponse.payload.payload.ray.direction == sceneEvent.payload.payload.ray.direction);
-                Assert.IsTrue(raycastResponse.payload.payload.ray.origin == sceneEvent.payload.payload.ray.origin);
                 Assert.IsTrue(raycastResponse.payload.payload.entity.entityId == sceneEvent.payload.payload.entity.entityId);
 
                 if (raycastResponse != null &&
-                    raycastResponse.eventType == sceneEvent.eventType &&
-                    raycastResponse.sceneId == sceneEvent.sceneId &&
-                    raycastResponse.payload.queryId == sceneEvent.payload.queryId &&
-                    raycastResponse.payload.queryType == sceneEvent.payload.queryType &&
-                    raycastResponse.payload.payload.ray.distance == sceneEvent.payload.payload.ray.distance &&
-                    raycastResponse.payload.payload.ray.direction == sceneEvent.payload.payload.ray.direction &&
-                    raycastResponse.payload.payload.ray.origin == sceneEvent.payload.payload.ray.origin &&
+                    AreSceneEventsEqual<WebInterface.RaycastHitFirstResponse, WebInterface.RaycastHitEntity>(raycastResponse, sceneEvent) &&
                     raycastResponse.payload.payload.entity.entityId == sceneEvent.payload.payload.entity.entityId)
                 {
                     eventTriggered = true;
@@ -195,43 +173,22 @@ public class PhysicsCast_Tests : TestsBase
             response.payload.entities[i].entity.entityId = entities[i].entityId;
         }
 
-        string targetEventType = "SceneEvent";
         var sceneEvent = new WebInterface.SceneEvent<WebInterface.RaycastHitAllResponse>();
-        sceneEvent.sceneId = scene.sceneData.id;
-        sceneEvent.payload = response;
-        sceneEvent.eventType = "raycastResponse";
 
         bool eventTriggered = false;
         int responseCount = 0;
 
-        yield return TestHelpers.WaitForEventFromEngine(targetEventType, sceneEvent,
-            () =>
-            {
-                sceneController.SendSceneMessage(System.Convert.ToBase64String(sendSceneMessage.ToByteArray()));
-                sceneController.SendSceneMessage(System.Convert.ToBase64String(sendSceneMessage.ToByteArray()));
-                sceneController.SendSceneMessage(System.Convert.ToBase64String(sendSceneMessage.ToByteArray()));
-            },
+        yield return SendRaycastQueryMessage<WebInterface.RaycastHitAllResponse, WebInterface.RaycastHitEntities>(
+            sceneEvent, response,
             (raycastResponse) =>
             {
                 responseCount++;
                 Assert.IsTrue(responseCount == 1, "This raycast query should be lossy and therefore excecuted once.");
                 Assert.IsTrue(raycastResponse != null);
-                Assert.IsTrue(raycastResponse.eventType == sceneEvent.eventType);
-                Assert.IsTrue(raycastResponse.sceneId == sceneEvent.sceneId);
-                Assert.IsTrue(raycastResponse.payload.queryId == sceneEvent.payload.queryId);
-                Assert.IsTrue(raycastResponse.payload.queryType == sceneEvent.payload.queryType);
-                Assert.IsTrue(raycastResponse.payload.payload.ray.distance == sceneEvent.payload.payload.ray.distance);
-                Assert.IsTrue(raycastResponse.payload.payload.ray.direction == sceneEvent.payload.payload.ray.direction);
-                Assert.IsTrue(raycastResponse.payload.payload.ray.origin == sceneEvent.payload.payload.ray.origin);
+                Assert.IsTrue(raycastResponse.payload.payload.entities.Length == ENTITIES_COUNT);
 
                 if (raycastResponse != null &&
-                    raycastResponse.eventType == sceneEvent.eventType &&
-                    raycastResponse.sceneId == sceneEvent.sceneId &&
-                    raycastResponse.payload.queryId == sceneEvent.payload.queryId &&
-                    raycastResponse.payload.queryType == sceneEvent.payload.queryType &&
-                    raycastResponse.payload.payload.ray.distance == sceneEvent.payload.payload.ray.distance &&
-                    raycastResponse.payload.payload.ray.direction == sceneEvent.payload.payload.ray.direction &&
-                    raycastResponse.payload.payload.ray.origin == sceneEvent.payload.payload.ray.origin &&
+                    AreSceneEventsEqual<WebInterface.RaycastHitAllResponse, WebInterface.RaycastHitEntities>(raycastResponse, sceneEvent) &&
                     raycastResponse.payload.payload.entities.Length == ENTITIES_COUNT)
                 {
                     for (int i = 0; i < raycastResponse.payload.payload.entities.Length; i++)
@@ -261,5 +218,56 @@ public class PhysicsCast_Tests : TestsBase
 
         Assert.IsTrue(eventTriggered);
     }
+
+    private IEnumerator SendRaycastQueryMessage<T, T2>(WebInterface.SceneEvent<T> sceneEvent, T response, System.Func<WebInterface.SceneEvent<T>, bool> OnSuccess) where T2 : WebInterface.RaycastHitInfo where T : WebInterface.RaycastResponse<T2>
+    {
+        string targetEventType = "SceneEvent";
+
+        sceneEvent.sceneId = scene.sceneData.id;
+        sceneEvent.payload = response;
+        sceneEvent.eventType = "raycastResponse";
+
+        yield return TestHelpers.WaitForEventFromEngine<WebInterface.SceneEvent<T>>(targetEventType, sceneEvent,
+            () =>
+            {
+                // Note (Zak): we send several times the same message to ensure it's
+                // only processed once (lossy messages)
+                sceneController.SendSceneMessage(System.Convert.ToBase64String(sendSceneMessage.ToByteArray()));
+                sceneController.SendSceneMessage(System.Convert.ToBase64String(sendSceneMessage.ToByteArray()));
+                sceneController.SendSceneMessage(System.Convert.ToBase64String(sendSceneMessage.ToByteArray()));
+            },
+            OnSuccess);
+    }
+
+
+
+    private bool AreSceneEventsEqual<T, T2>(WebInterface.SceneEvent<T> s1, WebInterface.SceneEvent<T> s2) where T2 : WebInterface.RaycastHitInfo where T : WebInterface.RaycastResponse<T2>
+    {
+        Assert.IsTrue(s1.eventType == s2.eventType);
+        Assert.IsTrue(s1.sceneId == s2.sceneId);
+
+        if (s1.eventType != s2.eventType ||
+            s1.sceneId != s2.sceneId)
+            return false;
+
+        return AreRaycastResponsesEqual(s1.payload, s2.payload);
+    }
+
+    private bool AreRaycastResponsesEqual<T>(WebInterface.RaycastResponse<T> r1, WebInterface.RaycastResponse<T> r2) where T : WebInterface.RaycastHitInfo
+    {
+        Assert.IsTrue(r1.queryId == r2.queryId);
+        Assert.IsTrue(r1.queryType == r2.queryType);
+        Assert.IsTrue(r1.payload.ray.distance == r2.payload.ray.distance);
+        Assert.IsTrue(r1.payload.ray.direction == r2.payload.ray.direction);
+        Assert.IsTrue(r1.payload.ray.origin == r2.payload.ray.origin);
+
+        return r1.queryId == r2.queryId &&
+               r1.queryType == r2.queryType &&
+               r1.payload.ray.distance == r2.payload.ray.distance &&
+               r1.payload.ray.direction == r2.payload.ray.direction &&
+               r1.payload.ray.origin == r2.payload.ray.origin;
+    }
+
+
 }
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/PhysicsCast/Tests/PhysicsCastTest.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/PhysicsCast/Tests/PhysicsCastTest.cs
@@ -78,9 +78,7 @@ public class PhysicsCast_Tests : TestsBase
         for (int i = 0; i < ENTITIES_COUNT; i++)
         {
             DecentralandEntity entity;
-            BoxShape shape;
-
-            InstantiateEntityWithShape(pos, new Vector3(5, 10, 1), out entity, out shape);
+            BoxShape shape = TestHelpers.CreateEntityWithBoxShape(scene, pos, new Vector3(5, 10, 1), out entity);
             yield return shape.routine;
 
             DCL.CollidersManager.i.ConfigureColliders(entity.meshRootGameObject, true, false, entity);
@@ -142,9 +140,7 @@ public class PhysicsCast_Tests : TestsBase
         for (int i = 0; i < ENTITIES_COUNT; i++)
         {
             DecentralandEntity entity;
-            BoxShape shape;
-
-            InstantiateEntityWithShape(pos, new Vector3(5, 10, 1), out entity, out shape);
+            BoxShape shape = TestHelpers.CreateEntityWithBoxShape(scene, pos, new Vector3(5, 10, 1), out entity);
             yield return shape.routine;
 
             DCL.CollidersManager.i.ConfigureColliders(entity.meshRootGameObject, true, false, entity);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingBus.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingBus.cs
@@ -199,11 +199,6 @@ namespace DCL
 
         private void RemoveUnreliableMessage(MessagingBus.QueuedSceneMessage message)
         {
-            // Note (Zak): Right now it's not necessary to check if this key exists
-            // within the dictionary, because this is the only place were it's 
-            // removed and it's called *only* when processing a message, so we
-            // know it's there. In the future, if we think this is slowing down
-            // things, we could remove it. 
             if (unreliableMessages.ContainsKey(message.unreliableMessageKey))
                 unreliableMessages.Remove(message.unreliableMessageKey);
         }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingBus.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingBus.cs
@@ -159,11 +159,7 @@ namespace DCL
 
                 LinkedListNode<MessagingBus.QueuedSceneMessage> node = null;
 
-                stringBuilder.Clear();
-                stringBuilder.Append(message.tag);
-                stringBuilder.Append(message.sceneId);
-
-                message.unreliableMessageKey = stringBuilder.ToString();
+                message.unreliableMessageKey = message.tag;
 
                 if (unreliableMessages.ContainsKey(message.unreliableMessageKey))
                 {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingController.cs
@@ -155,6 +155,7 @@ namespace DCL
             }
             else if (queuedMessage.method == MessagingTypes.QUERY)
             {
+                busId = MessagingBusId.UI;
                 queueMode = QueueMode.Lossy;
             }
             else if (queuedMessage.method == MessagingTypes.INIT_DONE)

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingController.cs
@@ -32,6 +32,7 @@ namespace DCL
 
     public class MessagingController : IDisposable
     {
+        const char SEPARATOR = '_';
         public enum QueueState
         {
             Init,
@@ -169,8 +170,9 @@ namespace DCL
 
         private void GetEntityIdAndClassIdFromTag(string tag, out int classId)
         {
-            int lastSeparator = tag.LastIndexOf('_');
-            classId = System.Convert.ToInt32(tag.Substring(lastSeparator + 1));
+            int lastSeparator = tag.LastIndexOf(SEPARATOR);
+            if (!int.TryParse(tag.Substring(lastSeparator + 1), out classId))
+                Debug.LogError("Couldn't parse classId string to int");
         }
 
         private string FormatQueueId(string sceneId, string tag)

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingController.cs
@@ -140,7 +140,7 @@ namespace DCL
             if (queuedMessage.method == MessagingTypes.ENTITY_COMPONENT_CREATE_OR_UPDATE)
             {
                 // By default, the tag is the id of the entity/component
-                string entityId = queuedMessage.tag;
+                string entityId = queuedMessage.payload.Tag;
                 int classId = 0;
 
                 // We need to extract the entityId and the classId from the tag.
@@ -152,6 +152,10 @@ namespace DCL
                 {
                     queueMode = QueueMode.Lossy;
                 }
+            }
+            else if (queuedMessage.method == MessagingTypes.QUERY)
+            {
+                queueMode = QueueMode.Lossy;
             }
             else if (queuedMessage.method == MessagingTypes.INIT_DONE)
             {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingController.cs
@@ -139,13 +139,11 @@ namespace DCL
             // Check if the message type is an UpdateEntityComponent 
             if (queuedMessage.method == MessagingTypes.ENTITY_COMPONENT_CREATE_OR_UPDATE)
             {
-                // By default, the tag is the id of the entity/component
-                string entityId = queuedMessage.payload.Tag;
                 int classId = 0;
 
                 // We need to extract the entityId and the classId from the tag.
                 // The tag format is "entityId_classId", i.e: "E1_2". 
-                GetEntityIdAndClassIdFromTag(queuedMessage.tag, out entityId, out classId);
+                GetEntityIdAndClassIdFromTag(queuedMessage.tag, out classId);
 
                 // If it is a transform update, the queue mode is Lossy
                 if (classId == (int)CLASS_ID_COMPONENT.TRANSFORM)
@@ -169,11 +167,10 @@ namespace DCL
             messagingBuses[busId].Enqueue(queuedMessage, queueMode);
         }
 
-        private void GetEntityIdAndClassIdFromTag(string tag, out string entityId, out int classId)
+        private void GetEntityIdAndClassIdFromTag(string tag, out int classId)
         {
-            int separator = tag.IndexOf('_');
-            entityId = tag.Substring(0, separator);
-            classId = System.Convert.ToInt32(tag.Substring(separator + 1));
+            int lastSeparator = tag.LastIndexOf('_');
+            classId = System.Convert.ToInt32(tag.Substring(lastSeparator + 1));
         }
 
         private string FormatQueueId(string sceneId, string tag)

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingControllersManager.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingControllersManager.cs
@@ -9,12 +9,12 @@ namespace DCL
     {
         public static bool VERBOSE = false;
 
-        private const float GLOBAL_MAX_MSG_BUDGET = 0.01f;
+        private const float GLOBAL_MAX_MSG_BUDGET = 0.016f;
         private const float GLOBAL_MAX_MSG_BUDGET_WHEN_LOADING = 1f;
         private const float GLOBAL_MIN_MSG_BUDGET_WHEN_LOADING = 1f;
-        public const float UI_MSG_BUS_BUDGET_MAX = 0.01f;
+        public const float UI_MSG_BUS_BUDGET_MAX = 0.013f;
         public const float INIT_MSG_BUS_BUDGET_MAX = 0.016f;
-        public const float SYSTEM_MSG_BUS_BUDGET_MAX = 0.01f;
+        public const float SYSTEM_MSG_BUS_BUDGET_MAX = 0.013f;
         public const float MSG_BUS_BUDGET_MIN = 0.00001f;
         private const float GLTF_BUDGET_MAX = 0.033f;
         private const float GLTF_BUDGET_MIN = 0.008f;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
@@ -121,30 +121,13 @@ namespace DCL
         {
             ParcelScene.parcelScenesCleaner.Stop();
         }
-        int showCount = 0;
-        int count = 0;
         private void Update()
         {
-            showCount = count;
-            count = 0;
-
             InputController.i.Update();
 
             PrioritizeMessageControllerList();
 
             MessagingControllersManager.i.UpdateThrottling();
-        }
-        float lastTime = 0;
-        int counterToShow = 0;
-        void OnGUI()
-        {
-            if (Time.realtimeSinceStartup - lastTime >= 0.25f)
-            {
-                lastTime = Time.realtimeSinceStartup;
-                counterToShow = showCount;
-            }
-
-            GUILayout.Label("Queries per update: " + counterToShow);
         }
 
         private void PrioritizeMessageControllerList(bool force = false)
@@ -508,10 +491,10 @@ namespace DCL
         }
 
         Queue<string> payloadsToDecode = new Queue<string>();
-        const float MAX_TIME_FOR_DECODE = 0.033f;
-        const float MIN_TIME_FOR_DECODE = 0.016f;
+        const float MAX_TIME_FOR_DECODE = 0.1f;
+        const float MIN_TIME_FOR_DECODE = 0.001f;
         float maxTimeForDecode = MAX_TIME_FOR_DECODE;
-        float secsPerThousandMsgs = 0.0075f;
+        float secsPerThousandMsgs = 0.01f;
         private IEnumerator DeferredDecoding()
         {
             float lastTimeDecoded = Time.unscaledTime;
@@ -528,7 +511,7 @@ namespace DCL
                     {
                         yield return null;
                         maxTimeForDecode = Mathf.Clamp(MIN_TIME_FOR_DECODE + (float)payloadsToDecode.Count / 1000.0f * secsPerThousandMsgs, MIN_TIME_FOR_DECODE, MAX_TIME_FOR_DECODE);
-                        lastTimeDecoded = Time.unscaledTime;
+                        lastTimeDecoded = Time.realtimeSinceStartup;
                     }
                 }
                 else
@@ -676,7 +659,6 @@ namespace DCL
 
         public void ParseQuery(string queryId, string payload, string sceneId)
         {
-            count++;
             QueryMessage query = new QueryMessage();
 
             MessageDecoder.DecodeQueryMessage(queryId, payload, ref query);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
@@ -582,6 +582,7 @@ namespace DCL
                 OnMessageProcessInfoStart?.Invoke(sceneId, method);
 #endif
                 OnMessageProcessStart?.Invoke(method);
+
                 switch (method)
                 {
                     case MessagingTypes.ENTITY_CREATE:

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
@@ -66,7 +66,7 @@ namespace DCL
         public event ProcessDelegate OnMessageProcessInfoStart;
         public event ProcessDelegate OnMessageProcessInfoEnds;
 #endif
-        [NonSerialized]
+        [System.NonSerialized]
         public List<ParcelScene> scenesSortedByDistance = new List<ParcelScene>();
         private Queue<MessagingBus.QueuedSceneMessage_Scene> sceneMessagesPool = new Queue<MessagingBus.QueuedSceneMessage_Scene>();
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
@@ -121,14 +121,30 @@ namespace DCL
         {
             ParcelScene.parcelScenesCleaner.Stop();
         }
-
+        int showCount = 0;
+        int count = 0;
         private void Update()
         {
+            showCount = count;
+            count = 0;
+
             InputController.i.Update();
 
             PrioritizeMessageControllerList();
 
             MessagingControllersManager.i.UpdateThrottling();
+        }
+        float lastTime = 0;
+        int counterToShow = 0;
+        void OnGUI()
+        {
+            if (Time.realtimeSinceStartup - lastTime >= 0.25f)
+            {
+                lastTime = Time.realtimeSinceStartup;
+                counterToShow = showCount;
+            }
+
+            GUILayout.Label("Queries per update: " + counterToShow);
         }
 
         private void PrioritizeMessageControllerList(bool force = false)
@@ -493,7 +509,7 @@ namespace DCL
 
         Queue<string> payloadsToDecode = new Queue<string>();
         const float MAX_TIME_FOR_DECODE = 0.033f;
-        const float MIN_TIME_FOR_DECODE = 0.008f;
+        const float MIN_TIME_FOR_DECODE = 0.016f;
         float maxTimeForDecode = MAX_TIME_FOR_DECODE;
         float secsPerThousandMsgs = 0.0075f;
         private IEnumerator DeferredDecoding()
@@ -660,6 +676,7 @@ namespace DCL
 
         public void ParseQuery(string queryId, string payload, string sceneId)
         {
+            count++;
             QueryMessage query = new QueryMessage();
 
             MessageDecoder.DecodeQueryMessage(queryId, payload, ref query);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
@@ -36,6 +36,7 @@ namespace DCL
         public Vector2Int debugSceneCoords;
         public bool ignoreGlobalScenes = false;
         public bool msgStepByStep = false;
+        public bool deferredMessagesDecoding = false;
 
         #region BENCHMARK_EVENTS
 
@@ -114,7 +115,8 @@ namespace DCL
 
             ParcelScene.parcelScenesCleaner.Start();
 
-            StartCoroutine(DeferredDecoding());
+            if (deferredMessagesDecoding)
+                StartCoroutine(DeferredDecoding());
         }
 
         void OnDestroy()
@@ -448,7 +450,7 @@ namespace DCL
 
             for (int i = 0; i < count; i++)
             {
-                if (RenderingController.i.renderingEnabled && enqueue)
+                if (deferredMessagesDecoding && RenderingController.i.renderingEnabled && enqueue)
                 {
                     payloadsToDecode.Enqueue(chunks[i]);
                 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
@@ -66,6 +66,7 @@ namespace DCL
         public event ProcessDelegate OnMessageProcessInfoStart;
         public event ProcessDelegate OnMessageProcessInfoEnds;
 #endif
+        [NonSerialized]
         public List<ParcelScene> scenesSortedByDistance = new List<ParcelScene>();
         private Queue<MessagingBus.QueuedSceneMessage_Scene> sceneMessagesPool = new Queue<MessagingBus.QueuedSceneMessage_Scene>();
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Tests/MessageTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Tests/MessageTests.cs
@@ -32,6 +32,8 @@ namespace Tests
         {
             yield return InitScene();
 
+            sceneController.deferredMessagesDecoding = false;
+
             var entity = TestHelpers.CreateSceneEntity(scene);
 
             yield return null;
@@ -48,8 +50,7 @@ namespace Tests
                             classId = (int)CLASS_ID_COMPONENT.AVATAR_SHAPE,
                             json = JsonUtility.ToJson(new AvatarModel())
                         }
-                    )),
-                    enqueue: false
+                    ))
             );
 
             sceneController.SendSceneMessage(
@@ -64,8 +65,7 @@ namespace Tests
                             classId = (int)CLASS_ID_COMPONENT.AVATAR_SHAPE,
                             json = JsonUtility.ToJson(new AvatarModel())
                         }
-                    )),
-                    enqueue: false
+                    ))
             );
 
             sceneController.OnMessageProcessInfoStart += delegate (string id, string method)
@@ -152,8 +152,7 @@ namespace Tests
                         new CreateEntityMessage
                         {
                             id = entityId
-                        })),
-                    enqueue: false
+                        }))
             );
 
             Assert.IsTrue(busId == MessagingBusId.UI);
@@ -167,8 +166,7 @@ namespace Tests
                         new CreateEntityMessage
                         {
                             id = entityId
-                        })),
-                    enqueue: false
+                        }))
             );
 
             Assert.IsTrue(busId == MessagingBusId.INIT);
@@ -184,8 +182,7 @@ namespace Tests
                             entityId = entityId,
                             classId = (int)CLASS_ID_COMPONENT.TRANSFORM,
                         }
-                    )),
-                    enqueue: false
+                    ))
             );
 
             Assert.IsTrue(busId == MessagingBusId.INIT);
@@ -201,8 +198,7 @@ namespace Tests
                             entityId = entityId,
                             classId = (int)CLASS_ID_COMPONENT.TRANSFORM,
                         }
-                    )),
-                    enqueue: false
+                    ))
             );
 
             Assert.IsTrue(busId == MessagingBusId.INIT);
@@ -218,8 +214,7 @@ namespace Tests
                             entityId = entityId,
                             classId = (int)CLASS_ID_COMPONENT.TRANSFORM,
                         }
-                    )),
-                    enqueue: false
+                    ))
             );
 
             Assert.IsTrue(busId == MessagingBusId.INIT);
@@ -230,8 +225,7 @@ namespace Tests
                     "",
                     MessagingTypes.INIT_DONE,
                     ""
-                ),
-                enqueue: false
+                )
             );
 
             Assert.IsTrue(busId == MessagingBusId.INIT);
@@ -247,8 +241,7 @@ namespace Tests
                             entityId = entityId,
                             parentId = "0"
                         })
-                ),
-                enqueue: false
+                )
             );
 
             Assert.IsTrue(busId == MessagingBusId.UI);
@@ -264,8 +257,7 @@ namespace Tests
                             entityId = entityId,
                             classId = (int)CLASS_ID_COMPONENT.TRANSFORM,
                         }
-                    )),
-                    enqueue: false
+                    ))
             );
 
             Assert.IsTrue(busId == MessagingBusId.SYSTEM);
@@ -281,8 +273,7 @@ namespace Tests
                             entityId = entityId,
                             parentId = "0"
                         })
-                ),
-                enqueue: false
+                )
             );
 
             Assert.IsTrue(busId == MessagingBusId.SYSTEM);
@@ -296,8 +287,7 @@ namespace Tests
                         new CreateEntityMessage
                         {
                             id = entityId
-                        })),
-                    enqueue: false
+                        }))
             );
 
             Assert.IsTrue(busId == MessagingBusId.UI);
@@ -311,8 +301,7 @@ namespace Tests
                         new CreateEntityMessage
                         {
                             id = entityId
-                        })),
-                    enqueue: false
+                        }))
             );
 
             Assert.IsTrue(busId == MessagingBusId.SYSTEM);
@@ -330,8 +319,7 @@ namespace Tests
                             entityId = entityId,
                             parentId = "0"
                         })
-                ),
-                enqueue: false
+                )
             );
 
             Assert.IsTrue(busId == MessagingBusId.UI);
@@ -347,8 +335,7 @@ namespace Tests
                             entityId = entityId,
                             parentId = "0"
                         })
-                ),
-                    enqueue: false
+                )
             );
 
             Assert.IsTrue(busId == MessagingBusId.SYSTEM);
@@ -362,8 +349,7 @@ namespace Tests
                         new CreateEntityMessage
                         {
                             id = entityId
-                        })),
-                    enqueue: false
+                        }))
             );
 
             Assert.IsTrue(busId == MessagingBusId.UI);
@@ -377,8 +363,7 @@ namespace Tests
                         new CreateEntityMessage
                         {
                             id = entityId
-                        })),
-                    enqueue: false
+                        }))
             );
 
             Assert.IsTrue(busId == MessagingBusId.SYSTEM);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Tests/MessageTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Tests/MessageTests.cs
@@ -32,8 +32,6 @@ namespace Tests
         {
             yield return InitScene();
 
-            sceneController.deferredMessagesDecoding = false;
-
             var entity = TestHelpers.CreateSceneEntity(scene);
 
             yield return null;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/TestHelpers.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/TestHelpers.cs
@@ -1221,6 +1221,7 @@ namespace DCL.Helpers
         public static SceneController InitializeSceneController(bool usesWebServer = false)
         {
             var sceneController = UnityEngine.Object.FindObjectOfType<SceneController>();
+            sceneController.deferredMessagesDecoding = false;
 
             if (sceneController != null && sceneController.componentFactory == null)
             {
@@ -1297,11 +1298,13 @@ namespace DCL.Helpers
             {
                 OnIterationStart?.Invoke();
 
-                var messageObject = JsonUtility.FromJson<T>(lastMessageFromEnginePayload);
+                if (!string.IsNullOrEmpty(lastMessageFromEnginePayload))
+                {
+                    var messageObject = JsonUtility.FromJson<T>(lastMessageFromEnginePayload);
 
-                if (OnSuccess != null)
-                    return OnSuccess.Invoke(messageObject);
-
+                    if (OnSuccess != null)
+                        return OnSuccess.Invoke(messageObject);
+                }
                 return false;
             }, 2f);
         }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/TestHelpers.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/TestHelpers.cs
@@ -455,6 +455,20 @@ namespace DCL.Helpers
             return gltfShape;
         }
 
+        public static BoxShape CreateEntityWithBoxShape(ParcelScene scene, Vector3 pos, Vector3 scale, out DecentralandEntity entity)
+        {
+            BoxShape shape = TestHelpers.InstantiateEntityWithShape<BoxShape, BoxShape.Model>(
+                scene,
+                DCL.Models.CLASS_ID.BOX_SHAPE,
+                Vector3.zero,
+                out entity,
+                new BoxShape.Model() { });
+
+            TestHelpers.SetEntityTransform(scene, entity, pos, Quaternion.identity, scale);
+
+            return shape;
+        }
+
         public static BoxShape CreateEntityWithBoxShape(ParcelScene scene, Vector3 position,
             BoxShape.Model model = null)
         {

--- a/unity-client/Assets/Scripts/Tests/IntegrationTests/IntegrationTestController.cs
+++ b/unity-client/Assets/Scripts/Tests/IntegrationTests/IntegrationTestController.cs
@@ -55,8 +55,7 @@ public class IntegrationTestController : MonoBehaviour
                     new CreateEntityMessage
                     {
                         id = entityId
-                    })),
-                enqueue: false
+                    }))
         );
 
         //NOTE(Brian): This is making my eyes bleed. (Zak): Twice
@@ -71,8 +70,7 @@ public class IntegrationTestController : MonoBehaviour
                         entityId = entityId,
                         parentId = "0"
                     })
-            ),
-            enqueue: false
+            )
         );
 
         yield return new WaitForAllMessagesProcessed();


### PR DESCRIPTION
# What? 
In order to prevent casting many raycasts on the same frame, one possible solution is to make query messages replace older ones each time they arrive to the client. But this approach leads to another problem: sometimes we need to be able to cast more than one ray per frame (i.e. a car that needs to cast three rays on the front to avoid colliding). To allow this, Raycast Instances come to the rescue: a raycast instance is a numeric id that identifies each query that we need to make each frame.

# Why? 
When casting raycasts continuously on each update iteration, several messages can accumulate in client messaging bus. This can lead to performance and user experience issues because raycasts may be calculated many times each frame when not needed. Also, other messages processing are contingent on how many queries are enqueued on the same bus, aggravating the issue.
