### PR TITLE
chore: update interaction hover position to mesh center

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/InteractionHoverCanvas/InteractionHoverCanvasController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/InteractionHoverCanvas/InteractionHoverCanvasController.cs
@@ -65,6 +65,8 @@ public class InteractionHoverCanvasController : MonoBehaviour
 
     void CalculateMeshCenteredPos(DCLTransform.Model transformModel = null)
     {
+        if (!canvas.enabled) return;
+
         if (entity.meshesInfo.renderers == null || entity.meshesInfo.renderers.Length == 0)
         {
             meshCenteredPos = transform.parent.position;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/InteractionHoverCanvas/InteractionHoverCanvasController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/InteractionHoverCanvas/InteractionHoverCanvasController.cs
@@ -1,10 +1,12 @@
-﻿using UnityEngine;
+﻿using DCL.Models;
+using DCL.Components;
+using UnityEngine;
 using DCL.Interface;
 using TMPro;
 
 public class InteractionHoverCanvasController : MonoBehaviour
 {
-    public Vector3 offset = new Vector3(0f, 0f, 0f);
+    public Vector3 offset = new Vector2(0f, 50f);
     public Canvas canvas;
     public RectTransform backgroundTransform;
     public TextMeshProUGUI text;
@@ -15,17 +17,24 @@ public class InteractionHoverCanvasController : MonoBehaviour
 
     Camera mainCamera;
     GameObject hoverIcon;
+    Vector3 meshCenteredPos;
+    DecentralandEntity entity;
 
     void Awake()
     {
         mainCamera = Camera.main;
     }
 
-    public void Setup(WebInterface.ACTION_BUTTON button, string feedbackText)
+    public void Setup(WebInterface.ACTION_BUTTON button, string feedbackText, DecentralandEntity entity)
     {
         text.text = feedbackText;
+        this.entity = entity;
 
         ConfigureIcon(button);
+
+        entity.OnTransformChange -= CalculateMeshCenteredPos;
+        entity.OnTransformChange += CalculateMeshCenteredPos;
+        CalculateMeshCenteredPos();
 
         Hide();
     }
@@ -54,6 +63,24 @@ public class InteractionHoverCanvasController : MonoBehaviour
         }
     }
 
+    void CalculateMeshCenteredPos(DCLTransform.Model transformModel = null)
+    {
+        if (entity.meshesInfo.renderers == null || entity.meshesInfo.renderers.Length == 0)
+        {
+            meshCenteredPos = transform.parent.position;
+        }
+        else
+        {
+            Vector3 sum = Vector3.zero;
+            for (int i = 0; i < entity.meshesInfo.renderers.Length; i++)
+            {
+                sum += entity.meshesInfo.renderers[i].bounds.center;
+            }
+
+            meshCenteredPos = sum / entity.meshesInfo.renderers.Length;
+        }
+    }
+
     public void Show()
     {
         canvas.enabled = true;
@@ -68,6 +95,7 @@ public class InteractionHoverCanvasController : MonoBehaviour
     {
         if (!canvas.enabled) return;
 
+        CalculateMeshCenteredPos();
         UpdateSizeAndPos();
     }
 
@@ -76,7 +104,7 @@ public class InteractionHoverCanvasController : MonoBehaviour
         if (mainCamera == null)
             mainCamera = Camera.main;
 
-        Vector3 screenPoint = mainCamera.WorldToViewportPoint(transform.parent.position + offset);
+        Vector3 screenPoint = mainCamera.WorldToViewportPoint(meshCenteredPos);
 
         if (screenPoint.z > 0)
         {
@@ -85,7 +113,7 @@ public class InteractionHoverCanvasController : MonoBehaviour
             float height = canvasRect.rect.height;
             screenPoint.Scale(new Vector3(width, height, 0));
 
-            ((RectTransform)backgroundTransform).anchoredPosition = screenPoint;
+            ((RectTransform)backgroundTransform).anchoredPosition = screenPoint + offset;
         }
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/InteractionHoverCanvas/Resources/InteractionHoverCanvas.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/InteractionHoverCanvas/Resources/InteractionHoverCanvas.prefab
@@ -116,7 +116,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fdb703c4373e2421ab6fc794a7291837, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  offset: {x: 0, y: 3, z: 0}
+  offset: {x: 0, y: 50, z: 0}
   canvas: {fileID: 4700288523959264737}
   backgroundTransform: {fileID: 6432359610209792728}
   text: {fileID: 5253129788489465426}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/OnPointerEvent.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/OnPointerEvent.cs
@@ -8,7 +8,7 @@ namespace DCL.Components
 {
     public class OnPointerEvent : UUIDComponent<OnPointerEvent.Model>
     {
-        public static bool enableInteractionHoverFeedback = true;
+        public static bool enableInteractionHoverFeedback = false;
 
         [System.Serializable]
         new public class Model : UUIDComponent.Model

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/OnPointerEvent.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/OnPointerEvent.cs
@@ -8,7 +8,7 @@ namespace DCL.Components
 {
     public class OnPointerEvent : UUIDComponent<OnPointerEvent.Model>
     {
-        public static bool enableInteractionHoverFeedback = false;
+        public static bool enableInteractionHoverFeedback = true;
 
         [System.Serializable]
         new public class Model : UUIDComponent.Model
@@ -69,7 +69,7 @@ namespace DCL.Components
                 GameObject hoverCanvasGameObject = Object.Instantiate(Resources.Load("InteractionHoverCanvas"), transform) as GameObject;
                 hoverCanvasController = hoverCanvasGameObject.GetComponent<InteractionHoverCanvasController>();
             }
-            hoverCanvasController.Setup((WebInterface.ACTION_BUTTON)model.button, model.toastText);
+            hoverCanvasController.Setup((WebInterface.ACTION_BUTTON)model.button, model.toastText, entity);
         }
 
         void OnComponentUpdated(DecentralandEntity e)


### PR DESCRIPTION
* Updated interaction hover toast to be shown based on the centered mesh position instead of the entities transform position.

* Enabled hover feedback for testing purposes