### PR TITLE
fix: Now goto crowd checks the limits of the world before trying to teleport

### DIFF
--- a/kernel/packages/shared/world/TeleportController.ts
+++ b/kernel/packages/shared/world/TeleportController.ts
@@ -40,7 +40,7 @@ export class TeleportController {
     const profile = getUserProfile().profile as Profile
 
     if (!tutorialEnabled() || profile.tutorialStep !== tutorialStepId.INITIAL_SCENE) {
-      (window as any)['unityInterface'].ShowWelcomeNotification()
+      ;(window as any)['unityInterface'].ShowWelcomeNotification()
     }
   }
 
@@ -57,7 +57,9 @@ export class TeleportController {
 
       const currentParcel = worldToGrid(lastPlayerPosition)
 
-      usersParcels = usersParcels.filter(it => currentParcel.x !== it[0] && currentParcel.y !== it[1])
+      usersParcels = usersParcels.filter(
+        it => isInsideParcelLimits(it[0], it[1]) && currentParcel.x !== it[0] && currentParcel.y !== it[1]
+      )
 
       if (usersParcels.length > 0) {
         // Sorting from most close users
@@ -71,7 +73,10 @@ export class TeleportController {
           `Found a parcel with ${closeUsers} user(s) nearby: ${target[0]},${target[1]}. Teleporting...`
         )
       } else {
-        return { message: 'There seems to be no users in other parcels at the current realm. Could not teleport.', success: false }
+        return {
+          message: 'There seems to be no users in other parcels at the current realm. Could not teleport.',
+          success: false
+        }
       }
     } catch (e) {
       defaultLogger.error('Error while trying to teleport to crowd', e)
@@ -99,13 +104,7 @@ export class TeleportController {
   public static goTo(x: number, y: number, teleportMessage?: string): { message: string; success: boolean } {
     const tpMessage: string = teleportMessage ? teleportMessage : `Teleporting to ${x}, ${y}...`
 
-    const insideCoords =
-      x > parcelLimits.minLandCoordinateX &&
-      x <= parcelLimits.maxLandCoordinateX &&
-      y > parcelLimits.minLandCoordinateY &&
-      y <= parcelLimits.maxLandCoordinateY
-
-    if (insideCoords) {
+    if (isInsideParcelLimits(x, y)) {
       teleportObservable.notifyObservers({
         x: x,
         y: y,
@@ -120,4 +119,13 @@ export class TeleportController {
       return { message: errorMessage, success: false }
     }
   }
+}
+
+function isInsideParcelLimits(x: number, y: number) {
+  return (
+    x > parcelLimits.minLandCoordinateX &&
+    x <= parcelLimits.maxLandCoordinateX &&
+    y > parcelLimits.minLandCoordinateY &&
+    y <= parcelLimits.maxLandCoordinateY
+  )
 }

--- a/kernel/packages/shared/world/TeleportController.ts
+++ b/kernel/packages/shared/world/TeleportController.ts
@@ -40,7 +40,7 @@ export class TeleportController {
     const profile = getUserProfile().profile as Profile
 
     if (!tutorialEnabled() || profile.tutorialStep !== tutorialStepId.INITIAL_SCENE) {
-      ;(window as any)['unityInterface'].ShowWelcomeNotification()
+      (window as any)['unityInterface'].ShowWelcomeNotification()
     }
   }
 


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Before this change when executing `/goto crowd` you could try to teleport to a position outside of bounds (like the tutorial area). An error was shown as a result.

# Why? <!-- Explain the reason -->
To teleport to the crowds that are inside limits
