### PR TITLE
fix: random objects spawning

### DIFF
--- a/unity-client/Assets/Builder/Scripts/Tests/BuilderMeshLoadingIndicator.cs
+++ b/unity-client/Assets/Builder/Scripts/Tests/BuilderMeshLoadingIndicator.cs
@@ -14,7 +14,7 @@ namespace Builder.Tests
         public IEnumerator BuilderMeshLoadingIndicatorTest()
         {
             yield return InitScene();
-            DCL.Configuration.Environment.DEBUG = true;
+            DCL.Configuration.EnvironmentSettings.DEBUG = true;
             sceneController.SetDebug();
             yield return new WaitForSeconds(0.1f);
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
@@ -7,9 +7,10 @@ namespace DCL.Configuration
         public static string version = "0.8";
     }
 
-    public static class Environment
+    public static class EnvironmentSettings
     {
         public static bool DEBUG = true;
+        public static Vector3 MORDOR = new Vector3(1000, 1000, 1000);
     }
 
     public static class InputSettings

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Linq;
 using DCL.Helpers;
+using DCL.Configuration;
 using UnityEngine;
 
 namespace DCL
@@ -105,6 +106,9 @@ namespace DCL
                     break;
 
                 GameObject assetBundleModelGO = UnityEngine.Object.Instantiate(goList[i]);
+
+                // Hide gameobject until it's been correctly processed, otherwise it flashes at 0,0,0
+                assetBundleModelGO.transform.position = EnvironmentSettings.MORDOR;
 
                 yield return MaterialCachingHelper.UseCachedMaterials(assetBundleModelGO);
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraController.cs
@@ -21,7 +21,6 @@ public class CameraController : MonoBehaviour
     private Vector3Variable cameraPosition => CommonScriptableObjects.cameraPosition;
     private Vector3Variable playerUnityToWorldOffset => CommonScriptableObjects.playerUnityToWorldOffset;
 
-
     internal CameraStateBase.ModeId currentMode = CameraStateBase.ModeId.FirstPerson;
     public CameraStateBase currentCameraState => cachedModeToVirtualCamera[currentMode];
 
@@ -109,7 +108,6 @@ public class CameraController : MonoBehaviour
         cameraChangeAction.OnTriggered -= OnCameraChangeAction;
         RenderingController.i.OnRenderingStateChanged -= OnRenderingStateChanged;
     }
-
 
     public class SetRotationPayload
     {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/MaterialTransitionController/Tests/MaterialTransitionControllerTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/MaterialTransitionController/Tests/MaterialTransitionControllerTests.cs
@@ -17,7 +17,7 @@ namespace Tests
         public IEnumerator MaterialTransitionWithGLTF()
         {
             yield return InitScene();
-            DCL.Configuration.Environment.DEBUG = true;
+            DCL.Configuration.EnvironmentSettings.DEBUG = true;
             sceneController.SetDebug();
 
             var entity1 = TestHelpers.CreateSceneEntity(scene);
@@ -85,7 +85,7 @@ namespace Tests
         public IEnumerator MaterialTransitionWithParametrizableMeshes()
         {
             yield return InitScene(reloadUnityScene: false);
-            DCL.Configuration.Environment.DEBUG = true;
+            DCL.Configuration.EnvironmentSettings.DEBUG = true;
             sceneController.SetDebug();
 
             var entity1 = TestHelpers.CreateSceneEntity(scene);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/PlayerAvatarController/PlayerAvatarController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/PlayerAvatarController/PlayerAvatarController.cs
@@ -5,22 +5,26 @@ using UnityEngine;
 public class PlayerAvatarController : MonoBehaviour
 {
     public AvatarRenderer avatarRenderer;
-    private UserProfile userProfile => UserProfile.GetOwnUserProfile();
+
+    UserProfile userProfile => UserProfile.GetOwnUserProfile();
+    bool repositioningWorld => DCLCharacterController.i.characterPosition.RepositionedWorldLastFrame();
 
     private void Awake()
     {
         userProfile.OnUpdate += OnUserProfileOnUpdate;
+
+        avatarRenderer.SetVisibility(false);
     }
 
     private void OnTriggerEnter(Collider other)
     {
-        if(other.CompareTag("MainCamera"))
+        if (!repositioningWorld && other.CompareTag("MainCamera"))
             avatarRenderer.SetVisibility(false);
     }
 
     private void OnTriggerExit(Collider other)
     {
-        if(other.CompareTag("MainCamera"))
+        if (!repositioningWorld && other.CompareTag("MainCamera"))
             avatarRenderer.SetVisibility(true);
     }
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScene.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScene.cs
@@ -5,10 +5,7 @@ using DCL.Models;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Assertions;
-using Environment = DCL.Configuration.Environment;
 using Object = UnityEngine.Object;
-using Random = UnityEngine.Random;
-using System.Collections;
 
 namespace DCL.Controllers
 {
@@ -25,7 +22,6 @@ namespace DCL.Controllers
 
         private const string PARCEL_BLOCKER_PREFAB = "Prefabs/ParcelBlocker";
         private const int ENTITY_POOL_PREWARM_COUNT = 2000;
-        private static Vector3 MORDOR = new Vector3(1000, 1000, 1000);
 
         public Dictionary<string, DecentralandEntity> entities = new Dictionary<string, DecentralandEntity>();
         public Dictionary<string, BaseDisposable> disposableComponents = new Dictionary<string, BaseDisposable>();
@@ -225,7 +221,7 @@ namespace DCL.Controllers
 
         public void InitializeDebugPlane()
         {
-            if (Environment.DEBUG && sceneData.parcels != null)
+            if (EnvironmentSettings.DEBUG && sceneData.parcels != null)
             {
                 int sceneDataParcelsLength = sceneData.parcels.Length;
                 for (int j = 0; j < sceneDataParcelsLength; j++)
@@ -284,7 +280,7 @@ namespace DCL.Controllers
             {
                 if (entities.Count > 0)
                 {
-                    this.gameObject.transform.position = MORDOR;
+                    this.gameObject.transform.position = EnvironmentSettings.MORDOR;
 
                     RemoveAllEntities();
                 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Tests/SceneTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Tests/SceneTests.cs
@@ -29,7 +29,7 @@ namespace Tests
             yield return SetUp_SceneController(debugMode: true, false, false);
             yield return SetUp_CharacterController();
 
-            DCL.Configuration.Environment.DEBUG = true;
+            DCL.Configuration.EnvironmentSettings.DEBUG = true;
 
             sceneController.SetDebug();
             yield return null;

--- a/unity-client/Assets/Scripts/Tests/InteractiveObjectsHoverTestSceneController.cs
+++ b/unity-client/Assets/Scripts/Tests/InteractiveObjectsHoverTestSceneController.cs
@@ -48,7 +48,7 @@ public class InteractiveObjectsHoverTestSceneController : MonoBehaviour
 
     protected virtual IEnumerator InitScene()
     {
-        DCL.Configuration.Environment.DEBUG = true;
+        DCL.Configuration.EnvironmentSettings.DEBUG = true;
         SceneController.i.SetDebug();
 
         TestHelpers.InitializeSceneController(false);


### PR DESCRIPTION
* Added asset bundles repositioning before caching their material to avoid spawning at 0,0,0 while waiting
* Added world-repositioning check when toggling the third person avatar to fix the "jump scare" flickering on world-reposition

-------------------------------------------------------------
This can be tested at 
https://explorer.decentraland.zone/branch/fix/RandomObjectsSpawning/index.html?position=-9%2C73&ENV=org

Walking to the closest path in the plaza and then going to the right, until you reach the tunnel with a face
<img width="890" alt="Screen Shot 2020-01-08 at 10 43 29" src="https://user-images.githubusercontent.com/1031741/71982692-df3f9c00-3203-11ea-8ffe-617a71ee3b5c.png">

You can compare doing the same short stroll in zone (https://explorer.decentraland.zone/?position=-9,73&ENV=org) or in org (https://explorer.decentraland.org/?position=-9,73)