### PR TITLE
fix: handle video texture resizing

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.cs
@@ -94,6 +94,16 @@ namespace DCL.Components.Video.Plugin
                 case VideoState.PLAYING:
                     if (shouldBePlaying && visible)
                     {
+                        int width = WebVideoPlayerGetWidth(videoPlayerId);
+                        int height = WebVideoPlayerGetHeight(videoPlayerId);
+                        if (texture.width != width || texture.height != height)
+                        {
+                            if (texture.Resize(width, height))
+                            {
+                                texture.Apply();
+                                textureNativePtr = texture.GetNativeTexturePtr();
+                            }
+                        }
                         WebVideoPlayerTextureUpdate(videoPlayerId, textureNativePtr, isWebGL1);
                     }
                     break;


### PR DESCRIPTION
Some video stream sources may vary video resolution depending on bandwidth so we need to handle this by resizing the target texture for the video.