### PR TITLE
fix: deactivate rendering failed to turn off the camera

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Camera.asmdef
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Camera.asmdef
@@ -4,7 +4,8 @@
         "GUID:4720e174f2805c74bb7aa94cc8bb5bf8",
         "GUID:4307f53044263cf4b835bd812fc161a4",
         "GUID:98bf3bf29030cbf4092d89a7cc28b7fb",
-        "GUID:b1087c5731ff68448a0a9c625bb7e52d"
+        "GUID:b1087c5731ff68448a0a9c625bb7e52d",
+        "GUID:e555144732b726c4cba5b0f6337fea75"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [],

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraController.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Cinemachine;
 using DCL.Helpers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 public class CameraController : MonoBehaviour
@@ -44,7 +44,10 @@ public class CameraController : MonoBehaviour
 
     private void Awake()
     {
-        cachedModeToVirtualCamera =  cameraModes.ToDictionary(x => x.cameraMode, x => x.virtualCamera);
+        RenderingController.i.OnRenderingStateChanged += OnRenderingStateChanged;
+
+        cachedModeToVirtualCamera = cameraModes.ToDictionary(x => x.cameraMode, x => x.virtualCamera);
+
         using (var iterator = cachedModeToVirtualCamera.GetEnumerator())
         {
             while (iterator.MoveNext())
@@ -62,6 +65,11 @@ public class CameraController : MonoBehaviour
 
         SetFreeCameraModeActive(false);
         SetCameraMode(currentMode);
+    }
+
+    private void OnRenderingStateChanged(bool enabled)
+    {
+        cameraTransform.gameObject.SetActive(enabled);
     }
 
     private void OnCameraChangeAction(DCLAction_Trigger action)
@@ -108,8 +116,10 @@ public class CameraController : MonoBehaviour
                     characterForward.Set(xzPlaneForward);
                     break;
                 case CameraMode.ThirdPerson:
+
                     if (!characterForward.HasValue())
                         characterForward.Set(xzPlaneForward);
+
                     var lerpedForward = Vector3.Slerp(characterForward.Get().Value, xzPlaneForward, 5 * Time.deltaTime);
                     characterForward.Set(lerpedForward);
                     break;
@@ -143,6 +153,7 @@ public class CameraController : MonoBehaviour
         freeCameraModeAction.OnStarted -= freeCameraModeStartedDelegate;
         freeCameraModeAction.OnFinished -= freeCameraModeFinishedDelegate;
         cameraChangeAction.OnTriggered -= OnCameraChangeAction;
+        RenderingController.i.OnRenderingStateChanged -= OnRenderingStateChanged;
     }
 
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Resources.meta
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d8c785fac8d5c2546a2ab991c22ceeac
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Tests/CameraTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Tests/CameraTests.cs
@@ -1,8 +1,7 @@
-﻿using System.Collections;
 using Cinemachine;
-using DCL.Helpers;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using System.Collections;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -52,12 +51,14 @@ namespace CameraController_Test
 
             var payload = new CameraController.SetRotationPayload()
             {
-                x = 0, y = 0, z = 0,
+                x = 0,
+                y = 0,
+                z = 0,
                 cameraTarget = new Vector3(lookAtX, lookAtY, lookAtZ)
             };
 
             var rotationEuler = Quaternion.LookRotation(payload.cameraTarget.Value).eulerAngles;
-            cameraController.SetRotation(JsonConvert.SerializeObject(payload, Formatting.None,  new JsonSerializerSettings()
+            cameraController.SetRotation(JsonConvert.SerializeObject(payload, Formatting.None, new JsonSerializerSettings()
             {
                 ReferenceLoopHandling = ReferenceLoopHandling.Ignore
             }));
@@ -70,7 +71,7 @@ namespace CameraController_Test
         [TestCase(0, 0, 0, ExpectedResult = null)] //ExpectedResult is needed because the method is IEnumerator. The workaround is needed because there's no "UnityTestCase" to use with IEnumerators
         [TestCase(1, 2, 3, ExpectedResult = null)]
         [TestCase(3, 3, 3, ExpectedResult = null)]
-        public  IEnumerator UpdateCameraPositionSO(float posX, float posY, float posZ)
+        public IEnumerator UpdateCameraPositionSO(float posX, float posY, float posZ)
         {
             var currentVcam = (cameraController.cachedModeToVirtualCamera[cameraController.currentMode] as CinemachineVirtualCamera);
 
@@ -97,6 +98,17 @@ namespace CameraController_Test
             yield return null;
 
             Assert.AreEqual(currentVcam.State.FinalOrientation * Vector3.forward, CommonScriptableObjects.cameraForward.Get());
+        }
+
+        [UnityTest]
+        public IEnumerator ActivateAndDeactivateWithKernelRenderingToggleEvents()
+        {
+            RenderingController.i.DeactivateRendering();
+            Assert.IsFalse(cameraController.cameraTransform.gameObject.activeSelf);
+
+            RenderingController.i.ActivateRendering();
+            Assert.IsTrue(cameraController.cameraTransform.gameObject.activeSelf);
+            yield break;
         }
     }
 }


### PR DESCRIPTION
Reason was that `CameraController` wasn't suscribing to activate/deactivate kernel rendering events properly.