### PR TITLE
fix: namespace Tests triggers other tests by mistake

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.cs
@@ -8,7 +8,7 @@ using UnityEngine.TestTools;
 using NUnit.Framework;
 using System.Collections;
 
-namespace Tests
+namespace SceneBoundariesChecker
 {
     public class SceneBoundariesCheckerTests : TestsBase
     {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.cs
@@ -8,7 +8,7 @@ using UnityEngine.TestTools;
 using NUnit.Framework;
 using System.Collections;
 
-namespace SceneBoundariesChecker
+namespace SceneBoundariesCheckerTests
 {
     public class SceneBoundariesCheckerTests : TestsBase
     {

--- a/unity-client/Assets/Scripts/MainScripts/MainScripts.asmdef
+++ b/unity-client/Assets/Scripts/MainScripts/MainScripts.asmdef
@@ -17,7 +17,6 @@
         "ScriptableObjects",
         "WaitForSecondsCache",
         "ContentProvider",
-        "LoadersController",
         "AvatarAssets"
     ],
     "optionalUnityReferences": [],


### PR DESCRIPTION
Changing name to avoid triggering other tests