### PR TITLE
feat: Sending peer position (as parcel) to lighthouse for optimization

### DIFF
--- a/kernel/package-lock.json
+++ b/kernel/package-lock.json
@@ -2685,9 +2685,9 @@
       }
     },
     "decentraland-katalyst-peer": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/decentraland-katalyst-peer/-/decentraland-katalyst-peer-0.1.22.tgz",
-      "integrity": "sha512-om9soZol5eNoPAx8RdbGpmZDxHO7MTLydDS2CpUZHDLPwfXncc1gtqcZ08B2uGnbYJWdwmjQj+pPE3tWHj9iGQ==",
+      "version": "0.1.23",
+      "resolved": "https://registry.npmjs.org/decentraland-katalyst-peer/-/decentraland-katalyst-peer-0.1.23.tgz",
+      "integrity": "sha512-+Pnnxs2/kZBxFdmYflbTj/2nkRXbkcL0QFdtVEpRKVZ2LHSuG/LvZxCy065DDwX+u7VxmbF0CEPbb+hgBCdHpQ==",
       "requires": {
         "eventemitter3": "^4.0.0",
         "fp-future": "^1.0.1",

--- a/kernel/package.json
+++ b/kernel/package.json
@@ -106,7 +106,7 @@
     "cids": "^0.7.3",
     "concurrently": "^4.1.0",
     "decentraland-auth-protocol": "^0.3.2",
-    "decentraland-katalyst-peer": "^0.1.22",
+    "decentraland-katalyst-peer": "^0.1.23",
     "decentraland-renderer": "^1.8.4333",
     "decentraland-rpc": "^3.1.8",
     "devtools-protocol": "0.0.615714",

--- a/kernel/packages/shared/comms/index.ts
+++ b/kernel/packages/shared/comms/index.ts
@@ -535,6 +535,12 @@ export async function connect(userId: string) {
               }
               // if any error occurs
               return identity
+            },
+            parcelGetter: () => {
+              if (context && context.currentPosition) {
+                const parcel = position2parcel(context.currentPosition)
+                return [parcel.x, parcel.z]
+              }
             }
           }
         )


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
The explorer starts sending the parcel positions of peers

# Why? <!-- Explain the reason -->
Because we can use that information to optimize network connection
