### PR TITLE
fix:  enabled ToS and now open links in a new tab.

### DIFF
--- a/kernel/packages/entryPoints/unity.ts
+++ b/kernel/packages/entryPoints/unity.ts
@@ -27,7 +27,7 @@ initializeUnity(container)
     i.ConfigureExpressionsHUD({ active: true, visible: true })
     i.ConfigurePlayerInfoCardHUD({ active: true, visible: true })
     i.ConfigureAirdroppingHUD({ active: true, visible: true })
-    i.ConfigureTermsOfServiceHUD({ active: true, visible: false })
+    i.ConfigureTermsOfServiceHUD({ active: true, visible: true })
 
     global['globalStore'].dispatch(signalRendererInitialized())
     await startUnityParcelLoading()

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TermsOfServiceHUD/TermsOfServiceHUDController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TermsOfServiceHUD/TermsOfServiceHUDController.cs
@@ -54,13 +54,13 @@ public class TermsOfServiceHUDController : IHUD, IDisposable
     private void OpenToS()
     {
         if (!string.IsNullOrEmpty(model.tosURL))
-            Application.OpenURL(model.tosURL);
+            WebInterface.OpenURL(model.tosURL);
     }
 
     private void OpenPrivacyPolicy()
     {
         if (!string.IsNullOrEmpty(model.privacyPolicyURL))
-            Application.OpenURL(model.privacyPolicyURL);
+            WebInterface.OpenURL(model.privacyPolicyURL);
     }
 
     private void OpenContactEmail()

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TermsOfServiceHUD/TermsOfServiceHUDController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TermsOfServiceHUD/TermsOfServiceHUDController.cs
@@ -66,7 +66,7 @@ public class TermsOfServiceHUDController : IHUD, IDisposable
     private void OpenContactEmail()
     {
         if (!string.IsNullOrEmpty(model.emailContactURL))
-            Application.OpenURL($"mailto:{model.emailContactURL}");
+            WebInterface.OpenURL($"mailto:{model.emailContactURL}");
     }
 
     public void SetVisibility(bool visible)


### PR DESCRIPTION
ToS was disabled and links were opening in the same explorer tab.