### PR TITLE
feat: message to request scenes info around a parcel

### DIFF
--- a/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
@@ -419,3 +419,12 @@ export type ProfileForRenderer = {
   updatedAt?: number
   createdAt?: number
 }
+
+/**
+ * @public
+ */
+export type MinimapSceneInfo = {
+  name: string
+  type: number
+  parcels: { x: number; y: number }[]
+}

--- a/kernel/packages/shared/atlas/actions.ts
+++ b/kernel/packages/shared/atlas/actions.ts
@@ -7,7 +7,8 @@ import {
   MarketData,
   MARKET_DATA,
   QUERY_NAME_FROM_SCENE_JSON,
-  SUCCESS_NAME_FROM_SCENE_JSON
+  SUCCESS_NAME_FROM_SCENE_JSON,
+  REPORT_SCENES_AROUND_PARCEL
 } from './types'
 import { Vector2Component } from '../../atomicHelpers/landHelpers'
 
@@ -28,3 +29,7 @@ export type MarketDataAction = ReturnType<typeof marketData>
 export const REPORTED_SCENES_FOR_MINIMAP = 'Reporting scenes for minimap'
 export const reportedScenes = (parcels: string[], reportPosition?: Vector2Component) =>
   action(REPORTED_SCENES_FOR_MINIMAP, { parcels, reportPosition })
+
+export const reportScenesAroundParcel = (parcelCoord: { x: number; y: number }, scenesAround: number) =>
+  action(REPORT_SCENES_AROUND_PARCEL, { parcelCoord, scenesAround })
+export type ReportScenesAroundParcel = ReturnType<typeof reportScenesAroundParcel>

--- a/kernel/packages/shared/atlas/sagas.ts
+++ b/kernel/packages/shared/atlas/sagas.ts
@@ -12,10 +12,18 @@ import {
   FetchNameFromSceneJsonSuccess,
   marketData,
   QuerySceneName,
-  reportedScenes
+  reportedScenes,
+  ReportScenesAroundParcel
 } from './actions'
 import { getNameFromAtlasState, getTypeFromAtlasState, shouldLoadSceneJsonName } from './selectors'
-import { AtlasState, FETCH_NAME_FROM_SCENE_JSON, MarketEntry, SUCCESS_NAME_FROM_SCENE_JSON, MARKET_DATA } from './types'
+import {
+  AtlasState,
+  FETCH_NAME_FROM_SCENE_JSON,
+  MarketEntry,
+  SUCCESS_NAME_FROM_SCENE_JSON,
+  MARKET_DATA,
+  REPORT_SCENES_AROUND_PARCEL
+} from './types'
 import { parcelLimits } from '../../config'
 
 declare const window: {
@@ -34,6 +42,8 @@ export function* atlasSaga(): any {
 
   yield takeLatest(RENDERER_INITIALIZED, reportScenesAround)
   yield takeLatest(SUCCESS_NAME_FROM_SCENE_JSON, reportOne)
+
+  yield takeLatest(REPORT_SCENES_AROUND_PARCEL, reportScenesAroundParcel)
 }
 
 function* fetchDistricts() {
@@ -107,32 +117,51 @@ export function* checkAndReportAround() {
 }
 
 export function* reportScenesAround() {
-  const userPosition = lastPlayerPosition
   let atlasState = (yield select(state => state.atlas)) as AtlasState
   while (!atlasState.marketName['0,0']) {
     yield take(MARKET_DATA)
     atlasState = yield select(state => state.atlas)
   }
-  const data = atlasState.marketName
-  const targets: Record<string, MarketEntry> = {}
+
+  const userPosition = lastPlayerPosition
   const MAX_SCENES_AROUND = 15
   const userX = userPosition.x / parcelLimits.parcelSize
   const userY = userPosition.z / parcelLimits.parcelSize
+  const targets = getScenesAround({ x: userX, y: userY }, MAX_SCENES_AROUND, atlasState)
+
+  yield put(reportedScenes(Object.keys(targets), { x: userPosition.x, y: userPosition.z }))
+  yield call(reportScenes, atlasState, targets)
+}
+
+export function* reportScenesAroundParcel(action: ReportScenesAroundParcel) {
+  let atlasState = (yield select(state => state.atlas)) as AtlasState
+  while (!atlasState.marketName['0,0']) {
+    yield take(MARKET_DATA)
+    atlasState = yield select(state => state.atlas)
+  }
+
+  const targets = getScenesAround(action.payload.parcelCoord, action.payload.scenesAround, atlasState)
+  yield call(reportScenes, atlasState, targets)
+}
+
+function getScenesAround(parcelCoords: { x: number; y: number }, maxScenesAround: number, atlasState: AtlasState) {
+  const data = atlasState.marketName
+  const targets: Record<string, MarketEntry> = {}
+
   Object.keys(data).forEach(index => {
     const parcel = data[index]
     if (atlasState.alreadyReported[`${parcel.x},${parcel.y}`]) {
       return
     }
-    if (Math.abs(parcel.x - userX) > MAX_SCENES_AROUND) {
+    if (Math.abs(parcel.x - parcelCoords.x) > maxScenesAround) {
       return
     }
-    if (Math.abs(parcel.y - userY) > MAX_SCENES_AROUND) {
+    if (Math.abs(parcel.y - parcelCoords.y) > maxScenesAround) {
       return
     }
     targets[index] = parcel
   })
-  yield put(reportedScenes(Object.keys(targets), { x: userPosition.x, y: userPosition.z }))
-  yield call(reportScenes, atlasState, targets)
+  return targets
 }
 
 export function* reportScenes(marketplaceInfo?: AtlasState, selection?: Record<string, MarketEntry>): any {

--- a/kernel/packages/shared/atlas/sagas.ts
+++ b/kernel/packages/shared/atlas/sagas.ts
@@ -25,6 +25,7 @@ import {
   REPORT_SCENES_AROUND_PARCEL
 } from './types'
 import { parcelLimits } from '../../config'
+import { Vector2Component } from 'atomicHelpers/landHelpers'
 
 declare const window: {
   unityInterface: {
@@ -144,7 +145,7 @@ export function* reportScenesAroundParcel(action: ReportScenesAroundParcel) {
   yield call(reportScenes, atlasState, targets)
 }
 
-function getScenesAround(parcelCoords: { x: number; y: number }, maxScenesAround: number, atlasState: AtlasState) {
+function getScenesAround(parcelCoords: Vector2Component, maxScenesAround: number, atlasState: AtlasState) {
   const data = atlasState.marketName
   const targets: Record<string, MarketEntry> = {}
 

--- a/kernel/packages/shared/atlas/types.ts
+++ b/kernel/packages/shared/atlas/types.ts
@@ -7,6 +7,7 @@ export const SUCCESS_NAME_FROM_SCENE_JSON = '[Success] Fetch name from scene.jso
 export const FAILURE_NAME_FROM_SCENE_JSON = '[Failure] Fetch name from scene.json'
 export const DISTRICT_DATA = '[Info] District data downloaded'
 export const MARKET_DATA = '[Info] Market data downloaded'
+export const REPORT_SCENES_AROUND_PARCEL = 'Report scenes around parcel'
 
 export type AtlasState = {
   marketName: Record<string, MarketEntry>

--- a/unity-client/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -356,6 +356,13 @@ namespace DCL.Interface
             public string userEmail;
         }
 
+        [System.Serializable]
+        public class RequestScenesInfoAroundParcelPayload
+        {
+            public Vector2 parcel;
+            public int scenesAround;
+        }
+
 #if UNITY_WEBGL && !UNITY_EDITOR
     /**
      * This method is called after the first render. It marks the loading of the
@@ -756,6 +763,15 @@ namespace DCL.Interface
             SendMessage("ReportUserEmail", new SendUserEmailPayload()
             {
                 userEmail = email
+            });
+        }
+
+        public static void RequestScenesInfoAroundParcel(Vector2 parcel, int maxScenesArea)
+        {
+            SendMessage("RequestScenesInfoInArea", new RequestScenesInfoAroundParcelPayload()
+            {
+                parcel = parcel,
+                scenesAround = maxScenesArea
             });
         }
     }


### PR DESCRIPTION
# What?
Added message from renderer to kernel to request scenes info around a parcel

# Why? 
We need to fetch the info of scenes around a specific parcel. Currently we can only request info around the parcel where the player is on and with a fixed amount of scenes around.
