### PR TITLE
chore: disable tutorial

### DIFF
--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -133,7 +133,7 @@ export const ENGINE_DEBUG_PANEL = location.search.indexOf('ENGINE_DEBUG_PANEL') 
 export const SCENE_DEBUG_PANEL = location.search.indexOf('SCENE_DEBUG_PANEL') !== -1 && !ENGINE_DEBUG_PANEL
 export const SHOW_FPS_COUNTER = location.search.indexOf('SHOW_FPS_COUNTER') !== -1 || DEBUG
 export const RESET_TUTORIAL = location.search.indexOf('RESET_TUTORIAL') !== -1
-export const NO_TUTORIAL = location.search.indexOf('NO_TUTORIAL') !== -1
+export const NO_TUTORIAL = true
 export const HAS_INITIAL_POSITION_MARK = location.search.indexOf('position') !== -1
 
 export function tutorialEnabled() {


### PR DESCRIPTION
We're seeing a 50% drop-off of users before finishing the tutorial. We decided to disable it by default.