### PR TITLE
chore: enable scene boundaries check in production

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneBoundariesController/SceneBoundariesChecker.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneBoundariesController/SceneBoundariesChecker.cs
@@ -16,9 +16,6 @@ namespace DCL.Controllers
 
         public void EvaluateEntityPosition(DecentralandEntity entity)
         {
-            // TODO: Remove once we fix at least the main plazas geometry to not surpass their scene limits...
-            if (!SceneController.i.isDebugMode) return;
-
             if (entity == null || !scene.entities.ContainsValue(entity)) return;
 
             // Recursively evaluate entity children as well, we need to check this up front because this entity may not have meshes of its own, but the children may.

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.cs
@@ -14,7 +14,6 @@ namespace SceneBoundariesCheckerTests
     public class SceneBoundariesCheckerTests : TestsBase
     {
         [UnityTest]
-        [Explicit]
         public IEnumerator PShapeIsInvalidatedWhenStartingOutOfBounds()
         {
             yield return InitScene();
@@ -39,7 +38,6 @@ namespace SceneBoundariesCheckerTests
         }
 
         [UnityTest]
-        [Explicit]
         public IEnumerator GLTFShapeIsInvalidatedWhenStartingOutOfBounds()
         {
             yield return InitScene();
@@ -73,7 +71,6 @@ namespace SceneBoundariesCheckerTests
         }
 
         [UnityTest]
-        [Explicit]
         public IEnumerator NFTShapeIsInvalidatedWhenStartingOutOfBounds()
         {
             yield return InitScene();
@@ -111,7 +108,6 @@ namespace SceneBoundariesCheckerTests
         }
 
         [UnityTest]
-        [Explicit]
         public IEnumerator PShapeIsInvalidatedWhenLeavingBounds()
         {
             yield return InitScene();
@@ -144,7 +140,6 @@ namespace SceneBoundariesCheckerTests
         }
 
         [UnityTest]
-        [Explicit]
         public IEnumerator GLTFShapeIsInvalidatedWhenLeavingBounds()
         {
             yield return InitScene();
@@ -183,7 +178,6 @@ namespace SceneBoundariesCheckerTests
         }
 
         [UnityTest]
-        [Explicit]
         public IEnumerator NFTShapeIsInvalidatedWhenLeavingBounds()
         {
             yield return InitScene();
@@ -226,7 +220,6 @@ namespace SceneBoundariesCheckerTests
         }
 
         [UnityTest]
-        [Explicit]
         public IEnumerator PShapeIsResetWhenReenteringBounds()
         {
             yield return InitScene();
@@ -260,7 +253,6 @@ namespace SceneBoundariesCheckerTests
         }
 
         [UnityTest]
-        [Explicit]
         public IEnumerator GLTFShapeIsResetWhenReenteringBounds()
         {
             yield return InitScene();
@@ -299,7 +291,6 @@ namespace SceneBoundariesCheckerTests
         }
 
         [UnityTest]
-        [Explicit]
         public IEnumerator NFTShapeIsResetWhenReenteringBounds()
         {
             yield return InitScene();
@@ -342,7 +333,6 @@ namespace SceneBoundariesCheckerTests
         }
 
         [UnityTest]
-        [Explicit]
         public IEnumerator ChildShapeIsEvaluated()
         {
             yield return InitScene();
@@ -383,7 +373,6 @@ namespace SceneBoundariesCheckerTests
         }
 
         [UnityTest]
-        [Explicit]
         public IEnumerator ChildShapeIsEvaluatedOnShapelessParent()
         {
             yield return InitScene();
@@ -425,7 +414,6 @@ namespace SceneBoundariesCheckerTests
         }
 
         [UnityTest]
-        [Explicit]
         public IEnumerator HeightIsEvaluated()
         {
             yield return InitScene();


### PR DESCRIPTION
* Removed scene boundaries checker escape line for prod
* Enabled non-debug-mode tests

You can check that the plazas work OK (using ENV=org):
MEDIEVAL PLAZA -> -63, -65
FOREST PLAZA -> -9, 73
GENESIS PLAZA -> 0, 0
GAMER PLAZA -> 71, -10
MUSEUM -> 13, 75