### PR TITLE
fix: MY EYES! -- always use .org for hard-coded content

### DIFF
--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -236,10 +236,8 @@ export function getLoginConfigurationForCurrentDomain() {
 
 export const ENABLE_EMPTY_SCENES = !DEBUG || knownTLDs.includes(getTLD())
 
-export function getContentUrl() {
-  const TLDDefault = getDefaultTLD()
-
-  return `https://content.decentraland.${TLDDefault === 'today' ? 'org' : TLDDefault}`
+export function getWearablesSafeURL() {
+  return 'https://content.decentraland.org'
 }
 
 export function getServerConfigurations() {

--- a/kernel/packages/shared/passports/sagas.ts
+++ b/kernel/packages/shared/passports/sagas.ts
@@ -1,7 +1,7 @@
 import { getFromLocalStorage, saveToLocalStorage } from 'atomicHelpers/localStorage'
 import { call, fork, put, race, select, take, takeEvery, takeLatest, cancel, ForkEffect } from 'redux-saga/effects'
 import { NotificationType } from 'shared/types'
-import { getServerConfigurations, ALL_WEARABLES, getContentUrl } from '../../config'
+import { getServerConfigurations, ALL_WEARABLES, getWearablesSafeURL } from '../../config'
 import defaultLogger from '../logger'
 import { isInitialized } from '../renderer/selectors'
 import { RENDERER_INITIALIZED } from '../renderer/types'
@@ -178,7 +178,7 @@ function takeLatestById<T extends Action>(
 function overrideBaseUrl(wearable: Wearable) {
   return {
     ...wearable,
-    baseUrl: getContentUrl() + '/contents/',
+    baseUrl: getWearablesSafeURL() + '/contents/',
     baseUrlBundles: getServerConfigurations().contentAsBundle + '/contents/'
   }
 }

--- a/kernel/packages/shared/passports/sagas.ts
+++ b/kernel/packages/shared/passports/sagas.ts
@@ -179,7 +179,7 @@ function overrideBaseUrl(wearable: Wearable) {
   return {
     ...wearable,
     baseUrl: getWearablesSafeURL() + '/contents/',
-    baseUrlBundles: getServerConfigurations().contentAsBundle + '/contents/'
+    baseUrlBundles: getServerConfigurations().contentAsBundle + '/'
   }
 }
 


### PR DESCRIPTION
Which is currently only some wearables

Fixes no-eyes problem:
![image](https://user-images.githubusercontent.com/42750/74311779-f582cf80-4d4e-11ea-884d-62be0edce20c.png)
To:
![image](https://user-images.githubusercontent.com/42750/74311768-ee5bc180-4d4e-11ea-9ed8-5d5baf3cc121.png)
