### PR TITLE
chore: avatar cursor interaction feedback

### DIFF
--- a/unity-client/Assets/Resources/ScriptableObjects/PlayerInfoCardVisibleState.asset
+++ b/unity-client/Assets/Resources/ScriptableObjects/PlayerInfoCardVisibleState.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bdae4528345114a1fa069b0a59dc53c7, type: 3}
+  m_Name: CurrentPlayerInfoCardVisibleState
+  m_EditorClassIdentifier: 
+  value: 0

--- a/unity-client/Assets/Resources/ScriptableObjects/PlayerInfoCardVisibleState.asset.meta
+++ b/unity-client/Assets/Resources/ScriptableObjects/PlayerInfoCardVisibleState.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5c13e3269fe3f4c91946fa2c21f5eb20
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.asmdef
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.asmdef
@@ -13,7 +13,8 @@
         "GUID:4720e174f2805c74bb7aa94cc8bb5bf8",
         "GUID:43315b150e1df4592868fc0fe58b3429",
         "GUID:4a37c94d8d2dc8242af4c424d0b4a8ae",
-        "GUID:2fe41b558b0755a499a0dae91e369bc7"
+        "GUID:2fe41b558b0755a499a0dae91e369bc7",
+        "GUID:4973650d2444c4561a15d50f24d91cd9"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [],

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -14,7 +14,7 @@ namespace DCL
         public AvatarRenderer avatarRenderer;
         public AvatarMovementController avatarMovementController;
         [SerializeField] internal GameObject minimapRepresentation;
-        [SerializeField] private OnPointerDown onPointerDown;
+        [SerializeField] private AvatarOnPointerDown onPointerDown;
         private StringVariable currentPlayerInfoCardName;
 
         private string currentSerialization = "";

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -1,4 +1,6 @@
 using DCL.Components;
+using DCL.Controllers;
+using DCL.Interface;
 using System.Collections;
 using UnityEngine;
 
@@ -12,7 +14,7 @@ namespace DCL
         public AvatarRenderer avatarRenderer;
         public AvatarMovementController avatarMovementController;
         [SerializeField] internal GameObject minimapRepresentation;
-        [SerializeField] private RaycastPointerClickProxy clickProxy;
+        [SerializeField] private OnPointerDown onPointerDown;
         private StringVariable currentPlayerInfoCardName;
 
         private string currentSerialization = "";
@@ -27,7 +29,17 @@ namespace DCL
             if (string.IsNullOrEmpty(currentSerialization))
                 SetMinimapRepresentationActive(false);
 
-            clickProxy.OnClick += PlayerClicked;
+            onPointerDown.OnPointerDownReport += PlayerClicked;
+        }
+
+        void Start()
+        {
+            onPointerDown.Setup(scene, entity, new OnPointerDown.Model()
+            {
+                type = OnPointerDown.NAME,
+                button = WebInterface.ACTION_BUTTON.POINTER.ToString(),
+                hoverText = "view profile"
+            });
         }
 
         private void PlayerClicked()
@@ -37,7 +49,7 @@ namespace DCL
 
         void OnDestroy()
         {
-            clickProxy.OnClick -= PlayerClicked;
+            onPointerDown.OnPointerDownReport -= PlayerClicked;
             if (entity != null)
                 entity.OnTransformChange = null;
         }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -60,7 +60,6 @@ namespace DCL
             if (newJson == "{}")
                 yield break;
 
-
             if (entity != null && entity.OnTransformChange == null)
             {
                 entity.OnTransformChange += avatarMovementController.OnTransformChanged;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
@@ -417,7 +417,7 @@ MonoBehaviour:
   avatarRenderer: {fileID: 3377148406933134318}
   avatarMovementController: {fileID: 122622683908687435}
   minimapRepresentation: {fileID: 7598803346502927653}
-  clickProxy: {fileID: 8343885640114264440}
+  onPointerDown: {fileID: 8164688390458126954}
   model:
     name: 
     bodyShape: 
@@ -600,8 +600,6 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
-  useDeltaTimeInsteadOfGlobalSpeed: 1
-  globalSpeed: 0.06
 --- !u!114 &122622683908687435
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -681,8 +679,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4331657482804467835}
+  - component: {fileID: 8164688390458126954}
   - component: {fileID: 1314168606903342224}
-  - component: {fileID: 8343885640114264440}
   m_Layer: 9
   m_Name: PointerEventCollider
   m_TagString: Untagged
@@ -704,6 +702,22 @@ Transform:
   m_Father: {fileID: 2842120016485600253}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8164688390458126954
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5854254909640412467}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 564338aaebdb98944b7035035fbe3909, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  model:
+    type: onPointerDown
+    uuid: pointerDown
+  hoverCanvasController: {fileID: 0}
 --- !u!65 &1314168606903342224
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -717,18 +731,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &8343885640114264440
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5854254909640412467}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 70155603c2fe1a44887cd114d74422c4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &7598803346502927653
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
@@ -417,7 +417,7 @@ MonoBehaviour:
   avatarRenderer: {fileID: 3377148406933134318}
   avatarMovementController: {fileID: 122622683908687435}
   minimapRepresentation: {fileID: 7598803346502927653}
-  onPointerDown: {fileID: 8164688390458126954}
+  onPointerDown: {fileID: 3865137627712764486}
   model:
     name: 
     bodyShape: 
@@ -679,7 +679,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4331657482804467835}
-  - component: {fileID: 8164688390458126954}
+  - component: {fileID: 3865137627712764486}
   - component: {fileID: 1314168606903342224}
   m_Layer: 9
   m_Name: PointerEventCollider
@@ -702,7 +702,7 @@ Transform:
   m_Father: {fileID: 2842120016485600253}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &8164688390458126954
+--- !u!114 &3865137627712764486
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -711,13 +711,12 @@ MonoBehaviour:
   m_GameObject: {fileID: 5854254909640412467}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 564338aaebdb98944b7035035fbe3909, type: 3}
+  m_Script: {fileID: 11500000, guid: c895124a3dad9421bbeaf89ace0a198c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   model:
     type: onPointerDown
     uuid: pointerDown
-  hoverCanvasController: {fileID: 0}
 --- !u!65 &1314168606903342224
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/AvatarOnPointerDown.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/AvatarOnPointerDown.cs
@@ -1,0 +1,23 @@
+using DCL.Interface;
+using UnityEngine;
+using DCL.Helpers;
+
+namespace DCL.Components
+{
+    public class AvatarOnPointerDown : OnPointerDown
+    {
+        public event System.Action OnPointerDownReport;
+
+        public override void Report(WebInterface.ACTION_BUTTON buttonId, Ray ray, HitInfo hit)
+        {
+            if (!enabled) return;
+
+            if (ShouldReportEvent(buttonId, hit))
+            {
+                base.Report(buttonId, ray, hit);
+
+                OnPointerDownReport?.Invoke();
+            }
+        }
+    }
+}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/AvatarOnPointerDown.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/AvatarOnPointerDown.cs
@@ -8,6 +8,16 @@ namespace DCL.Components
     {
         public event System.Action OnPointerDownReport;
 
+        void Awake()
+        {
+            CommonScriptableObjects.playerInfoCardVisibleState.OnChange += ReEnableOnInfoCardClosed;
+        }
+
+        void OnDestroy()
+        {
+            CommonScriptableObjects.playerInfoCardVisibleState.OnChange -= ReEnableOnInfoCardClosed;
+        }
+
         public override void Report(WebInterface.ACTION_BUTTON buttonId, Ray ray, HitInfo hit)
         {
             if (!enabled) return;
@@ -16,8 +26,18 @@ namespace DCL.Components
             {
                 base.Report(buttonId, ray, hit);
 
+                SetHoverState(false);
+                enabled = false;
+
                 OnPointerDownReport?.Invoke();
             }
+        }
+
+        void ReEnableOnInfoCardClosed(bool newState, bool prevState)
+        {
+            if (enabled || newState) return;
+
+            enabled = true;
         }
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/AvatarOnPointerDown.cs.meta
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/AvatarOnPointerDown.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c895124a3dad9421bbeaf89ace0a198c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/OnPointerDown.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/OnPointerDown.cs
@@ -7,20 +7,22 @@ namespace DCL.Components
     public class OnPointerDown : OnPointerEvent
     {
         public const string NAME = "pointerDown";
-        public event System.Action OnPointerDownReport; // TODO: move this to a new child class to be used by the AvatarShape
 
-        public void Report(WebInterface.ACTION_BUTTON buttonId, Ray ray, HitInfo hit)
+        public virtual void Report(WebInterface.ACTION_BUTTON buttonId, Ray ray, HitInfo hit)
         {
             if (!enabled) return;
 
-            if (IsAtHoverDistance(hit.distance) && (model.button == "ANY" || buttonId.ToString() == model.button))
+            if (ShouldReportEvent(buttonId, hit))
             {
                 string meshName = GetMeshName(hit.collider);
 
                 DCL.Interface.WebInterface.ReportOnPointerDownEvent(buttonId, scene.sceneData.id, model.uuid, entity.entityId, meshName, ray, hit.point, hit.normal, hit.distance);
-
-                OnPointerDownReport?.Invoke();
             }
+        }
+
+        protected bool ShouldReportEvent(WebInterface.ACTION_BUTTON buttonId, HitInfo hit)
+        {
+            return IsAtHoverDistance(hit.distance) && (model.button == "ANY" || buttonId.ToString() == model.button);
         }
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/OnPointerDown.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/OnPointerDown.cs
@@ -7,6 +7,7 @@ namespace DCL.Components
     public class OnPointerDown : OnPointerEvent
     {
         public const string NAME = "pointerDown";
+        public event System.Action OnPointerDownReport; // TODO: move this to a new child class to be used by the AvatarShape
 
         public void Report(WebInterface.ACTION_BUTTON buttonId, Ray ray, HitInfo hit)
         {
@@ -17,6 +18,8 @@ namespace DCL.Components
                 string meshName = GetMeshName(hit.collider);
 
                 DCL.Interface.WebInterface.ReportOnPointerDownEvent(buttonId, scene.sceneData.id, model.uuid, entity.entityId, meshName, ray, hit.point, hit.normal, hit.distance);
+
+                OnPointerDownReport?.Invoke();
             }
         }
     }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/OnPointerEvent.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/OnPointerEvent.cs
@@ -90,7 +90,7 @@ namespace DCL.Components
 
         public void SetHoverState(bool hoverState)
         {
-            if (!enableInteractionHoverFeedback) return;
+            if (!enableInteractionHoverFeedback || !enabled) return;
 
             hoverCanvasController.SetHoverState(hoverState);
         }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/OnPointerEvent.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/OnPointerEvent.cs
@@ -60,8 +60,6 @@ namespace DCL.Components
 
         public void Initialize()
         {
-            if (!entity.meshRootGameObject) return;
-
             // Create OnPointerEventCollider child
             pointerEventColliders = Utils.GetOrCreateComponent<OnPointerEventColliders>(this.gameObject);
             pointerEventColliders.Initialize(entity);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/OnPointerEventColliders.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/OnPointerEventColliders.cs
@@ -29,7 +29,7 @@ namespace DCL.Components
         {
             Renderer[] rendererList = entity.meshesInfo.renderers;
 
-            if (rendererList.Length == 0) return;
+            if (rendererList == null || rendererList.Length == 0) return;
 
             this.ownerEntity = entity;
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCardHUDView.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCardHUDView.cs
@@ -103,6 +103,7 @@ public class PlayerInfoCardHUDView : MonoBehaviour
         }
 
         cardCanvas.enabled = active;
+        CommonScriptableObjects.playerInfoCardVisibleState.Set(active);
     }
 
     private void UpdateTabs()

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/PointerEventsController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/PointerEventsController.cs
@@ -62,8 +62,7 @@ namespace DCL
                 return;
             }
 
-            var raycastHandlerTarget = hitInfo.transform.GetComponent<IRaycastPointerHandler>();
-
+            var raycastHandlerTarget = hitInfo.collider.GetComponent<IRaycastPointerHandler>();
             if (raycastHandlerTarget != null)
             {
                 ResolveGenericRaycastHandlers(raycastHandlerTarget);
@@ -72,13 +71,11 @@ namespace DCL
             }
 
             if (!CollidersManager.i.GetColliderInfo(hitInfo.collider, out ColliderInfo info))
-            {
-                UnhoverLastHoveredObject();
-                return;
-            }
+                newHoveredEvent = hitInfo.collider.GetComponentInChildren<OnPointerEvent>();
+            else
+                newHoveredEvent = info.entity.gameObject.GetComponentInChildren<OnPointerEvent>();
 
             clickHandler = null;
-            newHoveredEvent = info.entity.gameObject.GetComponentInChildren<OnPointerEvent>();
 
             if (newHoveredEvent == null || !newHoveredEvent.IsAtHoverDistance(DCLCharacterController.i.transform))
             {
@@ -291,14 +288,15 @@ namespace DCL
             {
                 Collider collider = raycastInfoPointerEventLayer.hitInfo.hit.collider;
 
+                GameObject hitGameObject;
                 if (CollidersManager.i.GetColliderInfo(collider, out ColliderInfo info))
-                {
-                    var go = info.entity.gameObject;
+                    hitGameObject = info.entity.gameObject;
+                else
+                    hitGameObject = collider.gameObject;
 
-                    go.GetComponentInChildren<OnClick>()?.Report(buttonId, raycastInfoPointerEventLayer.hitInfo.hit);
-                    go.GetComponentInChildren<OnPointerDown>()?.Report(buttonId, ray, raycastInfoPointerEventLayer.hitInfo.hit);
-                    pointerUpEvent = go.GetComponentInChildren<OnPointerUp>();
-                }
+                hitGameObject.GetComponentInChildren<OnClick>()?.Report(buttonId, raycastInfoPointerEventLayer.hitInfo.hit);
+                hitGameObject.GetComponentInChildren<OnPointerDown>()?.Report(buttonId, ray, raycastInfoPointerEventLayer.hitInfo.hit);
+                pointerUpEvent = hitGameObject.GetComponentInChildren<OnPointerUp>();
 
                 lastPointerDownEventHitInfo = raycastInfoPointerEventLayer.hitInfo;
             }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneBoundariesController/SceneBoundariesChecker.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneBoundariesController/SceneBoundariesChecker.cs
@@ -151,6 +151,8 @@ namespace DCL.Controllers
 
         protected virtual void UpdateEntityMeshesValidState(DecentralandEntity entity, bool isInsideBoundaries, Bounds meshBounds)
         {
+            if (entity.meshesInfo.renderers[0] == null) return;
+
             if (isInsideBoundaries != entity.meshesInfo.renderers[0].enabled && entity.meshesInfo.currentShape.IsVisible())
             {
                 for (int i = 0; i < entity.meshesInfo.renderers.Length; i++)

--- a/unity-client/Assets/Scripts/MainScripts/DCL/ScriptableObject/BooleanVariable.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/ScriptableObject/BooleanVariable.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "BooleanVariable", menuName = "BooleanVariable")]
+public class BooleanVariable : BaseVariable<bool>
+{
+    public override bool Equals(bool other)
+    {
+        return other == value;
+    }
+
+}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/ScriptableObject/BooleanVariable.cs.meta
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/ScriptableObject/BooleanVariable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bdae4528345114a1fa069b0a59dc53c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/ScriptableObject/CommonScriptableObjects.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/ScriptableObject/CommonScriptableObjects.cs
@@ -29,8 +29,11 @@ public static class CommonScriptableObjects
     private static Vector3Variable cameraPositionValue;
     public static Vector3Variable cameraPosition => GetOrLoad(ref cameraPositionValue, "ScriptableObjects/CameraPosition");
 
-    public static Vector3Variable cameraRight => GetOrLoad(ref cameraRightValue, "ScriptableObjects/CameraRight");
     private static Vector3Variable cameraRightValue;
+    public static Vector3Variable cameraRight => GetOrLoad(ref cameraRightValue, "ScriptableObjects/CameraRight");
+
+    private static BooleanVariable playerInfoCardVisibleStateValue;
+    public static BooleanVariable playerInfoCardVisibleState => GetOrLoad(ref playerInfoCardVisibleStateValue, "ScriptableObjects/PlayerInfoCardVisibleState");
 
     private static T GetOrLoad<T>(ref T variable, string path) where T : Object
     {


### PR DESCRIPTION
* Implemented hover feedback on other player avatars to show "view profile" in the toast.

The easier way to test this is to access the build and use the `/goto crowd` command.
in `position=-46%2C-16&realm=unicorn-blue` there is a user connected since last monday, maybe he's still there, useful for debugging.