### PR TITLE
feat: expose the browser interface to allow inspection

### DIFF
--- a/kernel/packages/unity-interface/initializer.ts
+++ b/kernel/packages/unity-interface/initializer.ts
@@ -61,6 +61,8 @@ export async function initializeUnity(
 
   global['globalStore'].dispatch(waitingForRenderer())
   await engineInitialized
+  // Expose the "kernel" interface as a global object to allow easier inspection
+  global['browserInterface'] = _instancedJS
 
   return {
     engine: _gameInstance,

--- a/kernel/packages/unity-interface/initializer.ts
+++ b/kernel/packages/unity-interface/initializer.ts
@@ -61,8 +61,6 @@ export async function initializeUnity(
 
   global['globalStore'].dispatch(waitingForRenderer())
   await engineInitialized
-  // Expose the "kernel" interface as a global object to allow easier inspection
-  global['browserInterface'] = _instancedJS
 
   return {
     engine: _gameInstance,
@@ -105,6 +103,8 @@ namespace DCL {
 
     _instancedJS
       .then($ => {
+        // Expose the "kernel" interface as a global object to allow easier inspection  
+        global['browserInterface'] = $
         engineInitialized.resolve($)
       })
       .catch(error => {

--- a/kernel/packages/unity-interface/initializer.ts
+++ b/kernel/packages/unity-interface/initializer.ts
@@ -61,6 +61,8 @@ export async function initializeUnity(
 
   global['globalStore'].dispatch(waitingForRenderer())
   await engineInitialized
+  // Expose the "kernel" interface as a global object to allow easier inspection  
+  global['browserInterface'] = _gameInstance
 
   return {
     engine: _gameInstance,
@@ -103,8 +105,6 @@ namespace DCL {
 
     _instancedJS
       .then($ => {
-        // Expose the "kernel" interface as a global object to allow easier inspection  
-        global['browserInterface'] = $
         engineInitialized.resolve($)
       })
       .catch(error => {


### PR DESCRIPTION
## Why?
So we can tap into the browser interface and read messages sent from Unity to the Kernel.
The Unity interface is already being exposed as `unityInterface` in the global scope.