### PR TITLE
chore: disable CI flaky tests temporarily

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/Tests/CharacterControllerTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/Tests/CharacterControllerTests.cs
@@ -148,6 +148,8 @@ namespace Tests
         }
 
         [UnityTest]
+        [NUnit.Framework.Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
+        [Category("Explicit")]
         public IEnumerator CharacterSupportsMovingPlatforms()
         {
             Vector3 originalCharacterPosition = new Vector3
@@ -213,6 +215,8 @@ namespace Tests
 
 
         [UnityTest]
+        [NUnit.Framework.Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
+        [Category("Explicit")]
         public IEnumerator CharacterSupportsRotatingPlatforms()
         {
             Vector3 originalCharacterPosition = new Vector3
@@ -279,6 +283,8 @@ namespace Tests
         }
 
         [UnityTest]
+        [NUnit.Framework.Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
+        [Category("Explicit")]
         public IEnumerator CharacterIsReleasedOnEntityRemoval()
         {
             yield return CharacterSupportsMovingPlatforms();
@@ -294,6 +300,8 @@ namespace Tests
         }
 
         [UnityTest]
+        [NUnit.Framework.Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
+        [Category("Explicit")]
         public IEnumerator CharacterIsReleasedOnPlatformCollisionToggle()
         {
             yield return CharacterSupportsMovingPlatforms();
@@ -313,6 +321,8 @@ namespace Tests
         }
 
         [UnityTest]
+        [NUnit.Framework.Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
+        [Category("Explicit")]
         public IEnumerator CharacterIsReleasedOnShapeRemoval()
         {
             yield return CharacterSupportsMovingPlatforms();

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/MaterialTransitionController/Tests/MaterialTransitionControllerTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/MaterialTransitionController/Tests/MaterialTransitionControllerTests.cs
@@ -80,6 +80,8 @@ namespace Tests
         }
 
         [UnityTest]
+        [NUnit.Framework.Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
+        [Category("Explicit")]
         public IEnumerator MaterialTransitionWithParametrizableMeshes()
         {
             yield return InitScene(reloadUnityScene: false);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneBoundariesController/Tests/SceneBoundariesCheckerTests.cs
@@ -63,6 +63,8 @@ namespace SceneBoundariesCheckerTests
         }
 
         [UnityTest]
+        [NUnit.Framework.Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
+        [Category("Explicit")]
         public IEnumerator GLTFShapeIsResetWhenReenteringBounds()
         {
             yield return SBC_Asserts.GLTFShapeIsResetWhenReenteringBounds(scene);

--- a/unity-client/Assets/Scripts/Tests/CursorControllerTests/CursorControllerTests.cs
+++ b/unity-client/Assets/Scripts/Tests/CursorControllerTests/CursorControllerTests.cs
@@ -157,6 +157,8 @@ namespace Tests
         }
 
         [UnityTest]
+        [NUnit.Framework.Explicit("This test started failing on the CI out of the blue. Will be re-enabled after implementing a solution dealing with high delta times")]
+        [Category("Explicit")]
         public IEnumerator FeedbackIsNotDisplayedOnParent()
         {
             var cursorController = GameObject.FindObjectOfType<CursorController>();


### PR DESCRIPTION
Turned flaky tests into explicit tests to avoid running them on the CI