### PR TITLE
fix: missing dependency (sha3) on package.json

### DIFF
--- a/kernel/package-lock.json
+++ b/kernel/package-lock.json
@@ -5910,6 +5910,21 @@
       "requires": {
         "browserify-sha3": "^0.0.4",
         "sha3": "^1.2.2"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.13.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
+        },
+        "sha3": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.6.tgz",
+          "integrity": "sha512-KgLGmJGrmNB4JWVsAV11Yk6KbvsAiygWJc7t5IebWva/0NukNrjJqhtKhzy3Eiv2AKuGvhZZt7dt1mDo7HkoiQ==",
+          "requires": {
+            "nan": "2.13.2"
+          }
+        }
       }
     },
     "keyv": {
@@ -8766,17 +8781,21 @@
       }
     },
     "sha3": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.3.tgz",
-      "integrity": "sha512-sOWDZi8cDBRkLfWOw18wvJyNblXDHzwMGnRWut8zNNeIeLnmMRO17bjpLc7OzMuj1ASUgx2IyohzUCAl+Kx5vA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/sha3/-/sha3-2.1.2.tgz",
+      "integrity": "sha512-agYUtkzMsdFTQkM3ECyt6YW0552fyEb0tYZkl7olurS1Vg2Ms5+2SdF4VFPC1jnwtiXMb8b0fSyuAGZh+q2mAw==",
       "requires": {
-        "nan": "2.13.2"
+        "buffer": "5.5.0"
       },
       "dependencies": {
-        "nan": {
-          "version": "2.13.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
+        "buffer": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
         }
       }
     },

--- a/kernel/package.json
+++ b/kernel/package.json
@@ -116,6 +116,7 @@
     "redux": "^4.0.4",
     "redux-saga": "^1.0.5",
     "reselect": "^4.0.0",
+    "sha3": "^2.1.2",
     "typesafe-actions": "^4.4.2",
     "web3x": "^4.0.6",
     "ws": "^7.0.0"


### PR DESCRIPTION
The kernel launching was failing because the "sha3" dependency was missing in package.json