### PR TITLE
fix: moving billboard and billboard texts

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Billboard/Billboard.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Billboard/Billboard.cs
@@ -40,7 +40,8 @@ namespace DCL
             DCLCharacterController.OnCharacterMoved -= OnCharacterMoved;
         }
 
-        public void Update()
+        // This runs on LateUpdate() instead of Update() to be applied AFTER the transform was moved
+        public void LateUpdate()
         {
             //NOTE(Brian): This fixes #757 (https://github.com/decentraland/unity-client/issues/757)
             //             We must find a more performant way to handle this, until that time, this is the approach.

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Billboard/Billboard.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Billboard/Billboard.cs
@@ -15,8 +15,10 @@ namespace DCL
         }
 
         public Model model = new Model();
+
         Transform entityTransform;
-        public Vector3Variable cameraPosition => CommonScriptableObjects.cameraPosition;
+        Vector3Variable cameraPosition => CommonScriptableObjects.cameraPosition;
+        Vector3 lastPosition;
 
         public override IEnumerator ApplyChanges(string newJson)
         {
@@ -40,17 +42,23 @@ namespace DCL
             DCLCharacterController.OnCharacterMoved -= OnCharacterMoved;
         }
 
-        // This runs on LateUpdate() instead of Update() to be applied AFTER the transform was moved
+        // This runs on LateUpdate() instead of Update() to be applied AFTER the transform was moved by the transform component
         public void LateUpdate()
         {
             //NOTE(Brian): This fixes #757 (https://github.com/decentraland/unity-client/issues/757)
             //             We must find a more performant way to handle this, until that time, this is the approach.
+
+            if (transform.position == lastPosition) return;
+
+            lastPosition = transform.position;
+
             ChangeOrientation();
         }
 
         Vector3 GetLookAtVector()
         {
-            Vector3 lookAtDir = (cameraPosition - entityTransform.position);
+            bool hasTextShape = entity.components.ContainsKey(Models.CLASS_ID_COMPONENT.TEXT_SHAPE);
+            Vector3 lookAtDir = hasTextShape ? (entityTransform.position - cameraPosition) : (cameraPosition - entityTransform.position);
 
             // Note (Zak): This check is here to avoid normalizing twice if not needed
             if (!(model.x && model.y && model.z))

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Billboard/Tests/BillboardTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Billboard/Tests/BillboardTests.cs
@@ -70,6 +70,42 @@ namespace Tests
             yield return null;
         }
 
+        [UnityTest]
+        public IEnumerator CheckLookAtPlayerWhileTransformMoves()
+        {
+            DCLCharacterController.i.PauseGravity();
+
+            yield return CreateComponent(x: true, y: true, z: true);
+
+            yield return null;
+
+            var entity = scene.entities[entityId];
+            Transform entityTransform = entity.gameObject.transform;
+            Vector3 lookAt = GetLookAtVector(billboard.model, entityTransform);
+
+            Assert.AreApproximatelyEqual(lookAt.x, entityTransform.forward.x, "billboard entity forward vector should be the same as the calculated one");
+            Assert.AreApproximatelyEqual(lookAt.y, entityTransform.forward.y, "billboard entity forward vector should be the same as the calculated one");
+            Assert.AreApproximatelyEqual(lookAt.z, entityTransform.forward.z, "billboard entity forward vector should be the same as the calculated one");
+
+            var billboardModel = new Billboard.Model();
+
+            yield return TestHelpers.EntityComponentUpdate<Billboard, Billboard.Model>(billboard, billboardModel);
+
+            lookAt = GetLookAtVector(billboardModel, entityTransform);
+            Assert.IsTrue(entityTransform.forward == lookAt, "billboard entity forward vector should be the same as the calculated one");
+
+            // We simulate a "system" moving the billboard object
+            Vector3 position = Vector3.one;
+            for (int i = 0; i < 5; i++)
+            {
+                position.y += i;
+                entityTransform.position = position;
+                Assert.IsTrue(entityTransform.forward == lookAt, "billboard entity forward vector should be the same as the calculated one");
+            }
+
+            yield return null;
+        }
+
         IEnumerator CreateComponent(bool x, bool y, bool z)
         {
             var entity = TestHelpers.CreateSceneEntity(scene, entityId);


### PR DESCRIPTION
* moving objects like the smoke in https://explorer.decentraland.zone/branch/fix/MovingBillboardAndBillboardTexts/index.html?position=54%2C-68 were glitchy with a billboard

* Textshape objects were shown mirrored when facing the player in https://explorer.decentraland.zone/branch/fix/MovingBillboardAndBillboardTexts/index.html?position=54%2C-71