### PR TITLE
fix: Canvas scaler match change from 0 to 1

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ExpressionsHUD/Resources/ExpressionsHUD.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ExpressionsHUD/Resources/ExpressionsHUD.prefab
@@ -836,7 +836,7 @@ MonoBehaviour:
   m_ScaleFactor: 1
   m_ReferenceResolution: {x: 1440, y: 900}
   m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
+  m_MatchWidthOrHeight: 1
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ExpressionsHUD/Resources/ExpressionsHUD.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ExpressionsHUD/Resources/ExpressionsHUD.prefab
@@ -2611,7 +2611,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 414, y: 30}
+  m_AnchoredPosition: {x: 508, y: 38}
   m_SizeDelta: {x: 24, y: 36}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &342209930503994829


### PR DESCRIPTION
# What?
_Canvas scaler match_ changed from 0 to 1

# Why? 
Because it was colliding with the chat window. This way won't happen again.
