### PR TITLE
fix: Conflicts pressing RETURN key on AddFriends window

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
@@ -313,8 +313,10 @@ public class TaskbarHUDController : IHUD
 
     public void OnPressReturn()
     {
-        if ((privateChatWindowHud != null && privateChatWindowHud.view.gameObject.activeSelf) ||
-            (friendsHud != null && friendsHud.view.friendRequestsList.gameObject.activeSelf))
+        bool isPrivateChatWindowOpen = privateChatWindowHud != null && privateChatWindowHud.view.gameObject.activeSelf;
+        bool isFriendRequestsWindowOpen = friendsHud != null &&  friendsHud.view.friendRequestsList.gameObject.activeSelf;
+
+        if (isPrivateChatWindowOpen || isFriendRequestsWindowOpen)
             return;
 
         worldChatWindowHud.OnPressReturn();

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
@@ -313,7 +313,8 @@ public class TaskbarHUDController : IHUD
 
     public void OnPressReturn()
     {
-        if (privateChatWindowHud != null && privateChatWindowHud.view.gameObject.activeSelf)
+        if ((privateChatWindowHud != null && privateChatWindowHud.view.gameObject.activeSelf) ||
+            (friendsHud != null && friendsHud.view.friendRequestsList.gameObject.activeSelf))
             return;
 
         worldChatWindowHud.OnPressReturn();


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
If we press the ENTER key after write a friend name in the Add Friends input field, the friend window is closed and the worl chat is opened.
