### PR TITLE
fix: Updating peer library to use the new distance function

### DIFF
--- a/kernel/package-lock.json
+++ b/kernel/package-lock.json
@@ -2561,9 +2561,9 @@
       "dev": true
     },
     "decentraland-katalyst-peer": {
-      "version": "0.1.35",
-      "resolved": "https://registry.npmjs.org/decentraland-katalyst-peer/-/decentraland-katalyst-peer-0.1.35.tgz",
-      "integrity": "sha512-8pByNMGRWeh3w5k0yjA/yj/ETlyb6Q808C5gmZS1krFsSUAuMl/A4pUygNg/SMZ1cehGj7/ugxCYSvaYqXhfyg==",
+      "version": "0.1.36",
+      "resolved": "https://registry.npmjs.org/decentraland-katalyst-peer/-/decentraland-katalyst-peer-0.1.36.tgz",
+      "integrity": "sha512-RxRqOsE9mJzkqgUetj4IVXTjTprW74Icub9nPK2tfssjvALPkxKQaGrXM4FhppG7G2d3u3Ql5+LHj8gkVJhQWQ==",
       "requires": {
         "eventemitter3": "^4.0.0",
         "fp-future": "^1.0.1",

--- a/kernel/package.json
+++ b/kernel/package.json
@@ -98,7 +98,7 @@
     "body-scroll-lock": "^2.5.10",
     "cids": "^0.7.3",
     "dcl-crypto": "^1.7.0",
-    "decentraland-katalyst-peer": "^0.1.35",
+    "decentraland-katalyst-peer": "^0.1.36",
     "decentraland-renderer": "^1.8.15009",
     "decentraland-rpc": "^3.1.8",
     "devtools-protocol": "0.0.615714",


### PR DESCRIPTION
# What? <!-- what is this PR? -->
This new function is less resource intensive and makes network updates less frequent when far away from other peers.

See: https://github.com/decentraland/catalyst/commit/c35f5e0d69985f0a21a01fe2110a2be0d3435229

# Why? <!-- Explain the reason -->
To avoid unnecessary network changes that could hurt the explorer's performance
