### PR TITLE
feat: add current realm data to SDK

### DIFF
--- a/kernel/packages/decentraland-ecs/types/@decentraland/EnvironmentAPI/index.d.ts
+++ b/kernel/packages/decentraland-ecs/types/@decentraland/EnvironmentAPI/index.d.ts
@@ -1,0 +1,11 @@
+declare module '@decentraland/EnvironmentAPI' {
+  export type Realm = {
+    domain: string
+    catalystName: string
+    layer: string
+  }
+  /**
+   * Returns the current connected realm
+   */
+  export function getCurrentRealm(): Promise<Realm | undefined>
+}

--- a/kernel/packages/shared/apis/EnvironmentAPI.ts
+++ b/kernel/packages/shared/apis/EnvironmentAPI.ts
@@ -1,6 +1,11 @@
 import { registerAPI, exposeMethod } from 'decentraland-rpc/lib/host'
 import { ExposableAPI } from './ExposableAPI'
 import { EnvironmentData } from 'shared/types'
+import { Realm } from '../dao/types'
+import { Store } from 'redux'
+import { RootState } from 'shared/store/rootTypes'
+
+declare const window: any
 
 @registerAPI('EnvironmentAPI')
 export class EnvironmentAPI extends ExposableAPI {
@@ -11,5 +16,14 @@ export class EnvironmentAPI extends ExposableAPI {
   @exposeMethod
   async getBootstrapData(): Promise<EnvironmentData<any>> {
     return this.data
+  }
+
+  /**
+   * Returns the current connected realm
+   */
+  @exposeMethod
+  async getCurrentRealm(): Promise<Realm | undefined> {
+    const store: Store<RootState> = window['globalStore']
+    return store.getState().dao.realm
   }
 }

--- a/kernel/public/ecs-scenes/-200.-3-realm-data/game.ts
+++ b/kernel/public/ecs-scenes/-200.-3-realm-data/game.ts
@@ -1,0 +1,21 @@
+import { getCurrentRealm } from '@decentraland/EnvironmentAPI'
+
+const cube = new Entity()
+
+cube.addComponentOrReplace(
+  new Transform({
+    position: new Vector3(5, 1, 5)
+  })
+)
+
+const text = new TextShape('Wait for it')
+text.billboard = true
+text.isPickable = true
+cube.addComponentOrReplace(text)
+
+engine.addEntity(cube)
+
+executeTask(async () => {
+  const currentRealm = await getCurrentRealm()
+  text.value = `You are in the realm: ${JSON.stringify(currentRealm)}`
+})

--- a/kernel/public/ecs-scenes/-200.-3-realm-data/scene.json
+++ b/kernel/public/ecs-scenes/-200.-3-realm-data/scene.json
@@ -1,0 +1,30 @@
+{
+  "display": {
+    "title": "interactive-text",
+    "favicon": "favicon_asset"
+  },
+  "contact": {
+    "name": "user data",
+    "email": ""
+  },
+  "owner": "",
+  "scene": {
+    "parcels": [
+      "-200,-3"
+    ],
+    "base": "-200,-3"
+  },
+  "communications": {
+    "type": "webrtc",
+    "signalling": "https://signalling-01.decentraland.org"
+  },
+  "policy": {
+    "contentRating": "E",
+    "fly": true,
+    "voiceEnabled": true,
+    "blacklist": [],
+    "teleportPosition": ""
+  },
+  "main": "game.js",
+  "tags": []
+}

--- a/kernel/public/ecs-scenes/-200.-3-realm-data/tsconfig.json
+++ b/kernel/public/ecs-scenes/-200.-3-realm-data/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "outFile": "./game.js"
+  },
+  "include": ["*.ts"],
+  "extends": "../../../packages/decentraland-ecs/types/tsconfig.json"
+}


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Added realm data to SDK in EnvironmentAPI

# Why? <!-- Explain the reason -->
Allow scene creators to take into account where are users currently interacting and match appropriately.
