### PR TITLE
feat: New score function

### DIFF
--- a/kernel/packages/shared/dao/index.ts
+++ b/kernel/packages/shared/dao/index.ts
@@ -26,9 +26,11 @@ const score = ({ usersCount, maxUsers = 50 }: Layer) => {
     return -10 * v
   }
 
-  const p = 3 / (maxUsers ? maxUsers : 50)
+  const phase = - Math.PI / 1.8
 
-  return v + v * Math.cos(p * (usersCount - 1))
+  const period = Math.PI / (0.67 * (maxUsers ? maxUsers : 50))
+
+  return v + v * Math.cos(phase + period * (usersCount))
 }
 
 function ping(url: string): Promise<{ success: boolean; elapsed?: number; result?: CatalystLayers }> {


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Changed score function to try to concentrate people in one layer up until it reaches 75% fullness

This is the curve of the new score function for 50 people:

![image](https://user-images.githubusercontent.com/2048532/74862635-41bfa800-532b-11ea-8f62-205279513577.png)

Keep in mind that when a layer is empty or full, those are considered special cases

# Why? <!-- Explain the reason -->
We get cases in which there are around 30 people in the world, but they are distributed in 4 or 5 layers, and that feels lonely
