### PR TITLE
feat: optimize circleci builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,10 +93,6 @@ jobs:
           command: |
             find Assets -type f \( -not -path '*Plugins*' \) \( -iname \*.cs -o -iname \*.meta -o -iname \*.xml -o -iname \*.shader -o -iname \*.prefab -o -iname \*.yml -o -iname \*.mat -o -iname \*.json -o -iname \*.js -o -iname \*.jspre  -o -iname \*.jslib  -o -iname \*.hlsl  -o -iname \*.asmdef  -o -iname \*.csproj  \) \( -exec md5sum "$PWD"/{} \; \) | sort > ../.unitysources-checksum
       - restore_cache:
-          name: Restore unity Library Cache
-          keys:
-            - unity-libcache2-{{ .Branch  }}
-      - restore_cache:
           name: Restore decentraland-renderer if exists
           keys:
             - unity-build-{{ checksum "../.unitysources-checksum" }}
@@ -118,11 +114,6 @@ jobs:
                 bash ./test-ci.sh
                 exit $?
             fi;
-      - save_cache:
-          name: Store Library Cache
-          key: unity-libcache2-{{ .Branch  }}
-          paths:
-            - /tmp/explorer/unity-client/Library/
       - save_cache:
           name: Store test results
           key: unity-tests-{{ checksum "../.unitysources-checksum" }}
@@ -147,10 +138,6 @@ jobs:
           name: Get the hash of source files
           command: |
             find Assets -type f \( -not -path '*Plugins*' \) \( -iname \*.cs -o -iname \*.meta -o -iname \*.xml -o -iname \*.shader -o -iname \*.prefab -o -iname \*.yml -o -iname \*.mat -o -iname \*.json -o -iname \*.js -o -iname \*.jspre  -o -iname \*.jslib  -o -iname \*.hlsl  -o -iname \*.asmdef  -o -iname \*.csproj  \) \( -exec md5sum "$PWD"/{} \; \) | sort > ../.unitysources-checksum
-      - restore_cache:
-          name: Restore unity Library Cache
-          keys:
-            - unity-libcache2-{{ .Branch  }}
       - restore_cache:
           name: Restore decentraland-renderer if exists
           keys:
@@ -183,11 +170,6 @@ jobs:
           key: unity-build-{{ checksum "../.unitysources-checksum" }}
           paths:
             - /tmp/explorer/unity-client/Builds/
-      - save_cache:
-          name: Store Library Cache
-          key: unity-libcache2-{{ .Branch  }}
-          paths:
-            - /tmp/explorer/unity-client/Library/
       - store_artifacts:
           name: Store logs
           path: /tmp/buildlog.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,11 @@ jobs:
       - run:
           name: Get the hash of source files
           command: |
-            find Assets -type f \( -exec shasum "$PWD"/{} \; \) | sort > ../.unitysources-checksum
+            find Assets -type f \( -not -path '*Plugins*' \) \( -iname \*.cs -o -iname \*.meta -o -iname \*.xml -o -iname \*.shader -o -iname \*.prefab -o -iname \*.yml -o -iname \*.mat -o -iname \*.json -o -iname \*.js -o -iname \*.jspre  -o -iname \*.jslib  -o -iname \*.hlsl  -o -iname \*.asmdef  -o -iname \*.csproj  \) \( -exec md5sum "$PWD"/{} \; \) | sort > ../.unitysources-checksum
+      - restore_cache:
+          name: Restore unity Library Cache
+          keys:
+            - unity-libcache2-{{ .Branch  }}
       - restore_cache:
           name: Restore decentraland-renderer if exists
           keys:
@@ -115,6 +119,11 @@ jobs:
                 exit $?
             fi;
       - save_cache:
+          name: Store Library Cache
+          key: unity-libcache2-{{ .Branch  }}
+          paths:
+            - /tmp/explorer/unity-client/Library/
+      - save_cache:
           name: Store test results
           key: unity-tests-{{ checksum "../.unitysources-checksum" }}
           paths:
@@ -137,7 +146,11 @@ jobs:
       - run:
           name: Get the hash of source files
           command: |
-            find Assets -type f \( -exec shasum "$PWD"/{} \; \) | sort > ../.unitysources-checksum
+            find Assets -type f \( -not -path '*Plugins*' \) \( -iname \*.cs -o -iname \*.meta -o -iname \*.xml -o -iname \*.shader -o -iname \*.prefab -o -iname \*.yml -o -iname \*.mat -o -iname \*.json -o -iname \*.js -o -iname \*.jspre  -o -iname \*.jslib  -o -iname \*.hlsl  -o -iname \*.asmdef  -o -iname \*.csproj  \) \( -exec md5sum "$PWD"/{} \; \) | sort > ../.unitysources-checksum
+      - restore_cache:
+          name: Restore unity Library Cache
+          keys:
+            - unity-libcache2-{{ .Branch  }}
       - restore_cache:
           name: Restore decentraland-renderer if exists
           keys:
@@ -170,6 +183,11 @@ jobs:
           key: unity-build-{{ checksum "../.unitysources-checksum" }}
           paths:
             - /tmp/explorer/unity-client/Builds/
+      - save_cache:
+          name: Store Library Cache
+          key: unity-libcache2-{{ .Branch  }}
+          paths:
+            - /tmp/explorer/unity-client/Library/
       - store_artifacts:
           name: Store logs
           path: /tmp/buildlog.txt
@@ -187,7 +205,7 @@ jobs:
       - run:
           name: Get the hash of source files
           command: |
-            find packages -type f \( -exec shasum "$PWD"/{} \; \) | sort > ../.kernelsources-checksum
+            find packages -type f \( -iname \*.ts -o -iname \*.tsx -o -iname \*.json -o -iname \*.proto -o -iname \*.sh \) \( -exec md5sum "$PWD"/{} \; \) | sort > ../.kernelsources-checksum
       - restore_cache:
           name: Restore built files
           keys:
@@ -220,7 +238,7 @@ jobs:
             make build-essentials
             mkdir -p scene-cache
             cd scene-cache && find . -name '*.js' | xargs -I{} cp -f -t ../public/ --parents {}; cd ..
-            find public -name *.ts | xargs shasum packages/decentraland-ecs/dist/index.d.ts static/systems/scene.system.js | sort > .compiled-scene-checksum
+            find public -name *.ts | xargs md5sum packages/decentraland-ecs/dist/index.d.ts static/systems/scene.system.js | sort > .compiled-scene-checksum
       - restore_cache:
           name: Restore cached test scenes, part I
           keys:


### PR DESCRIPTION
This commit introduces three changes to the CircleCI script:

1. Using `md5sum` instead of `shasum` reduces the time to detect
     whether the source code changed or not from about 1 minute to
     about 2 seconds (!!).
2. Before that, I was trying to reduce the time to calculate that
     checksum by only looking at the relevant files (that's why the
     change on `find` introducing all the `-o -iname \*.something`)
     In hindsight, the `md5sum` change makes this innecessary; the
     tradeoffs are:
      - If we miss some extension that *should* trigger the build,
        then we might get passing builds that should have stopped.
        But how frequent is a change that *only* changes a file
        that we might miss?
        * From the Unity side, we're pretty safe: anything .meta
          triggers a build cache invalidation
        * From the kernel side, the number of extensions on the
          folder is pretty small -- running this `find`:
```
  find kernel/packages -type f -exec basename {} +
    | grep -oE '[^.]+$' # show only extensions
    | sort | unique     # sort & unique
```
Gives a total of 9 extensions on my machine:
 ```
           - DS_Store
           - LICENSE
           - gitignore
           - js
           - json
           - md
           - proto
           - sh
           - ts
```
In order to determine which files to cache in Unity, I used the following script to list extensions:
```
find . -type f \( -not -path '*Library/*' \) # anything in lib can be ignored
  -exec basename {} + # take only the file name
  | grep -oE '[^.]+$'     # match only the ending extension
  | sort | uniq # sort and unique
```
And then to list the biggest files:
```
find . -type f \( -not -path '*Library/*' \) # same find as before
 \( -exec ls -l {} \; \)   # `ls -l` to get more info on each file
 | awk '{print $5 " " $9}' # print columns 5 and 9 of `ls` (size & name)
 | grep -E '^[0-9]{6,10}'  # grep only lines starting with 6 digit numbers
```

3. New cache: `Library` folder. Dropped because it makes the
    cache build fail.