### PR TITLE
Fix: runloops URL and headless chrome (run as root)

### DIFF
--- a/kernel/scripts/runLoops.ts
+++ b/kernel/scripts/runLoops.ts
@@ -4,7 +4,9 @@ const position = process.env.BOT_POSITION ? process.env.BOT_POSITION : '20,20'
 const host = process.env.HOST ? process.env.HOST : 'https://explorer.decentraland.zone'
 
 async function main() {
-  const browser = await puppeteer.launch()
+  const browser = await puppeteer.launch({
+    args: ['--no-sandbox']
+  });
   const page = await browser.newPage()
 
   page.on('console', msg => {
@@ -13,7 +15,7 @@ async function main() {
     }
   })
 
-  await page.goto(`${host}&position=${position}&ws=ws%3A%2F%2Flocalhost%3A5001%2Floop`, {
+  await page.goto(`${host}/?position=${position}&ws=ws%3A%2F%2Flocalhost%3A5001%2Floop`, {
     waitUntil: 'networkidle2'
   })
 


### PR DESCRIPTION
* Fixing run chrome as root (needs flag `--no-sandbox`)
* Fixing invalid URL