### PR TITLE
fix: reported current scene id

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
@@ -150,14 +150,26 @@ namespace DCL
             if (forceSort || sceneSortDirty)
             {
                 sceneSortDirty = false;
+
                 scenesSortedByDistance.Sort(SortScenesByDistanceMethod);
 
-                ParcelScene currentScene = scenesSortedByDistance.Any()
-                    ? scenesSortedByDistance.First(scene => scene.sceneData != null && !scene.isPersistent)
-                    : null;
+                using (var iterator = scenesSortedByDistance.GetEnumerator())
+                {
+                    ParcelScene scene;
+                    bool characterIsInsideScene;
 
-                if (currentScene != null && currentScene.sceneData != null)
-                    currentSceneId = currentScene.sceneData.id;
+                    while (iterator.MoveNext())
+                    {
+                        scene = iterator.Current;
+                        characterIsInsideScene = scene.IsInsideSceneBoundaries(DCLCharacterController.i.characterPosition);
+
+                        if (scene.sceneData.id != globalSceneId && characterIsInsideScene)
+                        {
+                            currentSceneId = scene.sceneData.id;
+                            break;
+                        }
+                    }
+                }
 
                 CommonScriptableObjects.sceneID.Set(currentSceneId);
 
@@ -175,7 +187,6 @@ namespace DCL
 
             return dist1 - dist2;
         }
-
 
         void Start()
         {
@@ -213,7 +224,6 @@ namespace DCL
             InputController_Legacy.i.Update();
             TrySortScenesByDistance();
         }
-
 
         public void CreateUIScene(string json)
         {
@@ -352,7 +362,6 @@ namespace DCL
 
             OnMessageProcessEnds?.Invoke(MessagingTypes.SCENE_LOAD);
         }
-
 
         public void UpdateParcelScenesExecute(string decentralandSceneJSON)
         {


### PR DESCRIPTION
Since the scene sorting is not accuarate based on grid coords (it sorts based on **parcels**, not **scenes**), we go back to traversing the scenes collection (at most with our current LOS for loaded scenes it would be like 25~ items, not much at all)

------------------------------------
You can test this fixes the door opening in the Space Office scene at **ZONE 56.-59**, using the keycard at the back of the building