### PR TITLE
fix: parcel blocker instancing perf spike

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/BlockerHandler.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/BlockerHandler.cs
@@ -1,0 +1,104 @@
+using DCL.Configuration;
+using DCL.Helpers;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace DCL.Controllers
+{
+    public class BlockerHandler
+    {
+        private readonly Dictionary<(int, int), PoolableObject> blockers = new Dictionary<(int, int), PoolableObject>();
+
+        private static GameObject blockerPrefab;
+        const string PARCEL_BLOCKER_POOL_NAME = "ParcelBlocker";
+        private const string PARCEL_BLOCKER_PREFAB = "Prefabs/ParcelBlocker";
+
+        Vector3 auxPosVec = new Vector3();
+        Vector3 auxScaleVec = new Vector3();
+
+        private static Vector2Int[] aroundOffsets = {
+            new Vector2Int(1, 0),
+            new Vector2Int(-1, 0),
+            new Vector2Int(0, 1),
+            new Vector2Int(0, -1),
+            new Vector2Int(1, 1),
+            new Vector2Int(-1, -1),
+            new Vector2Int(1, -1),
+            new Vector2Int(-1, 1) };
+
+        public BlockerHandler()
+        {
+            if (blockerPrefab == null)
+                blockerPrefab = Resources.Load<GameObject>(PARCEL_BLOCKER_PREFAB);
+
+            // We need to manually create the Pool for empty game objects if it doesn't exist
+            if (!PoolManager.i.ContainsPool(PARCEL_BLOCKER_POOL_NAME))
+            {
+                GameObject go = Object.Instantiate(blockerPrefab);
+                Pool pool = PoolManager.i.AddPool(PARCEL_BLOCKER_POOL_NAME, go);
+                pool.ForcePrewarm();
+            }
+        }
+
+
+        public void SetupBlockers(Vector2Int[] parcels, float height, Transform parent)
+        {
+            CleanBlockers();
+
+            int parcelsLength = parcels.Length;
+
+            auxScaleVec.x = ParcelSettings.PARCEL_SIZE;
+            auxScaleVec.y = height;
+            auxScaleVec.z = ParcelSettings.PARCEL_SIZE;
+
+            auxPosVec.y = height / 2;
+
+            for (int i = 0; i < parcelsLength; i++)
+            {
+                Vector2Int pos = parcels[i];
+
+                bool isSurrounded = true;
+
+                for (int i1 = 0; i1 < aroundOffsets.Length; i1++)
+                {
+                    Vector2Int o = aroundOffsets[i1];
+
+                    if (!blockers.ContainsKey((pos.x + o.x, pos.y + o.y)))
+                    {
+                        isSurrounded = false;
+                        break;
+                    }
+                }
+
+                if (isSurrounded)
+                    continue;
+
+                PoolableObject blocker = PoolManager.i.Get(PARCEL_BLOCKER_POOL_NAME);
+
+                blocker.transform.SetParent(parent, false);
+                blocker.transform.position = DCLCharacterController.i.characterPosition.WorldToUnityPosition(Utils.GridToWorldPosition(pos.x, pos.y)) + (Vector3.up * blockerPrefab.transform.localPosition.y) + new Vector3(ParcelSettings.PARCEL_SIZE / 2, 0, ParcelSettings.PARCEL_SIZE / 2);
+
+                auxPosVec.x = blocker.transform.position.x;
+                auxPosVec.z = blocker.transform.position.z;
+
+                blocker.transform.position = auxPosVec;
+                blocker.transform.localScale = auxScaleVec;
+
+                blockers.Add((pos.x, pos.y), blocker);
+            }
+        }
+
+        public void CleanBlockers()
+        {
+            using (var it = blockers.GetEnumerator())
+            {
+                while (it.MoveNext())
+                {
+                    it.Current.Value.Release();
+                }
+            }
+
+            blockers.Clear();
+        }
+    }
+}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/BlockerHandler.cs.meta
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/BlockerHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 16b11456e012cc148ace1eeff93b40a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScene.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScene.cs
@@ -1,4 +1,4 @@
-using DCL.Components;
+﻿using DCL.Components;
 using DCL.Configuration;
 using DCL.Helpers;
 using DCL.Models;
@@ -58,7 +58,7 @@ namespace DCL.Controllers
         private State state = State.NOT_READY;
         public SceneBoundariesChecker boundariesChecker { private set; get; }
 
-        BlockerHandler blockerHandler;
+        public BlockerHandler blockerHandler;
 
 
         public void Awake()

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScene.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScene.cs
@@ -9,7 +9,7 @@ using Object = UnityEngine.Object;
 
 namespace DCL.Controllers
 {
-    public class ParcelScene : MonoBehaviour, ICleanable
+    public partial class ParcelScene : MonoBehaviour, ICleanable
     {
         public static bool VERBOSE = false;
         enum State
@@ -20,7 +20,6 @@ namespace DCL.Controllers
             READY,
         }
 
-        private const string PARCEL_BLOCKER_PREFAB = "Prefabs/ParcelBlocker";
         private const int ENTITY_POOL_PREWARM_COUNT = 2000;
 
         public Dictionary<string, DecentralandEntity> entities = new Dictionary<string, DecentralandEntity>();
@@ -53,29 +52,19 @@ namespace DCL.Controllers
 
         public static ParcelScenesCleaner parcelScenesCleaner = new ParcelScenesCleaner();
 
-        private readonly List<PoolableObject> blockers = new List<PoolableObject>();
         private readonly List<string> disposableNotReady = new List<string>();
         private bool flaggedToUnload = false;
         private bool isReleased = false;
         private State state = State.NOT_READY;
         public SceneBoundariesChecker boundariesChecker { private set; get; }
 
-        private static GameObject blockerPrefab;
+        BlockerHandler blockerHandler;
+
 
         public void Awake()
         {
             state = State.NOT_READY;
-
-            if (blockerPrefab == null)
-                blockerPrefab = Resources.Load<GameObject>(PARCEL_BLOCKER_PREFAB);
-
-            // We need to manually create the Pool for empty game objects if it doesn't exist
-            if (!PoolManager.i.ContainsPool(PARCEL_BLOCKER_POOL_NAME))
-            {
-                GameObject go = Instantiate(blockerPrefab);
-                Pool pool = PoolManager.i.AddPool(PARCEL_BLOCKER_POOL_NAME, go);
-                pool.ForcePrewarm();
-            }
+            blockerHandler = new BlockerHandler();
 
             if (DCLCharacterController.i)
                 DCLCharacterController.i.characterPosition.OnPrecisionAdjust += OnPrecisionAdjust;
@@ -154,57 +143,12 @@ namespace DCL.Controllers
             }
 #endif
             if (useBlockers)
-                SetupBlockers(data.parcels);
+                blockerHandler.SetupBlockers(data.parcels, metricsController.GetLimits().sceneHeight, this.transform);
 
             if (isTestScene)
                 SetSceneReady();
         }
 
-        public void CleanBlockers()
-        {
-            int count = blockers.Count;
-
-            for (int i = 0; i < count; i++)
-            {
-                blockers[i].Release();
-            }
-
-            blockers.Clear();
-        }
-
-        const string PARCEL_BLOCKER_POOL_NAME = "ParcelBlocker";
-        Vector3 auxVec = new Vector3();
-
-        private void SetupBlockers(Vector2Int[] parcels)
-        {
-            CleanBlockers();
-
-            int parcelsLength = parcels.Length;
-            for (int i = 0; i < parcelsLength; i++)
-            {
-                Vector2Int pos = parcels[i];
-
-                PoolableObject blocker = PoolManager.i.Get(PARCEL_BLOCKER_POOL_NAME);
-
-                blocker.transform.SetParent(this.transform, false);
-                blocker.transform.position = DCLCharacterController.i.characterPosition.WorldToUnityPosition(Utils.GridToWorldPosition(pos.x, pos.y)) + (Vector3.up * blockerPrefab.transform.localPosition.y) + new Vector3(ParcelSettings.PARCEL_SIZE / 2, 0, ParcelSettings.PARCEL_SIZE / 2);
-
-                float sceneHeight = metricsController.GetLimits().sceneHeight;
-
-                auxVec.x = blocker.transform.position.x;
-                auxVec.y = sceneHeight / 2;
-                auxVec.z = blocker.transform.position.z;
-
-                blocker.transform.position = auxVec;
-
-                auxVec.x = ParcelSettings.PARCEL_SIZE;
-                auxVec.y = sceneHeight;
-                auxVec.z = ParcelSettings.PARCEL_SIZE;
-                blocker.transform.localScale = auxVec;
-
-                blockers.Add(blocker);
-            }
-        }
 
         void OnPrecisionAdjust(DCLCharacterPosition position)
         {
@@ -1135,7 +1079,7 @@ namespace DCL.Controllers
             state = State.READY;
 
             if (useBlockers)
-                CleanBlockers();
+                blockerHandler.CleanBlockers();
 
             SceneController.i.SendSceneReady(sceneData.id);
             RefreshName();

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScene.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScene.cs
@@ -1,4 +1,4 @@
-﻿using DCL.Components;
+using DCL.Components;
 using DCL.Configuration;
 using DCL.Helpers;
 using DCL.Models;
@@ -9,7 +9,7 @@ using Object = UnityEngine.Object;
 
 namespace DCL.Controllers
 {
-    public partial class ParcelScene : MonoBehaviour, ICleanable
+    public class ParcelScene : MonoBehaviour, ICleanable
     {
         public static bool VERBOSE = false;
         enum State

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Tests/SceneTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Tests/SceneTests.cs
@@ -315,7 +315,7 @@ namespace Tests
             Assert.AreEqual(1, sceneController.loadedScenes.Count);
 
             var theScene = sceneController.loadedScenes["xxx"];
-            theScene.CleanBlockers();
+            theScene.blockerHandler.CleanBlockers();
             yield return null;
 
             Assert.AreEqual(3, theScene.sceneData.parcels.Length);
@@ -346,7 +346,7 @@ namespace Tests
             Assert.AreEqual(1, sceneController.loadedScenes.Count);
 
             var theScene = sceneController.loadedScenes["xxx"];
-            theScene.CleanBlockers();
+            theScene.blockerHandler.CleanBlockers();
             yield return null;
 
             Assert.AreEqual(3, theScene.sceneData.parcels.Length);


### PR DESCRIPTION
For big scenes (e.g. plazas) we are instancing too many green blockers. This should cut the number of blockers by a fair amount.