### PR TITLE
fix: set currentSceneId to null if player is not inside any scene

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioStream.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioStream.cs
@@ -30,21 +30,22 @@ namespace DCL.Components
 
         private void Start()
         {
-            CommonScriptableObjects.playerCoords.OnChange += OnPlayerCoordsChanged;
+            CommonScriptableObjects.sceneID.OnChange += OnSceneChanged;
             CommonScriptableObjects.rendererState.OnChange += OnRendererStateChanged;
         }
 
         private void OnDestroy()
         {
-            CommonScriptableObjects.playerCoords.OnChange -= OnPlayerCoordsChanged;
+            CommonScriptableObjects.sceneID.OnChange -= OnSceneChanged;
             CommonScriptableObjects.rendererState.OnChange -= OnRendererStateChanged;
             StopStreaming();
         }
 
-        private bool AreCoordsInsideComponentScene(Vector2Int coords)
+        private bool IsPlayerInSameSceneAsComponent(string currentSceneId)
         {
             if (scene == null) return false;
-            return scene.parcels.Contains(coords);
+            if (string.IsNullOrEmpty(currentSceneId)) return false;
+            return scene.sceneData.id == currentSceneId;
         }
 
         private void UpdatePlayingState(bool forceStateUpdate)
@@ -54,7 +55,7 @@ namespace DCL.Components
                 return;
             }
 
-            bool canPlayStream = AreCoordsInsideComponentScene(CommonScriptableObjects.playerCoords.Get()) && CommonScriptableObjects.rendererState.Get();
+            bool canPlayStream = IsPlayerInSameSceneAsComponent(CommonScriptableObjects.sceneID) && CommonScriptableObjects.rendererState;
 
             bool shouldStopStream = (isPlaying && !model.playing) || (isPlaying && !canPlayStream);
             bool shouldStartStream = !isPlaying && canPlayStream && model.playing;
@@ -78,7 +79,7 @@ namespace DCL.Components
             }
         }
 
-        private void OnPlayerCoordsChanged(Vector2Int coords, Vector2Int prevCoords)
+        private void OnSceneChanged(string sceneId, string prevSceneId)
         {
             UpdatePlayingState(false);
         }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Minimap/MinimapHUDController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/Minimap/MinimapHUDController.cs
@@ -80,7 +80,8 @@ public class MinimapHUDController : IDisposable, IHUD
 
     public void ReportScene()
     {
-        WebInterface.SendReportScene(currentSceneId);
+        if (!string.IsNullOrEmpty(currentSceneId))
+            WebInterface.SendReportScene(currentSceneId);
     }
 
     public void SetVisibility(bool visible)

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationHUD/Notification.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NotificationHUD/Notification.cs
@@ -52,7 +52,7 @@ public class Notification : MonoBehaviour
 
         if (!string.IsNullOrEmpty(notificationModel.scene))
         {
-            string sceneID = CommonScriptableObjects.sceneID;
+            string sceneID = CommonScriptableObjects.sceneID ?? string.Empty;
             CurrentSceneUpdated(sceneID, string.Empty);
         }
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
@@ -167,6 +167,7 @@ namespace DCL
 
         private void SortScenesByDistance()
         {
+            currentSceneId = null;
             scenesSortedByDistance.Sort(SortScenesByDistanceMethod);
 
             using (var iterator = scenesSortedByDistance.GetEnumerator())


### PR DESCRIPTION
# What?
`currentSceneId` is set to null before checking in what scene is the player in

# Why?
when player move outside a scene but don't enter inside any other scene, like in Preview where only one scene exist or going to the edge of the world (not now cause currently we are loading empty scenes at the edge of the world), the `currentSceneId` value was keeping the previous scene Id and we need a way to tell if player has leaved the scene
