### PR TITLE
fix: argument null exception on GetColliderInfo

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/CollidersManager/CollidersManager.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/CollidersManager/CollidersManager.cs
@@ -98,7 +98,7 @@ namespace DCL
 
         public bool GetColliderInfo(Collider collider, out ColliderInfo info)
         {
-            if (colliderInfo.ContainsKey(collider))
+            if (collider != null && colliderInfo.ContainsKey(collider))
             {
                 info = colliderInfo[collider];
                 return true;


### PR DESCRIPTION
Added missing null check in GetColliderInfo().

In salmonomicon (ZONE 68,-55), when we get to the 2nd part of the game (after collecting the pages and interacting with the book, there was an ArgumentNullException in `CollidersManager.GetColliderInfo()` that interrupted the execution of the scene, with this null check the issue is fixed. Not sure in which other scenes this can happen