### PR TITLE
fix: hide teleport animation background (perf issue)

### DIFF
--- a/kernel/packages/unity-interface/dcl.ts
+++ b/kernel/packages/unity-interface/dcl.ts
@@ -178,6 +178,9 @@ export function setLoadingScreenVisible(shouldShow: boolean) {
   document.getElementById('overlay')!.style.display = shouldShow ? 'block' : 'none'
   document.getElementById('load-messages-wrapper')!.style.display = shouldShow ? 'block' : 'none'
   document.getElementById('progress-bar')!.style.display = shouldShow ? 'block' : 'none'
+  if (!shouldShow) {
+    stopTeleportAnimation()
+  }
 }
 
 function delightedSurvey() {
@@ -206,6 +209,11 @@ function ensureTeleportAnimation() {
     'style',
     'background: #151419 url(images/teleport.gif) no-repeat center !important; background-size: 194px 257px !important;'
   )
+}
+
+function stopTeleportAnimation() {
+  document.getElementById('gameContainer')!.setAttribute('style', 'background: #151419')
+  document.body.setAttribute('style', 'background: #151419')
 }
 
 const CHUNK_SIZE = 500


### PR DESCRIPTION
As detected by @BrianAmadori, the `gif` is causing serious perf issues

before:
![image](https://user-images.githubusercontent.com/42750/72461505-eb9c9980-37ad-11ea-8324-eb067df83319.png)

after:
![image](https://user-images.githubusercontent.com/42750/72461522-f48d6b00-37ad-11ea-80ab-3aa59b64063d.png)
