### PR TITLE
fix: add missing null check

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/AssetPromise_AB.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/AssetPromise_AB.cs
@@ -132,7 +132,7 @@ namespace DCL
 
                 AssetBundle assetBundle = DownloadHandlerAssetBundle.GetContent(assetBundleRequest);
 
-                if (assetBundle == null)
+                if (assetBundle == null || asset == null)
                 {
                     assetBundleRequest.Abort();
                     OnFail?.Invoke();


### PR DESCRIPTION
Added missing null check that may be triggering the memory crash when several avatars are in the same area
