### PR TITLE
chore: move BuildMergedBounds method to Utils

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneBoundariesController/SceneBoundariesChecker.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneBoundariesController/SceneBoundariesChecker.cs
@@ -1,13 +1,13 @@
 ﻿using UnityEngine;
 using DCL.Models;
 using DCL.Components;
+using DCL.Helpers;
 
 namespace DCL.Controllers
 {
     public class SceneBoundariesChecker
     {
         protected ParcelScene scene;
-        private Renderer renderer;
 
         public SceneBoundariesChecker(ParcelScene ownerScene)
         {
@@ -17,12 +17,12 @@ namespace DCL.Controllers
         public void EvaluateEntityPosition(DecentralandEntity entity)
         {
             // TODO: Remove once we fix at least the main plazas geometry to not surpass their scene limits...
-            if(!SceneController.i.isDebugMode) return;
+            if (!SceneController.i.isDebugMode) return;
 
-            if(entity == null || !scene.entities.ContainsValue(entity)) return;
+            if (entity == null || !scene.entities.ContainsValue(entity)) return;
 
             // Recursively evaluate entity children as well, we need to check this up front because this entity may not have meshes of its own, but the children may.
-            if(entity.children.Count > 0)
+            if (entity.children.Count > 0)
             {
                 using (var iterator = entity.children.GetEnumerator())
                 {
@@ -33,20 +33,22 @@ namespace DCL.Controllers
                 }
             }
 
-            if(entity.meshRootGameObject == null || entity.meshesInfo.renderers == null || entity.meshesInfo.renderers.Length == 0) return;
+            if (entity.meshRootGameObject == null || entity.meshesInfo.renderers == null || entity.meshesInfo.renderers.Length == 0) return;
 
             // If the mesh is being loaded we should skip the evaluation (it will be triggered again later when the loading finishes)
-            if(entity.meshRootGameObject.GetComponent<MaterialTransitionController>()) // the object's MaterialTransitionController is destroyed when it finishes loading
+            if (entity.meshRootGameObject.GetComponent<MaterialTransitionController>()) // the object's MaterialTransitionController is destroyed when it finishes loading
             {
                 return;
             }
             else
             {
                 var loadWrapper = entity.meshRootGameObject.GetComponent<LoadWrapper>();
-                if(loadWrapper != null && !loadWrapper.alreadyLoaded) return;
+                if (loadWrapper != null && !loadWrapper.alreadyLoaded) return;
             }
 
-            Bounds meshBounds = BuildMergedBounds(entity.meshesInfo);
+            // GLTF models may have several child renderers with different positions and different bounds
+            Bounds meshBounds = Utils.BuildMergedBounds(entity.meshesInfo.renderers);
+
             bool isInsideBoundaries = scene.IsInsideSceneBoundaries(meshBounds);
 
             UpdateEntityMeshesValidState(entity, isInsideBoundaries, meshBounds);
@@ -56,7 +58,7 @@ namespace DCL.Controllers
 
         protected virtual void UpdateEntityMeshesValidState(DecentralandEntity entity, bool isInsideBoundaries, Bounds meshBounds)
         {
-            if(isInsideBoundaries != entity.meshesInfo.renderers[0].enabled && entity.meshesInfo.currentShape.IsVisible())
+            if (isInsideBoundaries != entity.meshesInfo.renderers[0].enabled && entity.meshesInfo.currentShape.IsVisible())
             {
                 for (int i = 0; i < entity.meshesInfo.renderers.Length; i++)
                 {
@@ -68,31 +70,13 @@ namespace DCL.Controllers
         void UpdateEntityCollidersValidState(DecentralandEntity entity, bool isInsideBoundaries)
         {
             int collidersCount = entity.meshesInfo.colliders.Count;
-            if(collidersCount > 0 && isInsideBoundaries != entity.meshesInfo.colliders[0].enabled && entity.meshesInfo.currentShape.HasCollisions())
+            if (collidersCount > 0 && isInsideBoundaries != entity.meshesInfo.colliders[0].enabled && entity.meshesInfo.currentShape.HasCollisions())
             {
                 for (int i = 0; i < collidersCount; i++)
                 {
                     entity.meshesInfo.colliders[i].enabled = isInsideBoundaries;
                 }
             }
-        }
-
-        // GLTF models may have several child renderers with different positions and different bounds
-        Bounds BuildMergedBounds(DecentralandEntity.MeshesInfo meshesInfo)
-        {
-            Bounds bounds = new Bounds();
-
-            for(int i=0; i < meshesInfo.renderers.Length; i++)
-             {
-                 renderer = meshesInfo.renderers[i];
- 
-                 if(i == 0)
-                     bounds = renderer.bounds;
-                 else
-                     bounds.Encapsulate(renderer.bounds);
-             }
-
-            return bounds;
         }
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
@@ -345,7 +345,7 @@ namespace DCL.Helpers
             }
         }
 
-        public static bool AproxComparison(this Color color1, Color color2, float tolerance = 0.01f) // tolerance of roughly 1f / 255f 
+        public static bool AproxComparison(this Color color1, Color color2, float tolerance = 0.01f) // tolerance of roughly 1f / 255f
         {
             if (Mathf.Abs(color1.r - color2.r) < tolerance
                 && Mathf.Abs(color1.g - color2.g) < tolerance
@@ -368,6 +368,21 @@ namespace DCL.Helpers
                 string newJson = $"{{ \"value\": {jsonArray}}}";
                 return JsonUtility.FromJson<DummyJsonUtilityFromArray<T>>(newJson).value;
             }
+        }
+
+        public static Bounds BuildMergedBounds(Renderer[] renderers)
+        {
+            Bounds bounds = new Bounds();
+
+            for (int i = 0; i < renderers.Length; i++)
+            {
+                if (i == 0)
+                    bounds = renderers[i].bounds;
+                else
+                    bounds.Encapsulate(renderers[i].bounds);
+            }
+
+            return bounds;
         }
     }
 }


### PR DESCRIPTION
Moved `SceneBoundariesChecker.BuildMergedBounds()` to Utils, the builder team needs access to it