### PR TITLE
fix: teleport loading previous scenes

### DIFF
--- a/kernel/packages/decentraland-loader/lifecycle/controllers/position.ts
+++ b/kernel/packages/decentraland-loader/lifecycle/controllers/position.ts
@@ -12,6 +12,7 @@ export class PositionLifecycleController extends EventEmitter {
   private positionSettled: boolean = false
   private currentlySightedScenes: string[] = []
   private currentSpawnpoint?: InstancedSpawnPoint
+  private currentPosition: Vector2Component | null = null
 
   constructor(
     private downloadManager: SceneDataDownloadManager,
@@ -31,7 +32,13 @@ export class PositionLifecycleController extends EventEmitter {
   }
 
   private async doReportCurrentPosition(position: Vector2Component, teleported: boolean) {
+    if (this.currentPosition && this.currentPosition.x === position.x && this.currentPosition.y === position.y) {
+      return
+    }
+
     let resolvedPosition = position
+    this.currentPosition = resolvedPosition
+
     if (teleported) {
       const land = await this.downloadManager.getParcelData(`${position.x},${position.y}`)
       if (land) {
@@ -49,7 +56,6 @@ export class PositionLifecycleController extends EventEmitter {
 
     if (parcels) {
       const newlySightedScenes = await this.sceneController.reportSightedParcels(parcels.sighted, parcels.lostSight)
-
       if (!this.eqSet(this.currentlySightedScenes, newlySightedScenes.sighted)) {
         this.currentlySightedScenes = newlySightedScenes.sighted
       }

--- a/kernel/packages/shared/atlas/selectors.ts
+++ b/kernel/packages/shared/atlas/selectors.ts
@@ -39,7 +39,7 @@ export function getName(state: RootAtlasState, x: number, y: number): string {
 }
 export function getTypeFromAtlasState(state: AtlasState, x: number, y: number): number {
   const key = `${x},${y}`
-  return state.marketName[key].type
+  return state.marketName[key] ? state.marketName[key].type : 0
 }
 
 export function getNameFromAtlasState(state: AtlasState, x: number, y: number): string {


### PR DESCRIPTION
When teleporting, kernel was unloading the current scenes, reloading them again and then loading the new ones, this messed up the flow and sometimes the client (unity) activated the rendering because the rendering lock was empty, and received the scenes loading directive after enabling the rendering.

* Added previous position check on teleport to avoid re-loading the previous scenes every time we teleport...