### PR TITLE
fix: avatar skewing

### DIFF
--- a/unity-client/Assets/Resources/Prefabs/CharacterController.prefab
+++ b/unity-client/Assets/Resources/Prefabs/CharacterController.prefab
@@ -25,11 +25,11 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 499268581}
-  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 20, y: 20, z: 20}
   m_Children: []
-  m_Father: {fileID: 6922703132412175459}
+  m_Father: {fileID: 2049354575245787133}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
 --- !u!212 &499268583
@@ -121,12 +121,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 541577446319450576}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.6, y: 0.8, z: 0.6}
   m_Children:
   - {fileID: 497704439567646594}
-  m_Father: {fileID: 6922703132412175459}
+  m_Father: {fileID: 2049354575245787133}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &8793224560918383839
@@ -203,7 +203,7 @@ Transform:
   m_LocalPosition: {x: 0, y: -1.6, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 6922703132412175459}
+  m_Father: {fileID: 2049354575245787133}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &4484426042789304097
@@ -380,6 +380,39 @@ MonoBehaviour:
   eyeMaterial: {fileID: 2100000, guid: fcfa021e0982c0840aaefe7411340f7f, type: 2}
   eyebrowMaterial: {fileID: 2100000, guid: db9e974bee285614b8ea2d8832d1a563, type: 2}
   mouthMaterial: {fileID: 2100000, guid: aa8f029bd537edb44b72b4737ca9b81d, type: 2}
+--- !u!1 &3797448927902441341
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2049354575245787133}
+  m_Layer: 15
+  m_Name: Pivot (anti-skewing)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2049354575245787133
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3797448927902441341}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 499268582}
+  - {fileID: 1248863400464373723}
+  - {fileID: 6758273427026275198}
+  m_Father: {fileID: 6922703132412175459}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6922703132412175462
 GameObject:
   m_ObjectHideFlags: 0
@@ -410,9 +443,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 499268582}
-  - {fileID: 1248863400464373723}
-  - {fileID: 6758273427026275198}
+  - {fileID: 2049354575245787133}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -443,6 +474,7 @@ MonoBehaviour:
   moveVelocity: {x: 0, y: 0, z: 0}
   characterYAxis: {fileID: 11400000, guid: d1bc201cd2f5a1d4b8f721ccc29d2c0f, type: 2}
   characterXAxis: {fileID: 11400000, guid: 44c3c5f07adca334696adae7b81c1869, type: 2}
+  rotationTransform: {fileID: 2049354575245787133}
 --- !u!143 &113901082
 CharacterController:
   m_ObjectHideFlags: 0

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/DCLCharacterController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/DCLCharacterController.cs
@@ -75,6 +75,7 @@ public class DCLCharacterController : MonoBehaviour
 
     [SerializeField] private InputAction_Measurable characterYAxis;
     [SerializeField] private InputAction_Measurable characterXAxis;
+    [SerializeField] private Transform rotationTransform;
     private Vector3Variable cameraForward => CommonScriptableObjects.cameraForward;
     private Vector3Variable cameraRight => CommonScriptableObjects.cameraRight;
 
@@ -245,7 +246,7 @@ public class DCLCharacterController : MonoBehaviour
                 // Horizontal movement
                 var speed = movementSpeed * (isSprinting ? runningSpeedMultiplier : 1f);
 
-                transform.forward = characterForward.Get().Value;
+                rotationTransform.forward = characterForward.Get().Value;
 
                 var xzPlaneForward = Vector3.Scale(cameraForward.Get(), new Vector3(1, 0, 1));
                 var xzPlaneRight = Vector3.Scale(cameraRight.Get(), new Vector3(1, 0, 1));
@@ -266,7 +267,7 @@ public class DCLCharacterController : MonoBehaviour
 
                 velocity += forwardTarget * speed;
 
-                CommonScriptableObjects.playerUnityEulerAngles.Set(transform.eulerAngles);
+                CommonScriptableObjects.playerUnityEulerAngles.Set(rotationTransform.eulerAngles);
             }
         }
 
@@ -366,10 +367,10 @@ public class DCLCharacterController : MonoBehaviour
 
         Ray ray = new Ray(transform.position, Vector3.down * rayMagnitude);
         if (!CastGroundCheckingRay(ray, Vector3.zero, out hitInfo, rayMagnitude) // center
-            && !CastGroundCheckingRay(ray, transform.forward, out hitInfo, rayMagnitude) // forward
-            && !CastGroundCheckingRay(ray, transform.right, out hitInfo, rayMagnitude) // right
-            && !CastGroundCheckingRay(ray, -transform.forward, out hitInfo, rayMagnitude) // back
-            && !CastGroundCheckingRay(ray, -transform.right, out hitInfo, rayMagnitude)) // left
+            && !CastGroundCheckingRay(ray, rotationTransform.forward, out hitInfo, rayMagnitude) // forward
+            && !CastGroundCheckingRay(ray, rotationTransform.right, out hitInfo, rayMagnitude) // right
+            && !CastGroundCheckingRay(ray, -rotationTransform.forward, out hitInfo, rayMagnitude) // back
+            && !CastGroundCheckingRay(ray, -rotationTransform.right, out hitInfo, rayMagnitude)) // left
         {
             return null;
         }


### PR DESCRIPTION
A side effect of using non-uniform scaling with parenting is the skewing of the childs. Adding a node with a  (1,1,1) scale between the non-uniform parent and the content should solve the issue.

EDIT: The above is invalid as a general solution. It will still fail in nested entities with arbitrary rotations/scales. The only way to solve this is by taking the CharacterRepresentation out of the parenting.