### PR TITLE
fix: blocking promises race condition lock issue

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/LoadWrapper_GLTF.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/LoadWrapper_GLTF.cs
@@ -10,14 +10,6 @@ namespace DCL.Components
         static readonly bool VERBOSE = false;
         RendereableAssetLoadHelper loadHelper;
 
-#if UNITY_EDITOR
-        [ContextMenu("Debug Load Count")]
-        public void DebugLoadCount()
-        {
-            loadHelper?.DebugLoadCount();
-        }
-#endif
-
         public override void Load(string targetUrl, Action<LoadWrapper> OnSuccess, Action<LoadWrapper> OnFail)
         {
             if (loadHelper != null)
@@ -74,6 +66,11 @@ namespace DCL.Components
         {
             loadHelper.Unload();
             this.entity.OnCleanupEvent -= OnEntityCleanup;
+        }
+
+        public override string ToString()
+        {
+            return $"LoadWrapper_GLTF ... {loadHelper.ToString()}";
         }
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/LoadWrapper_GLTF.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/LoadWrapper_GLTF.cs
@@ -70,7 +70,7 @@ namespace DCL.Components
 
         public override string ToString()
         {
-            return $"LoadWrapper_GLTF ... {loadHelper.ToString()}";
+            return $"LoadWrapper ... {loadHelper.ToString()}";
         }
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/RendereableAssetLoadHelper.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/RendereableAssetLoadHelper.cs
@@ -45,15 +45,28 @@ namespace DCL.Components
         AssetPromise_AB_GameObject abPromise;
 
 #if UNITY_EDITOR
-        public void DebugLoadCount()
+        public override string ToString()
         {
             float loadTime = Mathf.Min(loadFinishTime, Time.realtimeSinceStartup) - loadStartTime;
 
+            string result = "not loading";
+
             if (gltfPromise != null)
-                Debug.Log($"promise state = {gltfPromise.state} ({loadTime} load time)... waiting promises = {AssetPromiseKeeper_GLTF.i.waitingPromisesCount}");
+            {
+                result = $"promise state = {gltfPromise.state} ({loadTime} load time)... waiting promises = {AssetPromiseKeeper_GLTF.i.waitingPromisesCount}";
+
+                if (gltfPromise.state == AssetPromiseState.WAITING)
+                {
+                    result += $"\nmaster promise state... is blocked... {AssetPromiseKeeper_GLTF.i.GetMasterState(gltfPromise)}";
+                }
+            }
 
             if (abPromise != null)
-                Debug.Log($"promise state = {abPromise.state} ({loadTime} load time)... waiting promises = {AssetPromiseKeeper_AB.i.waitingPromisesCount}");
+            {
+                result = $"promise state = {abPromise.state} ({loadTime} load time)... waiting promises = {AssetPromiseKeeper_AB.i.waitingPromisesCount}";
+            }
+
+            return result;
         }
 
         float loadStartTime = 0;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/RendereableAssetLoadHelper.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/RendereableAssetLoadHelper.cs
@@ -53,7 +53,7 @@ namespace DCL.Components
 
             if (gltfPromise != null)
             {
-                result = $"promise state = {gltfPromise.state} ({loadTime} load time)... waiting promises = {AssetPromiseKeeper_GLTF.i.waitingPromisesCount}";
+                result = $"GLTF -> promise state = {gltfPromise.state} ({loadTime} load time)... waiting promises = {AssetPromiseKeeper_GLTF.i.waitingPromisesCount}";
 
                 if (gltfPromise.state == AssetPromiseState.WAITING)
                 {
@@ -63,7 +63,7 @@ namespace DCL.Components
 
             if (abPromise != null)
             {
-                result = $"promise state = {abPromise.state} ({loadTime} load time)... waiting promises = {AssetPromiseKeeper_AB.i.waitingPromisesCount}";
+                result = $"ASSET BUNDLE -> promise state = {abPromise.ToString()} ({loadTime} load time)... waiting promises = {AssetPromiseKeeper_AB.i.waitingPromisesCount}";
             }
 
             return result;
@@ -116,7 +116,7 @@ namespace DCL.Components
                 AssetPromiseKeeper_AB_GameObject.i.Forget(abPromise);
 
                 if (VERBOSE)
-                    Debug.Log("Forgetting not null promise...");
+                    Debug.Log("Forgetting not null promise..." + targetUrl);
             }
 
             string bundlesBaseUrl = useCustomContentServerUrl ? customContentServerUrl : bundlesContentUrl;
@@ -149,7 +149,7 @@ namespace DCL.Components
                 AssetPromiseKeeper_GLTF.i.Forget(gltfPromise);
 
                 if (VERBOSE)
-                    Debug.Log("Forgetting not null promise...");
+                    Debug.Log("Forgetting not null promise... " + targetUrl);
             }
 
             if (!contentProvider.TryGetContentsUrl_Raw(targetUrl, out string hash))

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/AssetPromise_AB.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/AssetPromise_AB.cs
@@ -149,7 +149,7 @@ namespace DCL
 
             if (!assetBundleRequest.WebRequestSucceded())
             {
-                Debug.Log($"request failed? {assetBundleRequest.error} ... {finalUrl}");
+                Debug.Log($"Request failed? {assetBundleRequest.error} ... {finalUrl}");
                 failedRequestUrls.Add(finalUrl);
                 assetBundleRequest.Abort();
                 assetBundleRequest = null;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/AssetPromise_AB.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/AssetPromise_AB.cs
@@ -1,4 +1,4 @@
-using DCL.Helpers;
+﻿using DCL.Helpers;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -130,6 +130,28 @@ namespace DCL
             UnregisterConcurrentRequest();
         }
 
+        public override string ToString()
+        {
+            string result = $"AB request state... loadCoroutine = {loadCoroutine} ... state = {state}\n";
+
+            if (assetBundleRequest != null)
+                result += $"url = {assetBundleRequest.url} ... code = {assetBundleRequest.responseCode} ... progress = {assetBundleRequest.downloadProgress}\n";
+            else
+                result += $"null request for url: {contentUrl + hash}\n";
+
+
+            if (dependencyPromises != null && dependencyPromises.Count > 0)
+            {
+                result += "dependencies:\n";
+                foreach (var p in dependencyPromises)
+                {
+                    result += p.ToString() + "\n";
+                }
+            }
+
+            return result;
+        }
+
         IEnumerator LoadAssetBundle(string finalUrl, Action OnSuccess, Action OnFail)
         {
             if (failedRequestUrls.Contains(finalUrl))
@@ -145,7 +167,9 @@ namespace DCL
             //NOTE(Brian): For some reason, another coroutine iteration can be triggered after Cleanup().
             //             So assetBundleRequest can be null here.
             if (assetBundleRequest == null)
+            {
                 yield break;
+            }
 
             if (!assetBundleRequest.WebRequestSucceded())
             {
@@ -158,6 +182,7 @@ namespace DCL
             }
 
             AssetBundle assetBundle = DownloadHandlerAssetBundle.GetContent(assetBundleRequest);
+
 
             if (assetBundle == null || asset == null)
             {
@@ -193,8 +218,9 @@ namespace DCL
                 //NOTE(Brian): For some reason, another coroutine iteration can be triggered after Cleanup().
                 //             To handle this case we exit using this.
                 if (loadCoroutine == null)
+                {
                     yield break;
-
+                }
                 if (asset == null)
                     break;
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/Tests/BlockedAndMasterPromisesShould.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/Tests/BlockedAndMasterPromisesShould.cs
@@ -50,6 +50,8 @@ namespace AssetPromiseKeeper_AssetBundle_Tests
             Assert.AreEqual(3, keeper.waitingPromisesCount);
 
             yield return prom;
+            yield return prom2;
+            yield return prom3;
 
             Assert.AreNotEqual(AssetPromiseState.FINISHED, prom.state);
             Assert.AreNotEqual(AssetPromiseState.FINISHED, prom2.state);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Linq;
 using DCL.Helpers;
@@ -76,6 +76,15 @@ namespace DCL
                 GameObject.Destroy(asset.container);
 
             AssetPromiseKeeper_AB.i.Forget(subPromise);
+        }
+
+
+        public override string ToString()
+        {
+            if (subPromise != null)
+                return $"{subPromise.ToString()} ... AB_GameObject state = {state}";
+            else
+                return $"subPromise == null? state = {state}";
         }
 
         public IEnumerator LoadingCoroutine(Action OnSuccess, Action OnFail)

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/Tests/BlockedAndMasterPromisesShould.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/Tests/BlockedAndMasterPromisesShould.cs
@@ -98,6 +98,8 @@ namespace AssetPromiseKeeper_AssetBundle_GameObject_Tests
             Assert.AreEqual(3, keeper.waitingPromisesCount);
 
             yield return prom;
+            yield return prom2;
+            yield return prom3;
 
             Assert.AreNotEqual(AssetPromiseState.FINISHED, prom.state);
             Assert.AreNotEqual(AssetPromiseState.FINISHED, prom2.state);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromise.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromise.cs
@@ -46,6 +46,7 @@ namespace DCL
         {
             OnPreFinishEvent = null;
             CallAndClearEvents(false);
+            state = AssetPromiseState.IDLE_AND_EMPTY;
         }
 
         internal void SetWaitingState()

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromiseKeeper.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromiseKeeper.cs
@@ -4,6 +4,10 @@ using UnityEngine;
 
 namespace DCL
 {
+    public class AssetPromiseKeeper
+    {
+        public static float PROCESS_PROMISES_TIME_BUDGET = 0.006f;
+    }
     /// <summary>
     /// The AssetPromiseKeeper is the user entry point interface.
     /// It manages stuff like requesting something that's already being loaded, etc.
@@ -19,8 +23,6 @@ namespace DCL
         where AssetLibraryType : AssetLibrary<AssetType>, new()
         where AssetPromiseType : AssetPromise<AssetType>
     {
-        const float PROCESS_PROMISES_TIME_BUDGET = 0.0025f;
-
         private static AssetPromiseKeeper<AssetType, AssetLibraryType, AssetPromiseType> instance;
         public static AssetPromiseKeeper<AssetType, AssetLibraryType, AssetPromiseType> i
         {
@@ -51,7 +53,29 @@ namespace DCL
         //NOTE(Brian): Master promise id -> blocked promises HashSet
         Dictionary<object, HashSet<AssetPromiseType>> masterToBlockedPromises = new Dictionary<object, HashSet<AssetPromiseType>>(100);
 
+        public bool useTimeBudget = true;
+        float startTime;
 
+        public bool IsBlocked(AssetPromiseType promise)
+        {
+            return blockedPromises.Contains(promise);
+        }
+
+        public string GetMasterState(AssetPromiseType promise)
+        {
+            object promiseId = promise.GetId();
+
+            if (!masterToBlockedPromises.ContainsKey(promiseId))
+                return "Master not found";
+
+            if (!masterToBlockedPromises[promiseId].Contains(promise))
+                return "Promise is not blocked???";
+
+            if (!masterPromiseById.ContainsKey(promiseId))
+                return "not registered as master?";
+
+            return $"master state = {masterPromiseById[promiseId].state}";
+        }
 
         public AssetPromiseKeeper(AssetLibraryType library)
         {
@@ -135,69 +159,74 @@ namespace DCL
             return promise;
         }
 
-        Queue<AssetPromise<AssetType>> blockedPromisesQueue = new Queue<AssetPromise<AssetType>>();
-        public bool useBlockedPromisesQueue = false;
+        Queue<AssetPromiseType> toResolveBlockedPromisesQueue = new Queue<AssetPromiseType>();
 
-        private void OnRequestCompleted(AssetPromise<AssetType> promise)
+        private void OnRequestCompleted(AssetPromise<AssetType> loadedPromise)
         {
-            if (useBlockedPromisesQueue)
+            if (!masterToBlockedPromises.ContainsKey(loadedPromise.GetId()))
             {
-                blockedPromisesQueue.Enqueue(promise);
+                CleanPromise(loadedPromise);
+                return;
             }
-            else
-            {
-                ProcessBlockedPromises(promise);
-                CleanPromise(promise);
-            }
+
+            toResolveBlockedPromisesQueue.Enqueue(loadedPromise as AssetPromiseType);
         }
 
         IEnumerator ProcessBlockedPromisesQueue()
         {
-            float start = Time.unscaledTime;
+            startTime = Time.unscaledTime;
+
             while (true)
             {
-                while (blockedPromisesQueue.Count > 0)
+                if (toResolveBlockedPromisesQueue.Count <= 0)
                 {
-                    AssetPromise<AssetType> promise = blockedPromisesQueue.Dequeue();
-
-                    ProcessBlockedPromises(promise);
-                    CleanPromise(promise);
-
-                    if (Time.realtimeSinceStartup - start >= PROCESS_PROMISES_TIME_BUDGET)
-                    {
-                        yield return null;
-                        start = Time.unscaledTime;
-                    }
+                    yield return null;
+                    continue;
                 }
-                yield return null;
 
-                start = Time.unscaledTime;
+                AssetPromiseType promise = toResolveBlockedPromisesQueue.Dequeue();
+                yield return ProcessBlockedPromisesDeferred(promise);
+                CleanPromise(promise);
+
+                var enumerator = SkipFrameIfOverBudget();
+
+                if (enumerator != null)
+                    yield return enumerator;
             }
         }
-
-        private void ProcessBlockedPromises(AssetPromise<AssetType> loadedPromise)
+        private IEnumerator ProcessBlockedPromisesDeferred(AssetPromiseType loadedPromise)
         {
             object loadedPromiseId = loadedPromise.GetId();
 
-            if (!masterToBlockedPromises.ContainsKey(loadedPromiseId))
-                return;
+            if (!masterToBlockedPromises.ContainsKey(loadedPromiseId)
+                || !masterPromiseById.ContainsKey(loadedPromiseId)
+                || masterPromiseById[loadedPromiseId] != loadedPromise)
+            {
+                Debug.LogWarning($"Early exit for some reason for id {loadedPromiseId}");
+                yield break;
+            }
 
-            if (!masterPromiseById.ContainsKey(loadedPromiseId))
-                return;
-
-            if (masterPromiseById[loadedPromiseId] != loadedPromise)
-                return;
 
             if (loadedPromise.state != AssetPromiseState.FINISHED)
-                ForgetBlockedPromises(loadedPromiseId);
+                yield return ForgetBlockedPromises(loadedPromiseId);
             else
-                LoadBlockedPromises(loadedPromiseId);
+                yield return LoadBlockedPromises(loadedPromiseId);
 
             if (masterToBlockedPromises.ContainsKey(loadedPromiseId))
                 masterToBlockedPromises.Remove(loadedPromiseId);
         }
 
-        private void ForgetBlockedPromises(object loadedPromiseId)
+
+        private IEnumerator SkipFrameIfOverBudget()
+        {
+            if (useTimeBudget && Time.realtimeSinceStartup - startTime >= AssetPromiseKeeper.PROCESS_PROMISES_TIME_BUDGET)
+            {
+                yield return null;
+                startTime = Time.unscaledTime;
+            }
+        }
+
+        private IEnumerator ForgetBlockedPromises(object loadedPromiseId)
         {
             List<AssetPromiseType> blockedPromisesToForget = new List<AssetPromiseType>();
 
@@ -217,25 +246,40 @@ namespace DCL
                 var promise = blockedPromisesToForget[i];
                 promise.ForceFail();
                 Forget(promise);
+
+                var enumerator = SkipFrameIfOverBudget();
+
+                if (enumerator != null)
+                    yield return enumerator;
             }
         }
 
-        private void LoadBlockedPromises(object loadedPromiseId)
+        private List<AssetPromiseType> GetBlockedPromisesToLoadForId(object masterPromiseId)
         {
-            List<AssetPromiseType> blockedPromisesToLoad = new List<AssetPromiseType>();
+            var blockedPromisesToLoadAux = new List<AssetPromiseType>();
 
-            using (var iterator = masterToBlockedPromises[loadedPromiseId].GetEnumerator())
+            using (var iterator = masterToBlockedPromises[masterPromiseId].GetEnumerator())
             {
                 while (iterator.MoveNext())
                 {
                     var blockedPromise = iterator.Current;
 
-                    if (blockedPromise.state == AssetPromiseState.WAITING)
-                        blockedPromisesToLoad.Add(blockedPromise);
-
+                    blockedPromisesToLoadAux.Add(blockedPromise);
                     blockedPromises.Remove(blockedPromise);
                 }
             }
+
+            return blockedPromisesToLoadAux;
+        }
+
+        private IEnumerator LoadBlockedPromises(object loadedPromiseId)
+        {
+            List<AssetPromiseType> blockedPromisesToLoad = GetBlockedPromisesToLoadForId(loadedPromiseId);
+
+            var enumerator = SkipFrameIfOverBudget();
+
+            if (enumerator != null)
+                yield return enumerator;
 
             int blockedPromisesToLoadCount = blockedPromisesToLoad.Count;
 
@@ -245,6 +289,11 @@ namespace DCL
                 promise.library = library;
                 promise.OnPreFinishEvent += CleanPromise;
                 promise.Load();
+
+                enumerator = SkipFrameIfOverBudget();
+
+                if (enumerator != null)
+                    yield return enumerator;
             }
         }
 
@@ -274,10 +323,11 @@ namespace DCL
 
         public void Cleanup()
         {
-            blockedPromises.Clear();
-            masterToBlockedPromises.Clear();
+            blockedPromises = new List<AssetPromiseType>();
+            masterToBlockedPromises = new Dictionary<object, HashSet<AssetPromiseType>>();
 
             int waitingPromisesCount = waitingPromises.Count;
+
             for (int i = 0; i < waitingPromisesCount; i++)
             {
                 waitingPromises[i].Cleanup();
@@ -288,8 +338,8 @@ namespace DCL
                 kvp.Value.Cleanup();
             }
 
-            masterPromiseById.Clear();
-            waitingPromises.Clear();
+            masterPromiseById = new Dictionary<object, AssetPromiseType>();
+            waitingPromises = new List<AssetPromiseType>();
             library.Cleanup();
         }
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromiseKeeper.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromiseKeeper.cs
@@ -206,6 +206,7 @@ namespace DCL
                 yield break;
             }
 
+            masterPromiseById.Remove(loadedPromiseId);
 
             if (loadedPromise.state != AssetPromiseState.FINISHED)
                 yield return ForgetBlockedPromises(loadedPromiseId);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromiseKeeper.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromiseKeeper.cs
@@ -206,6 +206,9 @@ namespace DCL
                 yield break;
             }
 
+            //NOTE(Brian): We have to keep checking to support the case in which
+            //             new promises are enqueued while this promise ID is being
+            //             resolved.
             while (masterToBlockedPromises[loadedPromiseId].Count > 0)
             {
                 if (loadedPromise.state != AssetPromiseState.FINISHED)

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromiseKeeper.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/AssetPromiseKeeper.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -209,7 +209,8 @@ namespace DCL
             //NOTE(Brian): We have to keep checking to support the case in which
             //             new promises are enqueued while this promise ID is being
             //             resolved.
-            while (masterToBlockedPromises[loadedPromiseId].Count > 0)
+            while (masterToBlockedPromises.ContainsKey(loadedPromiseId) &&
+                   masterToBlockedPromises[loadedPromiseId].Count > 0)
             {
                 if (loadedPromise.state != AssetPromiseState.FINISHED)
                     yield return ForgetBlockedPromises(loadedPromiseId);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/Mock/Tests/BlockedAndMasterPromisesShould.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/Mock/Tests/BlockedAndMasterPromisesShould.cs
@@ -1,6 +1,5 @@
-﻿using DCL;
+using DCL;
 using System.Collections;
-using UnityEngine;
 using UnityEngine.Assertions;
 using UnityEngine.TestTools;
 
@@ -44,7 +43,9 @@ namespace AssetPromiseKeeper_Mock_Tests
 
             Assert.AreEqual(3, keeper.waitingPromisesCount);
 
-            yield return new WaitForSeconds(prom.loadTime);
+            yield return prom;
+            yield return prom2;
+            yield return prom3;
 
             Assert.AreNotEqual(AssetPromiseState.FINISHED, prom.state);
             Assert.AreNotEqual(AssetPromiseState.FINISHED, prom2.state);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/Mock/Tests/BlockedAndMasterPromisesShould.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/Mock/Tests/BlockedAndMasterPromisesShould.cs
@@ -46,8 +46,8 @@ namespace AssetPromiseKeeper_Mock_Tests
                     keeper.Keep(mischievousPromise2);
                     yield return new DCL.WaitUntil(() => mischievousPromise.keepWaiting == false, 2.0f);
                     yield return new DCL.WaitUntil(() => mischievousPromise2.keepWaiting == false, 2.0f);
-                    Assert.IsFalse(mischievousPromise.keepWaiting, "While blocked promises are being resolved, new promises enqueued with the same id should solve correctly! Make sure masterPromiseById is cleaned up when the master promise finishes loading.");
-                    Assert.IsFalse(mischievousPromise2.keepWaiting, "While blocked promises are being resolved, new promises enqueued with the same id should solve correctly! Make sure masterPromiseById is cleaned up when the master promise finishes loading.");
+                    Assert.IsFalse(mischievousPromise.keepWaiting, "While blocked promises are being resolved, new promises enqueued with the same id should solve correctly!");
+                    Assert.IsFalse(mischievousPromise2.keepWaiting, "While blocked promises are being resolved, new promises enqueued with the same id should solve correctly!");
                 }
             }
         }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/Mock/Tests/BlockedAndMasterPromisesShould.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/Mock/Tests/BlockedAndMasterPromisesShould.cs
@@ -18,9 +18,13 @@ namespace AssetPromiseKeeper_Mock_Tests
 
             var promList = new List<AssetPromise_Mock>();
 
-            AssetPromise_Mock mischievousPromise = new AssetPromise_Mock();
+            var mischievousPromise = new AssetPromise_Mock();
             mischievousPromise.idGenerator = id;
             mischievousPromise.loadTime = 0.01f;
+
+            var mischievousPromise2 = new AssetPromise_Mock();
+            mischievousPromise2.idGenerator = id;
+            mischievousPromise2.loadTime = 0.01f;
 
             for (int i = 0; i < 49; i++)
             {
@@ -39,8 +43,11 @@ namespace AssetPromiseKeeper_Mock_Tests
                 if (i == 25)
                 {
                     keeper.Keep(mischievousPromise);
+                    keeper.Keep(mischievousPromise2);
                     yield return new DCL.WaitUntil(() => mischievousPromise.keepWaiting == false, 2.0f);
+                    yield return new DCL.WaitUntil(() => mischievousPromise2.keepWaiting == false, 2.0f);
                     Assert.IsFalse(mischievousPromise.keepWaiting, "While blocked promises are being resolved, new promises enqueued with the same id should solve correctly! Make sure masterPromiseById is cleaned up when the master promise finishes loading.");
+                    Assert.IsFalse(mischievousPromise2.keepWaiting, "While blocked promises are being resolved, new promises enqueued with the same id should solve correctly! Make sure masterPromiseById is cleaned up when the master promise finishes loading.");
                 }
             }
         }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/Mock/Tests/BlockedAndMasterPromisesShould.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/Mock/Tests/BlockedAndMasterPromisesShould.cs
@@ -1,5 +1,6 @@
 using DCL;
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine.Assertions;
 using UnityEngine.TestTools;
 
@@ -7,6 +8,43 @@ namespace AssetPromiseKeeper_Mock_Tests
 {
     public class BlockedAndMasterPromisesShould
     {
+        [UnityTest]
+        public IEnumerator ResolveCorrectlyIfKeepIsCalledWhenBlockedPromisesAreBeingProcessed()
+        {
+            var library = new AssetLibrary_Mock();
+            var keeper = new AssetPromiseKeeper_Mock(library);
+
+            string id = "1";
+
+            var promList = new List<AssetPromise_Mock>();
+
+            AssetPromise_Mock mischievousPromise = new AssetPromise_Mock();
+            mischievousPromise.idGenerator = id;
+            mischievousPromise.loadTime = 0.01f;
+
+            for (int i = 0; i < 49; i++)
+            {
+                AssetPromise_Mock tmpProm = new AssetPromise_Mock();
+                tmpProm.idGenerator = id;
+                tmpProm.loadTime = 0.01f;
+                keeper.Keep(tmpProm);
+                promList.Add(tmpProm);
+            }
+
+            for (int i = 0; i < promList.Count; i++)
+            {
+                AssetPromise_Mock prom = promList[i];
+                yield return prom;
+
+                if (i == 25)
+                {
+                    keeper.Keep(mischievousPromise);
+                    yield return new DCL.WaitUntil(() => mischievousPromise.keepWaiting == false, 2.0f);
+                    Assert.IsFalse(mischievousPromise.keepWaiting, "While blocked promises are being resolved, new promises enqueued with the same id should solve correctly! Make sure masterPromiseById is cleaned up when the master promise finishes loading.");
+                }
+            }
+        }
+
         [UnityTest]
         public IEnumerator FailCorrectlyIfMasterPromiseFails()
         {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/Mock/Tests/BlockedAndMasterPromisesShould.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/Mock/Tests/BlockedAndMasterPromisesShould.cs
@@ -1,4 +1,4 @@
-using DCL;
+﻿using DCL;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine.Assertions;
@@ -91,6 +91,8 @@ namespace AssetPromiseKeeper_Mock_Tests
             yield return prom;
             yield return prom2;
             yield return prom3;
+
+            Assert.AreEqual(0, keeper.waitingPromisesCount);
 
             Assert.AreNotEqual(AssetPromiseState.FINISHED, prom.state);
             Assert.AreNotEqual(AssetPromiseState.FINISHED, prom2.state);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/Mock/Tests/PromiseKeeperShouldBehaveCorrectlyWhen.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/Mock/Tests/PromiseKeeperShouldBehaveCorrectlyWhen.cs
@@ -1,4 +1,4 @@
-﻿using DCL;
+using DCL;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.Assertions;
@@ -116,6 +116,8 @@ namespace AssetPromiseKeeper_Mock_Tests
             keeper.Forget(prom);
 
             yield return prom;
+            yield return prom2;
+            yield return prom3;
 
             Assert.AreEqual(AssetPromiseState.FINISHED, prom.state);
             Assert.AreEqual(AssetPromiseState.FINISHED, prom2.state);
@@ -164,7 +166,9 @@ namespace AssetPromiseKeeper_Mock_Tests
 
             Assert.AreEqual(3, keeper.waitingPromisesCount);
 
-            yield return new WaitForSeconds(prom.loadTime);
+            yield return prom;
+            yield return prom2;
+            yield return prom3;
 
             Assert.AreEqual(AssetPromiseState.FINISHED, prom.state);
             Assert.AreEqual(AssetPromiseState.FINISHED, prom2.state);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Tests/BlockedAndMasterPromisesShould.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Tests/BlockedAndMasterPromisesShould.cs
@@ -93,6 +93,8 @@ namespace AssetPromiseKeeper_GLTF_Tests
             Assert.AreEqual(3, keeper.waitingPromisesCount);
 
             yield return prom;
+            yield return prom2;
+            yield return prom3;
 
             Assert.AreNotEqual(AssetPromiseState.FINISHED, prom.state);
             Assert.AreNotEqual(AssetPromiseState.FINISHED, prom2.state);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Tests.meta
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Tests.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: b483d7461287fb8458ebadc627d252c3
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCardHUDView.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCardHUDView.cs
@@ -1,6 +1,5 @@
-using System;
-using System.Collections.Generic;
 using DCL.Helpers;
+using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.Events;
@@ -160,10 +159,14 @@ public class PlayerInfoCardHUDView : MonoBehaviour
 
     internal bool IsBlocked(string userId)
     {
+        if (ownUserProfile == null || ownUserProfile.blocked == null)
+            return false;
+
         for (int i = 0; i < ownUserProfile.blocked.Count; i++)
         {
             if (ownUserProfile.blocked[i] == userId) return true;
         }
+
         return false;
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/RenderingController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/RenderingController.cs
@@ -1,4 +1,4 @@
-﻿using DCL;
+using DCL;
 using DCL.Controllers;
 using DCL.Helpers;
 using DCL.Interface;
@@ -38,9 +38,9 @@ public class RenderingController : MonoBehaviour
         InputController_Legacy.renderingIsDisabled = true;
         GLTFSceneImporter.renderingIsDisabled = true;
 
-        AssetPromiseKeeper_GLTF.i.useBlockedPromisesQueue = false;
-        AssetPromiseKeeper_AB.i.useBlockedPromisesQueue = false;
-        AssetPromiseKeeper_AB_GameObject.i.useBlockedPromisesQueue = false;
+        AssetPromiseKeeper_GLTF.i.useTimeBudget = false;
+        AssetPromiseKeeper_AB.i.useTimeBudget = false;
+        AssetPromiseKeeper_AB_GameObject.i.useTimeBudget = false;
         AssetPromise_AB.limitTimeBudget = false;
 
         DCLCharacterController.i.SetEnabled(false);
@@ -85,9 +85,9 @@ public class RenderingController : MonoBehaviour
 
         AssetPromise_AB.limitTimeBudget = true;
 
-        AssetPromiseKeeper_GLTF.i.useBlockedPromisesQueue = true;
-        AssetPromiseKeeper_AB.i.useBlockedPromisesQueue = true;
-        AssetPromiseKeeper_AB_GameObject.i.useBlockedPromisesQueue = true;
+        AssetPromiseKeeper_GLTF.i.useTimeBudget = true;
+        AssetPromiseKeeper_AB.i.useTimeBudget = true;
+        AssetPromiseKeeper_AB_GameObject.i.useTimeBudget = true;
 
         OnRenderingStateChanged?.Invoke(renderingEnabled);
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScene.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScene.cs
@@ -1114,7 +1114,16 @@ namespace DCL.Controllers
 
                             foreach (var entity in component.attachedEntities)
                             {
-                                Debug.Log($"This shape is attached to {entity.entityId} entity. Click here for highlight it.", entity.gameObject);
+                                var loader = LoadableShape.GetLoaderForEntity(entity);
+
+                                string loadInfo = "No loader";
+
+                                if (loader != null)
+                                {
+                                    loadInfo = loader.ToString();
+                                }
+
+                                Debug.Log($"This shape is attached to {entity.entityId} entity. Click here for highlight it.\nLoading info: {loadInfo}", entity.gameObject);
                             }
                         }
                         else


### PR DESCRIPTION
When we enqueue new promises while blocked promises are being resolved, those new promises get stuck forever. This shouldn't happen.

Added test with mock classes so we make sure this doesn't happen with any of our asset managers.

The commit revert is included, so make sure to look at the individual commits to review the actual fix.