### PR TITLE
fix: silence missing scene for `metricsupdate`

### DIFF
--- a/kernel/packages/unity-interface/dcl.ts
+++ b/kernel/packages/unity-interface/dcl.ts
@@ -134,7 +134,9 @@ const browserInterface = {
       const parcelScene = scene.parcelScene as UnityParcelScene
       parcelScene.emit(data.eventType as IEventNames, data.payload)
     } else {
-      defaultLogger.error(`SceneEvent: Scene ${data.sceneId} not found`, data)
+      if (data.eventType !== 'metricsUpdate') {
+        defaultLogger.error(`SceneEvent: Scene ${data.sceneId} not found`, data)
+      }
     }
   },
 


### PR DESCRIPTION
This way we clear up the console a little bit