### PR TITLE
fix: profile picture loading

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
@@ -34,7 +34,7 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
     {
         UpdateProperties(newModel);
 
-        if (!downloadAssets)
+        if (downloadAssets)
         {
             DownloadFaceIfNeeded();
             DownloadBodyIfNeeded();


### PR DESCRIPTION
The user profile picture (or avatar picture) wasn't being loaded when the user first entered the explorer.