### PR TITLE
fix: Hide JumpIn button when not receives realm info from a friend

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Resources/FriendsHUD.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Resources/FriendsHUD.prefab
@@ -105,7 +105,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 0, y: -528}
+  m_AnchoredPosition: {x: 0, y: -624}
   m_SizeDelta: {x: 400, y: 294}
   m_Pivot: {x: 0, y: 0}
 --- !u!225 &2481497620801839290
@@ -5118,7 +5118,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_text: "Type your <b>friend\u2019s name </b>or  <b>wallet adress </b>to send them
+  m_text: "Type your <b>friend\u2019s name </b>or  <b>wallet address </b>to send them
     a <b>Friend Request.</b>"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: c0f2e4affe3f2438d9042ca1db45764f, type: 2}
@@ -5189,7 +5189,7 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 6496958353206558150}
-    characterCount: 72
+    characterCount: 73
     spriteCount: 0
     spaceCount: 13
     wordCount: 13

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/JumpInButton.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/JumpInButton.cs
@@ -79,10 +79,10 @@ public class JumpInButton : MonoBehaviour
         currentRealmLayerName = realmLayerName;
         currentPresenceStatus = status;
 
-        ResfreshInfo();
+        RefreshInfo();
     }
 
-    private void ResfreshInfo()
+    private void RefreshInfo()
     {
         if (currentPresenceStatus == PresenceStatus.ONLINE &&
             !string.IsNullOrEmpty(currentRealmServerName) &&

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/JumpInButton.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/JumpInButton.cs
@@ -84,7 +84,9 @@ public class JumpInButton : MonoBehaviour
 
     private void ResfreshInfo()
     {
-        if (currentPresenceStatus == PresenceStatus.ONLINE)
+        if (currentPresenceStatus == PresenceStatus.ONLINE &&
+            !string.IsNullOrEmpty(currentRealmServerName) &&
+            !string.IsNullOrEmpty(currentRealmLayerName))
         {
             playerLocationText.text = $"{currentRealmServerName}-{currentRealmLayerName} {(int)currentCoords.x}, {(int)currentCoords.y}";
             this.gameObject.SetActive(true);


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
We should hide the JumpIn button when we don't receive the realm information.
