### PR TITLE
fix: NFTShape image fetching

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShapeLoaderController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShapeLoaderController.cs
@@ -59,7 +59,7 @@ public class NFTShapeLoaderController : MonoBehaviour
 
     Texture nftImageTexture;
 
-    bool VERBOSE = true;
+    bool VERBOSE = false;
 
     void Awake()
     {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShapeLoaderController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShapeLoaderController.cs
@@ -59,7 +59,7 @@ public class NFTShapeLoaderController : MonoBehaviour
 
     Texture nftImageTexture;
 
-    bool VERBOSE = false;
+    bool VERBOSE = true;
 
     void Awake()
     {
@@ -174,8 +174,6 @@ public class NFTShapeLoaderController : MonoBehaviour
 
         for (int i = 0; i < currentAssetData.files.Length; i++)
         {
-            if (!currentAssetData.files[i].url.EndsWith(".png")) continue;
-
             if (currentAssetData.files[i].role == "thumbnail")
                 thumbnailImageURL = currentAssetData.files[i].url;
             else if (currentAssetData.files[i].role == "preview")


### PR DESCRIPTION
Removed unneeded escape line when fetching NFT images

-------------------------------------------------
To test this you can access: https://explorer.decentraland.zone/branch/fix/NFTShapeImageFetching/index.html?position=60%2C-70 and see if the NFTShape loads the criptokitty image

This can't be tested in a unit test as we fetch the image using an API