### PR TITLE
fix: camera reported rotation

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/DCLCharacterController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/DCLCharacterController.cs
@@ -413,7 +413,7 @@ public class DCLCharacterController : MonoBehaviour
         float height = 0.875f;
 
         var reportPosition = characterPosition.worldPosition + (Vector3.up * height);
-        var compositeRotation = Quaternion.LookRotation(transform.forward);
+        var compositeRotation = Quaternion.LookRotation(cameraForward.Get());
         var playerHeight = height + (characterController.height / 2);
 
         //NOTE(Brian): We have to wait for a Teleport before sending the ReportPosition, because if not ReportPosition events will be sent


### PR DESCRIPTION
Updated client-kernel camera pos-rot reporting to use the new cameraForward scriptable object.

--------------------------------------

This can be tested in Koko Jone's scene, in ORG (https://explorer.decentraland.org/?position=-37%2C58) the camera rotation only takes into accound the **Y axis** for shooting the cannonballs (try shooting upwards), you can test de fixed version at
https://explorer.decentraland.zone/branch/fix/ReportedCameraRotation/index.html?ENV=org&position=-37%2C58

To play the koko jones scene, get into the car, click the driver/car and the experience starts, then using the **F** key you shoot the cannonballs