### PR TITLE
config: max visible peers increased

### DIFF
--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -126,7 +126,7 @@ export namespace commConfigurations {
 
   export const peerTtlMs = 60000
 
-  export const maxVisiblePeers = 25
+  export const maxVisiblePeers = 50
 
   export const iceServers = [
     {


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Increases maxVisiblePeers size to 50

# Why? <!-- Explain the reason -->
Because that's the max amount of peers we will have in a layer
