### PR TITLE
feat: tweaks of performance to the bus priorities

### DIFF
--- a/unity-client/Assets/Scenes/InitialScene.unity
+++ b/unity-client/Assets/Scenes/InitialScene.unity
@@ -334,8 +334,8 @@ MonoBehaviour:
   customContentServerUrl: http://localhost:1338/
   baseUrlMode: 0
   baseUrlCustom: 
-  environment: 2
-  startInCoords: {x: 64, y: -64}
+  environment: 4
+  startInCoords: {x: -6, y: -20}
   forceLocalComms: 1
   allWearables: 0
   testWearables: 0

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingBus.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingBus.cs
@@ -209,10 +209,9 @@ namespace DCL
                 unreliableMessages.Remove(message.unreliableMessageKey);
         }
 
-        public bool ProcessQueue(float timeBudget, out IEnumerator yieldReturn)
+        public bool ProcessQueue(float timeBudget, LinkedList<Action> actionsForNextFrame)
         {
-            LinkedList<MessagingBus.QueuedSceneMessage> queue = pendingMessages;
-            yieldReturn = null;
+            LinkedList<QueuedSceneMessage> queue = pendingMessages;
 
             // Note (Zak): This check is to avoid calling DCLDCLTime.realtimeSinceStartup
             // unnecessarily because it's pretty slow in JS
@@ -267,8 +266,8 @@ namespace DCL
                         if (msgYieldInstruction != null)
                         {
                             processedMessagesCount++;
-
-                            yieldReturn = msgYieldInstruction;
+                            // TODO: Add something like
+                            // actionsForNextFrame.AddLast(() => msgYieldInstruction);
 
                             msgYieldInstruction = null;
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingControllersManager.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingControllersManager.cs
@@ -231,6 +231,7 @@ namespace DCL
             while (true)
             {
                 start = Time.realtimeSinceStartup;
+                prevTimeBudget = INIT_MSG_BUS_BUDGET_MAX;
                 // This loop makes sure that queues are emptied out in the correct order.
                 // Every time we're done with a queue, we call `continue` to start again processing messages in the right priority
                 // (note that the next run might be in the next frame due to the time budget).

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingControllersManager.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingControllersManager.cs
@@ -315,6 +315,8 @@ namespace DCL
                     }
                     if (shouldRestart)
                         continue;
+
+                    yield return null;
                 }
 
                 yield return null;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/PerformanceTests/MessagingBusTest.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/PerformanceTests/MessagingBusTest.cs
@@ -1,5 +1,6 @@
 using DCL;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Unity.PerformanceTesting;
@@ -53,6 +54,7 @@ namespace MessagingBusTest
         [Test, Performance]
         public void MeasureTimeToProcessThousandMessages()
         {
+            LinkedList<Action> list = new LinkedList<Action>();
             bus.Start();
             Measure.Method(() =>
             {
@@ -60,8 +62,7 @@ namespace MessagingBusTest
                 Assert.IsTrue(bus.pendingMessagesCount > 1000);
                 while (bus.processedMessagesCount < processed + 1000)
                 {
-                    System.Collections.IEnumerator yieldReturn;
-                    bus.ProcessQueue(0.1f, out yieldReturn);
+                    bus.ProcessQueue(0.1f, list);
                 }
             })
             .SetUp(() =>


### PR DESCRIPTION
[This PR started as only moving code around: behavior should be pretty similar]

I was having a hard time visualizing bus queue priorities: I think this slightly improves the visibility of that, what do you think @BrianAmadori @pravusjif? I tried to use less lines so that the priority between queues is clearly distinguished. I made some changes that I hope should improve start up time.