### PR TITLE
fix: disable marked-for-removal entities

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScene.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScene.cs
@@ -227,6 +227,7 @@ namespace DCL.Controllers
                 if (entities.Count > 0)
                 {
                     this.gameObject.transform.position = EnvironmentSettings.MORDOR;
+                    this.gameObject.SetActive(false);
 
                     RemoveAllEntities();
                 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScene.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScene.cs
@@ -81,6 +81,10 @@ namespace DCL.Controllers
                 boundariesChecker = new SceneBoundariesChecker(this);
         }
 
+        void OnDisable()
+        {
+            metricsController.Disable();
+        }
 
         private void Update()
         {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScenesCleaner.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScenesCleaner.cs
@@ -42,10 +42,13 @@ namespace DCL
             if (!entity.markedForCleanup)
             {
                 entity.markedForCleanup = true;
-                entity.gameObject.SetActive(false);
+
+                if (entity.gameObject != null)
+                    entity.gameObject.SetActive(false);
 
 #if UNITY_EDITOR
-                entity.gameObject.name += "-MARKED-FOR-CLEANUP";
+                if (entity.gameObject != null)
+                    entity.gameObject.name += "-MARKED-FOR-CLEANUP";
 #endif
 
                 entitiesMarkedForCleanup.Enqueue(entity);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScenesCleaner.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScenesCleaner.cs
@@ -42,6 +42,12 @@ namespace DCL
             if (!entity.markedForCleanup)
             {
                 entity.markedForCleanup = true;
+                entity.gameObject.SetActive(false);
+
+#if UNITY_EDITOR
+                entity.gameObject.name += "-MARKED-FOR-CLEANUP";
+#endif
+
                 entitiesMarkedForCleanup.Enqueue(entity);
             }
         }


### PR DESCRIPTION
Added gameobject setActive false for marked-for-removal entities and scenes