### PR TITLE
fix: audio source position

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioSource.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioSource.prefab
@@ -26,7 +26,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1921490995325758924}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 7.6132913, y: 3.4112124, z: 2.641078}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -44,6 +44,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f08c963450eeec8449a23fdf448cb8b7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  model:
+    audioClipId: 
+    playing: 0
+    volume: 1
+    loop: 0
+    pitch: 1
 --- !u!82 &6016498642084047094
 AudioSource:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
corrected audio source prefab position.

Didn't make any test as this was an error when creating the component, the chances of this happening again on this component are super low

-------------------------------------------------------------

You can test with the church BGM next to the gamers plaza: 
* PROD (displaced audio source, it can be heard to the left of the altar)
https://explorer.decentraland.org/?position=75%2C-12

* THIS PR
https://explorer.decentraland.zone/branch/fix/AudioSourcePosition/index.html?position=75%2C-12&ENV=org