### PR TITLE
fix: sending scene ready too soon

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/ComponentUpdateHandler.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/ComponentUpdateHandler.cs
@@ -1,4 +1,4 @@
-﻿using DCL.Components;
+using DCL.Components;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -74,6 +74,7 @@ namespace DCL
                 }
             }
 
+            owner.RaiseOnAppliedChanges();
             routine = null;
         }
 
@@ -93,7 +94,6 @@ namespace DCL
 #if UNITY_EDITOR
             applyChangesRunning = false;
 #endif
-            owner.RaiseOnAppliedChanges();
         }
 
         public void HandleUpdate_Legacy(string newSerialization)

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadableShape.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadableShape.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using DCL.Controllers;
 using DCL.Helpers;
 using DCL.Models;
@@ -67,7 +67,6 @@ namespace DCL.Components
 
         private bool isLoaded = false;
         private bool failed = false;
-        private event Action<BaseDisposable> OnReadyCallbacks;
         public System.Action<DecentralandEntity> OnEntityShapeUpdated;
         new public LoadWrapperModelType model
         {
@@ -223,10 +222,12 @@ namespace DCL.Components
 
             entity.meshesInfo.CleanReferences();
         }
-
-        public override void CallWhenReady(Action<BaseDisposable> callback)
+        public override void CallWhenReady(Action<IComponent> callback)
         {
-            if (attachedEntities.Count == 0 || isLoaded || failed)
+            bool shapeIsReady = attachedEntities.Count == 0 || isLoaded || failed;
+            bool applyChangesIsRunning = updateHandler.isRoutineRunning;
+
+            if (shapeIsReady && !applyChangesIsRunning)
             {
                 callback.Invoke(this);
             }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/OBJShape.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/OBJShape.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using DCL.Controllers;
 
 namespace DCL.Components
@@ -7,11 +6,6 @@ namespace DCL.Components
     {
         public OBJShape(ParcelScene scene) : base(scene)
         {
-        }
-
-        public override void CallWhenReady(Action<BaseDisposable> callback)
-        {
-            callback.Invoke(this);
         }
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingBus.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingBus.cs
@@ -54,7 +54,7 @@ namespace DCL
 
     public class MessagingBus : IDisposable
     {
-        public static bool VERBOSE = false;
+        public static bool VERBOSE = true;
 
         public class QueuedSceneMessage
         {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
@@ -1,4 +1,4 @@
-using DCL.Controllers;
+﻿using DCL.Controllers;
 using DCL.Helpers;
 using DCL.Interface;
 using DCL.Models;
@@ -545,6 +545,8 @@ namespace DCL
 
             EnqueueMessage(queuedMessage);
 
+            Debug.Log($"Enqueuing msg for scene {sceneId} ... method = {message}");
+
             OnMessageDecodeEnds?.Invoke("Misc");
 
             return "";
@@ -600,6 +602,8 @@ namespace DCL
             string method = msgObject.method;
             DCL.Interface.PB_SendSceneMessage payload = msgObject.payload;
 
+            Debug.Log($"Processing msg for scene {sceneId} ... method = {method}");
+
             yieldInstruction = null;
 
             ParcelScene scene;
@@ -617,6 +621,7 @@ namespace DCL
                 {
                     return true;
                 }
+
 
 #if UNITY_EDITOR
                 OnMessageProcessInfoStart?.Invoke(sceneId, method);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Tests/SceneTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Tests/SceneTests.cs
@@ -87,14 +87,14 @@ namespace Tests
 
             scene.SetInitMessagesDone();
 
-            Assert.AreEqual(0, scene.disposableNotReadyCount);
+            Assert.AreEqual(0, scene.componentNotReadyCount);
         }
 
         [Test]
         public void ParcelScene_TrackDisposables_Empty()
         {
             SetUp_TestScene();
-            Assert.AreEqual(0, scene.disposableNotReadyCount);
+            Assert.AreEqual(0, scene.componentNotReadyCount);
         }
 
         [UnityTest]
@@ -377,11 +377,11 @@ namespace Tests
                 src = Utils.GetTestsAssetsPath() + "/GLB/Lantern/Lantern.glb"
             });
 
-            Assert.AreEqual(1, scene.disposableNotReadyCount);
+            Assert.AreEqual(1, scene.componentNotReadyCount);
             scene.SetInitMessagesDone();
-            Assert.AreEqual(1, scene.disposableNotReadyCount);
+            Assert.AreEqual(1, scene.componentNotReadyCount);
             yield return TestHelpers.WaitForGLTFLoad(entity);
-            Assert.AreEqual(0, scene.disposableNotReadyCount);
+            Assert.AreEqual(0, scene.componentNotReadyCount);
         }
 
         [Test]
@@ -394,7 +394,7 @@ namespace Tests
             TestHelpers.CreateEntityWithBoxShape(scene, Vector3.zero, true);
             TestHelpers.CreateEntityWithBoxShape(scene, Vector3.zero, true);
 
-            Assert.AreEqual(3, scene.disposableNotReadyCount);
+            Assert.AreEqual(3, scene.componentNotReadyCount);
         }
 
         [UnityTest]
@@ -404,11 +404,11 @@ namespace Tests
         {
             SetUp_TestScene();
             var boxShape = TestHelpers.CreateEntityWithBoxShape(scene, Vector3.zero, true);
-            Assert.AreEqual(1, scene.disposableNotReadyCount);
+            Assert.AreEqual(1, scene.componentNotReadyCount);
             scene.SetInitMessagesDone();
-            Assert.AreEqual(0, scene.disposableNotReadyCount);
+            Assert.AreEqual(0, scene.componentNotReadyCount);
             yield return boxShape.routine;
-            Assert.AreEqual(0, scene.disposableNotReadyCount);
+            Assert.AreEqual(0, scene.componentNotReadyCount);
         }
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
@@ -167,6 +167,8 @@ namespace DCL.Helpers
             {
                 using (var webRequest = request)
                 {
+                    webRequest.timeout = 30;
+
                     yield return webRequest.SendWebRequest();
 
                     if (!WebRequestSucceded(request))


### PR DESCRIPTION
Scene ready wasn't taking into account entity components. This could lead to some scenes sending the `SceneReady` message when they still have some pending components.