### PR TITLE
chore: Deactivating peer logs using a little monkey patch

### DIFF
--- a/kernel/packages/shared/comms/v2/LighthouseWorldInstanceConnection.ts
+++ b/kernel/packages/shared/comms/v2/LighthouseWorldInstanceConnection.ts
@@ -180,13 +180,13 @@ export class LighthouseWorldInstanceConnection implements WorldInstanceConnectio
   private initializePeer() {
     this.statusHandler({ status: 'connecting', connectedPeers: this.connectedPeersCount() })
     this.peer = this.createPeer()
-    this.peer.logLevel = 'WARN'
+    // @ts-ignore
+    this.peer.log = () => {}
     global.__DEBUG_PEER = this.peer
     return this.peer
   }
 
   private connectedPeersCount(): number {
-    // @ts-ignore
     return this.peer ? this.peer.connectedCount() : 0
   }
 

--- a/kernel/packages/shared/comms/v2/LighthouseWorldInstanceConnection.ts
+++ b/kernel/packages/shared/comms/v2/LighthouseWorldInstanceConnection.ts
@@ -181,7 +181,9 @@ export class LighthouseWorldInstanceConnection implements WorldInstanceConnectio
     this.statusHandler({ status: 'connecting', connectedPeers: this.connectedPeersCount() })
     this.peer = this.createPeer()
     // @ts-ignore
-    this.peer.log = () => {}
+    this.peer.log = () => {
+      // DO NOTHING
+    }
     global.__DEBUG_PEER = this.peer
     return this.peer
   }


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
This PR deactivates the logs of the peer api

# Why? <!-- Explain the reason -->
Because they are usually non-fatal but quite annoying
