### PR TITLE
feat: don't necessarily lock Corutines on WebRequests

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShapeLoaderController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShapeLoaderController.cs
@@ -134,7 +134,11 @@ public class NFTShapeLoaderController : MonoBehaviour
         string jsonURL = $"{NFTDataFetchingSettings.DAR_API_URL}/{darURLRegistry}/asset/{darURLAsset}";
 
         UnityWebRequest www = UnityWebRequest.Get(jsonURL);
-        yield return www.SendWebRequest();
+        www.SendWebRequest();
+        while (!www.isDone)
+        {
+            yield return null;
+        }
 
         if (!www.WebRequestSucceded())
         {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/AssetPromise_AB.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/AssetPromise_AB.cs
@@ -118,7 +118,11 @@ namespace DCL
 
             using (UnityWebRequest assetBundleRequest = UnityWebRequestAssetBundle.GetAssetBundle(finalUrl))
             {
-                yield return assetBundleRequest.SendWebRequest();
+                assetBundleRequest.SendWebRequest();
+                while (!assetBundleRequest.isDone)
+                {
+                    yield return null;
+                }
 
                 if (!assetBundleRequest.WebRequestSucceded())
                 {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/DynamicOBJLoaderController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/DynamicOBJLoaderController.cs
@@ -49,7 +49,11 @@ public class DynamicOBJLoaderController : MonoBehaviour
 
             UnityWebRequest webRequest = UnityWebRequest.Get(OBJUrl);
 
-            yield return webRequest.SendWebRequest();
+            webRequest.SendWebRequest();
+            while (!webRequest.isDone)
+            {
+                yield return null;
+            }
 
             if (webRequest.isNetworkError || webRequest.isHttpError)
             {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/ThumbnailsManager.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/ThumbnailsManager.cs
@@ -44,7 +44,11 @@ public static class ThumbnailsManager
     {
         UnityWebRequest www = UnityWebRequestTexture.GetTexture(url);
 
-        yield return www.SendWebRequest();
+        www.SendWebRequest();
+        while (!www.isDone)
+        {
+            yield return null;
+        }
 
         Sprite sprite;
         if (!www.isNetworkError && !www.isHttpError)

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
@@ -166,7 +166,11 @@ namespace DCL.Helpers
             {
                 using (var webRequest = request)
                 {
-                    yield return webRequest.SendWebRequest();
+                    webRequest.SendWebRequest();
+                    while (!webRequest.isDone)
+                    {
+                        yield return null;
+                    }
 
                     if (!WebRequestSucceded(request))
                     {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
@@ -123,7 +123,11 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
     {
         UnityWebRequest www = UnityWebRequestTexture.GetTexture(url);
 
-        yield return www.SendWebRequest();
+        www.SendWebRequest();
+        while (!www.isDone)
+        {
+            yield return null;
+        }
 
         if (!www.isNetworkError && !www.isHttpError)
         {

--- a/unity-client/Assets/Scripts/Tests/GLTFLoadingTestController.cs
+++ b/unity-client/Assets/Scripts/Tests/GLTFLoadingTestController.cs
@@ -57,7 +57,11 @@ public class GLTFLoadingTestController : MonoBehaviour
         uwr.SetRequestHeader("Content-Type", "application/json");
 
         // Send the request then wait here until it returns
-        yield return uwr.SendWebRequest();
+        uwr.SendWebRequest();
+        while (!uwr.isDone)
+        {
+            yield return null;
+        }
 
         if (uwr.isNetworkError)
         {

--- a/unity-client/Assets/UnityGLTF/Scripts/Loader/WebRequestLoader.cs
+++ b/unity-client/Assets/UnityGLTF/Scripts/Loader/WebRequestLoader.cs
@@ -64,11 +64,12 @@ namespace UnityGLTF.Loader
             UnityWebRequest www = new UnityWebRequest(finalUrl, "GET", new DownloadHandlerBuffer(), null);
 
             www.timeout = 5000;
-#if UNITY_2017_2_OR_NEWER
-            yield return www.SendWebRequest();
-#else
-            yield return www.Send();
-#endif
+
+            www.SendWebRequest();
+            while (!www.isDone)
+            {
+                yield return null;
+            }
             if ((int)www.responseCode >= 400)
             {
                 Debug.LogError($"{www.responseCode} - {www.url}");


### PR DESCRIPTION
From the documentation in Unity,

> ### Do not block on WWW or WebRequest downloads
> Do not use code which blocks on a WWW or WebRequest download, like this:
> 
> ```
> while(!www.isDone) {}
> ```
> 
> Blocking on WWW or WebRequest downloads does not work on Unity WebGL. Because WebGL is single threaded, and because the XMLHttpRequest class in JavaScript is asynchronous, your download never finishes unless you return control to the browser; instead, your content deadlocks. Instead, use a Coroutine and a yield statement to wait for the download to finish.

It's not clear whether this improves or not, but it works at least as well as before