### PR TITLE
fix: null exception when removing a entity that was showing a pointer event hover

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/PointerEventsController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/PointerEventsController.cs
@@ -159,6 +159,7 @@ namespace DCL
 
             for (int i = 0; i < lastHoveredEventList.Length; i++)
             {
+                if (lastHoveredEventList[i] == null) continue;
                 lastHoveredEventList[i].SetHoverState(false);
             }
 


### PR DESCRIPTION
Null exception arise when removing a entity that was showing a pointer event hover