### PR TITLE
fix: avatar and model visibility fixes

### DIFF
--- a/unity-client/Assets/Resources/ScriptableObjects/CameraForward.asset
+++ b/unity-client/Assets/Resources/ScriptableObjects/CameraForward.asset
@@ -12,4 +12,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 31e6564b5872422fa77436eed806c1db, type: 3}
   m_Name: CameraForward
   m_EditorClassIdentifier: 
-  value: {x: 0, y: 0, z: 0}
+  value: {x: 0, y: 0, z: 1}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
@@ -201,7 +201,7 @@ namespace DCL
         void OnWearableLoadingFail(WearableController wearableController)
         {
             Debug.LogError($"Avatar: {model.name}  -  Failed loading wearable: {wearableController.id}");
-            StopAllCoroutines();
+            StopLoadingCoroutines();
 
             ResetAvatar();
             isLoading = false;
@@ -337,7 +337,7 @@ namespace DCL
 
         protected virtual void OnDestroy()
         {
-            CoroutineStarter.Stop(loadCoroutine);
+            StopLoadingCoroutines();
             ResetAvatar();
         }
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -9,7 +9,7 @@ namespace DCL
         public AvatarName avatarName;
         public AvatarRenderer avatarRenderer;
         public AvatarMovementController avatarMovementController;
-        public GameObject minimapRepresentation;
+        [SerializeField] internal GameObject minimapRepresentation;
 
         private string currentSerialization = "";
         public AvatarModel model = new AvatarModel();

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -1,4 +1,4 @@
-﻿using DCL.Components;
+using DCL.Components;
 using System.Collections;
 using UnityEngine;
 
@@ -9,7 +9,7 @@ namespace DCL
         public AvatarName avatarName;
         public AvatarRenderer avatarRenderer;
         public AvatarMovementController avatarMovementController;
-        [SerializeField] private GameObject minimapRepresentation;
+        public GameObject minimapRepresentation;
 
         private string currentSerialization = "";
         public AvatarModel model = new AvatarModel();
@@ -40,7 +40,7 @@ namespace DCL
                 entity.OnTransformChange += avatarMovementController.OnTransformChanged;
             }
 
-            if (currentSerialization == newJson) 
+            if (currentSerialization == newJson)
                 yield break;
 
             model = SceneController.i.SafeFromJson<AvatarModel>(newJson);
@@ -49,7 +49,11 @@ namespace DCL
 
             bool avatarDone = false;
             bool avatarFailed = false;
+
+            yield return null; //NOTE(Brian): just in case we have a Object.Destroy waiting to be resolved.
+
             avatarRenderer.ApplyModel(model, () => avatarDone = true, () => avatarFailed = true);
+
             yield return new WaitUntil(() => avatarDone || avatarFailed);
 
             avatarName.SetName(model.name);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 namespace DCL.Configuration
 {
@@ -10,7 +10,7 @@ namespace DCL.Configuration
     public static class EnvironmentSettings
     {
         public static bool DEBUG = true;
-        public static readonly Vector3 MORDOR = new Vector3(1000, 1000, 1000);
+        public static readonly Vector3 MORDOR = new Vector3(10000, 10000, 10000);
     }
 
     public static class InputSettings

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/Asset_AB_GameObject.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/Asset_AB_GameObject.cs
@@ -1,3 +1,4 @@
+using DCL.Configuration;
 using UnityEngine;
 
 namespace DCL
@@ -12,6 +13,8 @@ namespace DCL
         {
             isInstantiated = false;
             container = new GameObject("AB Container");
+            // Hide gameobject until it's been correctly processed, otherwise it flashes at 0,0,0
+            container.transform.position = EnvironmentSettings.MORDOR;
         }
 
         public override void Cleanup()
@@ -28,7 +31,7 @@ namespace DCL
         public void Hide()
         {
             container.transform.parent = null;
-            container.transform.position = Vector3.one * 5000;
+            container.transform.position = EnvironmentSettings.MORDOR;
         }
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/MaterialCachingHelper.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/MaterialCachingHelper.cs
@@ -21,18 +21,28 @@ namespace DCL
             return mat.ComputeCRC() + mat.name;
         }
 
-        public static IEnumerator UseCachedMaterials(GameObject obj)
+        public static IEnumerator UseCachedMaterials(List<Renderer> renderers, bool enableRenderers = true)
         {
-            if (obj == null)
+            if (renderers == null)
+                yield break;
+
+            int renderersCount = renderers.Count;
+
+            if (renderersCount == 0)
                 yield break;
 
             var matList = new List<Material>(1);
 
-            foreach (var rend in obj.GetComponentsInChildren<Renderer>(true))
+            for (int i = 0; i < renderersCount; i++)
             {
+                Renderer r = renderers[i];
+
+                if (!enableRenderers)
+                    r.enabled = false;
+
                 matList.Clear();
 
-                foreach (var mat in rend.sharedMaterials)
+                foreach (var mat in r.sharedMaterials)
                 {
                     float elapsedTime = Time.realtimeSinceStartup;
 
@@ -60,7 +70,7 @@ namespace DCL
                     }
                 }
 
-                rend.sharedMaterials = matList.ToArray();
+                r.sharedMaterials = matList.ToArray();
             }
         }
     }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromiseSettings_Rendering.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromiseSettings_Rendering.cs
@@ -1,4 +1,5 @@
 using DCL.Helpers;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace DCL
@@ -46,11 +47,15 @@ namespace DCL
             }
         }
 
-        public void ApplyAfterLoad(Transform t)
+        public void ApplyAfterLoad(Transform transform)
         {
-            Renderer[] renderers = t.gameObject.GetComponentsInChildren<Renderer>(true);
+            ApplyAfterLoad(new List<Renderer>(transform.GetComponentsInChildren<Renderer>(true)));
+        }
 
-            for (int i = 0; i < renderers.Length; i++)
+        public void ApplyAfterLoad(List<Renderer> renderers = null)
+        {
+            int renderersCount = renderers.Count;
+            for (int i = 0; i < renderersCount; i++)
             {
                 Renderer renderer = renderers[i];
                 renderer.enabled = visibleFlags == VisibleFlags.INVISIBLE ? false : true;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
@@ -26,7 +26,9 @@ namespace DCL
 
         protected override void OnBeforeLoadOrReuse()
         {
+#if UNITY_EDITOR
             asset.container.name = "GLTF: " + url;
+#endif
             settings.ApplyBeforeLoad(asset.container.transform);
         }
 
@@ -79,25 +81,24 @@ namespace DCL
             if (!library.Add(asset))
                 return false;
 
-            if (asset.visible)
-            {
-                //NOTE(Brian): If the asset did load "in world" add it to library and then Get it immediately
-                //             So it keeps being there. As master gltfs can't be in the world.
-                //
-                //             ApplySettings will reposition the newly Get asset to the proper coordinates.
-                if (settings.forceNewInstance)
-                {
-                    asset = (library as AssetLibrary_GLTF).GetCopyFromOriginal(asset.id);
-                }
-                else
-                {
-                    asset = library.Get(asset.id);
-                }
+            if (!asset.visible)
+                return true;
 
-                //NOTE(Brian): Call again this method because we are replacing the asset.
-                OnBeforeLoadOrReuse();
+            //NOTE(Brian): If the asset did load "in world" add it to library and then Get it immediately
+            //             So it keeps being there. As master gltfs can't be in the world.
+            //
+            //             ApplySettings will reposition the newly Get asset to the proper coordinates.
+            if (settings.forceNewInstance)
+            {
+                asset = (library as AssetLibrary_GLTF).GetCopyFromOriginal(asset.id);
+            }
+            else
+            {
+                asset = library.Get(asset.id);
             }
 
+            //NOTE(Brian): Call again this method because we are replacing the asset.
+            OnBeforeLoadOrReuse();
             return true;
         }
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Asset_GLTF.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Asset_GLTF.cs
@@ -1,3 +1,4 @@
+using DCL.Configuration;
 using System.Collections;
 using UnityEngine;
 
@@ -33,7 +34,8 @@ namespace DCL
         public void Hide()
         {
             container.transform.parent = null;
-            container.transform.position = Vector3.one * 1000;
+            container.transform.position = EnvironmentSettings.MORDOR;
+            visible = false;
         }
 
         public void CancelShow()

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/DCLCharacterController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/DCLCharacterController.cs
@@ -410,7 +410,7 @@ public class DCLCharacterController : MonoBehaviour
         float height = 0.875f;
 
         var reportPosition = characterPosition.worldPosition + (Vector3.up * height);
-        var compositeRotation = Quaternion.LookRotation(cameraForward.Get());
+        var compositeRotation = cameraForward != Vector3.zero ? Quaternion.LookRotation(cameraForward.Get()) : Quaternion.identity;
         var playerHeight = height + (characterController.height / 2);
 
         //NOTE(Brian): We have to wait for a Teleport before sending the ReportPosition, because if not ReportPosition events will be sent

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/DCLCharacterController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/DCLCharacterController.cs
@@ -410,7 +410,7 @@ public class DCLCharacterController : MonoBehaviour
         float height = 0.875f;
 
         var reportPosition = characterPosition.worldPosition + (Vector3.up * height);
-        var compositeRotation = cameraForward != Vector3.zero ? Quaternion.LookRotation(cameraForward.Get()) : Quaternion.identity;
+        var compositeRotation = Quaternion.LookRotation(cameraForward.Get());
         var playerHeight = height + (characterController.height / 2);
 
         //NOTE(Brian): We have to wait for a Teleport before sending the ReportPosition, because if not ReportPosition events will be sent

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/CoroutineHelpers/CoroutineHelpers.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/CoroutineHelpers/CoroutineHelpers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -26,7 +26,7 @@ namespace DCL
             Action<Exception> done
         )
         {
-            return monoBehaviour.StartCoroutine(RunThrowingIterator(enumerator, done));
+            return CoroutineStarter.Start(RunThrowingIterator(enumerator, done));
         }
 
         /// <summary>

--- a/unity-client/Assets/UnityGLTF/Scripts/GLTFComponent.cs
+++ b/unity-client/Assets/UnityGLTF/Scripts/GLTFComponent.cs
@@ -1,4 +1,4 @@
-﻿using DCL.Components;
+using DCL.Components;
 using System;
 using System.Collections;
 using System.IO;
@@ -318,6 +318,7 @@ namespace UnityGLTF
                 Debug.Log("couldn't load GLTF because url is empty");
             }
 
+            CoroutineStarter.Stop(loadingRoutine);
             loadingRoutine = null;
             Destroy(loadingPlaceholder);
             Destroy(this);
@@ -385,6 +386,7 @@ namespace UnityGLTF
 
             if (!alreadyLoadedAsset && loadingRoutine != null)
             {
+                CoroutineStarter.Stop(loadingRoutine);
                 OnFail_Internal(null);
                 return;
             }


### PR DESCRIPTION
fix: avatar incomplete models were being shown when it shouldn't due to `SetVisibility` incorrectly overriding the renderer enabled states.

fix: some models showing in 0,0,0 of the world for a frame when it shouldn't 

fix: rewrote `BeHiddenUntilWholeAvatarIsReady` as wasn't asserting the entire avatar, just a wearable.

fix: `AssetPromise_GLTF` wasn't setting visible = false correctly leading to logic errors.

fix: Asset bundle promises weren't setting Invisibility correctly while the asset is being loaded.