### PR TITLE
chore: render settings preset tweaks

### DIFF
--- a/unity-client/Assets/Resources/ScriptableObjects/QualitySettingsData.asset
+++ b/unity-client/Assets/Resources/ScriptableObjects/QualitySettingsData.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   - displayName: Basic
     textureQuality: 1
     antiAliasing: 1
-    renderScale: 1
+    renderScale: 0.8
     shadows: 0
     softShadows: 0
     shadowResolution: 256
@@ -26,21 +26,21 @@ MonoBehaviour:
     colorGrading: 0
   - displayName: Medium
     textureQuality: 0
-    antiAliasing: 2
-    renderScale: 1
+    antiAliasing: 1
+    renderScale: 0.8
     shadows: 1
     softShadows: 1
     shadowResolution: 256
-    cameraDrawDistance: 100
+    cameraDrawDistance: 80
     bloom: 1
     colorGrading: 1
   - displayName: High
     textureQuality: 0
-    antiAliasing: 4
+    antiAliasing: 2
     renderScale: 1
     shadows: 1
     softShadows: 1
-    shadowResolution: 1024
+    shadowResolution: 512
     cameraDrawDistance: 100
     bloom: 1
     colorGrading: 1


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6875814/73292790-6cfa2000-41e1-11ea-86f6-89112a7f0a48.png)

* Anti-aliasing was disabled for basic/medium presets, as its the most cost intensive rendering feature.
* Rendering scale reduced to 0.8 for basic/medium as well.
* Drawing distance reduced to 80 for medium (fog ends at 95, so a bit shy of that value).
