### PR TITLE
fix: prevent delighted errors

### DIFF
--- a/kernel/packages/unity-interface/dcl.ts
+++ b/kernel/packages/unity-interface/dcl.ts
@@ -251,7 +251,11 @@ function delightedSurvey() {
       }
     }
 
-    delighted.survey(payload)
+    try {
+      delighted.survey(payload)
+    } catch (error) {
+      defaultLogger.error('Delighted error: ' + error.message, error)
+    }
   }
 }
 
@@ -748,7 +752,7 @@ export async function initializeEngine(_gameInstance: GameInstance) {
     onMessage(type: string, message: any) {
       if (type in browserInterface) {
         // tslint:disable-next-line:semicolon
-        ;(browserInterface as any)[type](message)
+        ; (browserInterface as any)[type](message)
       } else {
         defaultLogger.info(`Unknown message (did you forget to add ${type} to unity-interface/dcl.ts?)`, message)
       }


### PR DESCRIPTION
# What? 
prevent delighted errors

# Why? 
Delighted library cloud fails, so we add a try-catch to prevent that error reach to unity
