### PR TITLE
chore: optimize hover feedback

### DIFF
--- a/unity-client/Assets/Prefabs/PointerEventsController.prefab
+++ b/unity-client/Assets/Prefabs/PointerEventsController.prefab
@@ -27,7 +27,8 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 278.6145, y: 175.52747, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 1576462773199743587}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -41,5 +42,153 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ab6ce24ec00c7684b9788ac03231f03e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  interactionHoverCanvasController: {fileID: 3488885258875139384}
+--- !u!1001 &1128968661616295168
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 7926443760948197940}
+    m_Modifications:
+    - target: {fileID: 6724603896333122190, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_Name
+      value: InteractionHoverCanvas
+      objectReference: {fileID: 0}
+    - target: {fileID: 6724603896333122190, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4700288523959264737, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0efeabe527e0949d9aaa69eb2ea4d149, type: 3}
+--- !u!224 &1576462773199743587 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1894431656888850275, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+    type: 3}
+  m_PrefabInstance: {fileID: 1128968661616295168}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3488885258875139384 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4594205623192029240, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
+    type: 3}
+  m_PrefabInstance: {fileID: 1128968661616295168}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fdb703c4373e2421ab6fc794a7291837, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/InteractionHoverCanvas/InteractionHoverCanvasController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/InteractionHoverCanvas/InteractionHoverCanvasController.cs
@@ -9,39 +9,21 @@ public class InteractionHoverCanvasController : MonoBehaviour
     public Canvas canvas;
     public RectTransform backgroundTransform;
     public TextMeshProUGUI text;
-    public GameObject pointerActionIconPrefab;
-    public GameObject primaryActionIconPrefab;
-    public GameObject secondaryActionIconPrefab;
-    public GameObject anyActionIconPrefab;
+    public GameObject[] icons;
 
     bool isHovered = false;
     Camera mainCamera;
     GameObject hoverIcon;
     Vector3 meshCenteredPos;
     DecentralandEntity entity;
-    Dictionary<string, GameObject> buttonIcons = new Dictionary<string, GameObject>();
 
     const string ACTION_BUTTON_POINTER = "POINTER";
     const string ACTION_BUTTON_PRIMARY = "PRIMARY";
     const string ACTION_BUTTON_SECONDARY = "SECONDARY";
-    const string ACTION_BUTTON_ANY = "ANY";
 
     void Awake()
     {
         mainCamera = Camera.main;
-
-        buttonIcons.Add(ACTION_BUTTON_POINTER, Object.Instantiate(pointerActionIconPrefab, backgroundTransform));
-        buttonIcons[ACTION_BUTTON_POINTER].SetActive(false);
-
-        buttonIcons.Add(ACTION_BUTTON_PRIMARY, Object.Instantiate(primaryActionIconPrefab, backgroundTransform));
-        buttonIcons[ACTION_BUTTON_PRIMARY].SetActive(false);
-
-        buttonIcons.Add(ACTION_BUTTON_SECONDARY, Object.Instantiate(secondaryActionIconPrefab, backgroundTransform));
-        buttonIcons[ACTION_BUTTON_SECONDARY].SetActive(false);
-
-        buttonIcons.Add(ACTION_BUTTON_ANY, Object.Instantiate(secondaryActionIconPrefab, backgroundTransform));
-        buttonIcons[ACTION_BUTTON_ANY].SetActive(false);
-
     }
 
     public void Setup(string button, string feedbackText, DecentralandEntity entity)
@@ -58,10 +40,21 @@ public class InteractionHoverCanvasController : MonoBehaviour
     {
         hoverIcon?.SetActive(false);
 
-        if (buttonIcons.ContainsKey(button))
-            hoverIcon = buttonIcons[button];
-        else
-            hoverIcon = buttonIcons[ACTION_BUTTON_ANY];
+        switch (button)
+        {
+            case ACTION_BUTTON_POINTER:
+                hoverIcon = icons[0];
+                break;
+            case ACTION_BUTTON_PRIMARY:
+                hoverIcon = icons[1];
+                break;
+            case ACTION_BUTTON_SECONDARY:
+                hoverIcon = icons[2];
+                break;
+            default: // ANY
+                hoverIcon = icons[3];
+                break;
+        }
 
         hoverIcon.SetActive(true);
     }
@@ -73,6 +66,11 @@ public class InteractionHoverCanvasController : MonoBehaviour
         isHovered = hoverState;
 
         canvas.enabled = isHovered;
+    }
+
+    public GameObject GetCurrentHoverIcon()
+    {
+        return hoverIcon;
     }
 
     // This method will be used when we apply a "loose aim" for the 3rd person camera

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/InteractionHoverCanvas/InteractionHoverCanvasController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/InteractionHoverCanvas/InteractionHoverCanvasController.cs
@@ -2,6 +2,7 @@
 using DCL.Components;
 using UnityEngine;
 using TMPro;
+using System.Collections.Generic;
 
 public class InteractionHoverCanvasController : MonoBehaviour
 {
@@ -18,14 +19,29 @@ public class InteractionHoverCanvasController : MonoBehaviour
     GameObject hoverIcon;
     Vector3 meshCenteredPos;
     DecentralandEntity entity;
+    Dictionary<string, GameObject> buttonIcons = new Dictionary<string, GameObject>();
 
     const string ACTION_BUTTON_POINTER = "POINTER";
     const string ACTION_BUTTON_PRIMARY = "PRIMARY";
     const string ACTION_BUTTON_SECONDARY = "SECONDARY";
+    const string ACTION_BUTTON_ANY = "ANY";
 
     void Awake()
     {
         mainCamera = Camera.main;
+
+        buttonIcons.Add(ACTION_BUTTON_POINTER, Object.Instantiate(pointerActionIconPrefab, backgroundTransform));
+        buttonIcons[ACTION_BUTTON_POINTER].SetActive(false);
+
+        buttonIcons.Add(ACTION_BUTTON_PRIMARY, Object.Instantiate(primaryActionIconPrefab, backgroundTransform));
+        buttonIcons[ACTION_BUTTON_PRIMARY].SetActive(false);
+
+        buttonIcons.Add(ACTION_BUTTON_SECONDARY, Object.Instantiate(secondaryActionIconPrefab, backgroundTransform));
+        buttonIcons[ACTION_BUTTON_SECONDARY].SetActive(false);
+
+        buttonIcons.Add(ACTION_BUTTON_ANY, Object.Instantiate(secondaryActionIconPrefab, backgroundTransform));
+        buttonIcons[ACTION_BUTTON_ANY].SetActive(false);
+
     }
 
     public void Setup(string button, string feedbackText, DecentralandEntity entity)
@@ -40,26 +56,14 @@ public class InteractionHoverCanvasController : MonoBehaviour
 
     void ConfigureIcon(string button)
     {
-        // When we allow for custom input key bindings this implementation will change
+        hoverIcon?.SetActive(false);
 
-        if (hoverIcon != null)
-            Destroy(hoverIcon);
+        if (buttonIcons.ContainsKey(button))
+            hoverIcon = buttonIcons[button];
+        else
+            hoverIcon = buttonIcons[ACTION_BUTTON_ANY];
 
-        switch (button)
-        {
-            case ACTION_BUTTON_POINTER:
-                hoverIcon = Object.Instantiate(pointerActionIconPrefab, backgroundTransform);
-                break;
-            case ACTION_BUTTON_PRIMARY:
-                hoverIcon = Object.Instantiate(primaryActionIconPrefab, backgroundTransform);
-                break;
-            case ACTION_BUTTON_SECONDARY:
-                hoverIcon = Object.Instantiate(secondaryActionIconPrefab, backgroundTransform);
-                break;
-            default: // WebInterface.ACTION_BUTTON.ANY
-                hoverIcon = Object.Instantiate(anyActionIconPrefab, backgroundTransform);
-                break;
-        }
+        hoverIcon.SetActive(true);
     }
 
     public void SetHoverState(bool hoverState)

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/InteractionHoverCanvas/Resources/InteractionHoverCanvas.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/InteractionHoverCanvas/Resources/InteractionHoverCanvas.prefab
@@ -29,6 +29,10 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8091622107098573529}
+  - {fileID: 6507632769335737527}
+  - {fileID: 6463884872769161891}
+  - {fileID: 2094665859425058370}
+  - {fileID: 5355730443807630644}
   m_Father: {fileID: 1894431656888850275}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -128,6 +132,11 @@ MonoBehaviour:
     type: 3}
   anyActionIconPrefab: {fileID: 883752100616965295, guid: 7d57e6ad950144884968bd36cfa49478,
     type: 3}
+  icons:
+  - {fileID: 8746110877693093768}
+  - {fileID: 8834928924649345436}
+  - {fileID: 4485043749680457085}
+  - {fileID: 7601175057603706379}
 --- !u!114 &4672070199564005208
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -307,3 +316,587 @@ MonoBehaviour:
   - {fileID: 0}
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1001 &3638244795053091282
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 6432359610209792728}
+    m_Modifications:
+    - target: {fileID: 883752100616965295, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_Name
+      value: SecondaryButtonHoverIcon
+      objectReference: {fileID: 0}
+    - target: {fileID: 883752100616965295, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -25
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -45
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7786638872158442796, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_textInfo.characterCount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7786638872158442796, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_textInfo.wordCount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7786638872158442796, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_textInfo.lineCount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7786638872158442796, guid: e176613fd203f4bf281c28eb1a281524,
+        type: 3}
+      propertyPath: m_textInfo.pageCount
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e176613fd203f4bf281c28eb1a281524, type: 3}
+--- !u!1 &4485043749680457085 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 883752100616965295, guid: e176613fd203f4bf281c28eb1a281524,
+    type: 3}
+  m_PrefabInstance: {fileID: 3638244795053091282}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &2094665859425058370 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3417136854026590096, guid: e176613fd203f4bf281c28eb1a281524,
+    type: 3}
+  m_PrefabInstance: {fileID: 3638244795053091282}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7295685897255695012
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 6432359610209792728}
+    m_Modifications:
+    - target: {fileID: 883752100616965295, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_Name
+      value: AnyButtonHoverIcon
+      objectReference: {fileID: 0}
+    - target: {fileID: 883752100616965295, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -25
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -45
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7d57e6ad950144884968bd36cfa49478, type: 3}
+--- !u!1 &7601175057603706379 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 883752100616965295, guid: 7d57e6ad950144884968bd36cfa49478,
+    type: 3}
+  m_PrefabInstance: {fileID: 7295685897255695012}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &5355730443807630644 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3417136854026590096, guid: 7d57e6ad950144884968bd36cfa49478,
+    type: 3}
+  m_PrefabInstance: {fileID: 7295685897255695012}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8440830212976159527
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 6432359610209792728}
+    m_Modifications:
+    - target: {fileID: 883752100616965295, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_Name
+      value: PointerButtonHoverIcon
+      objectReference: {fileID: 0}
+    - target: {fileID: 883752100616965295, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -25
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -45
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4dd25573aa6f5440892c022173d6e68b, type: 3}
+--- !u!1 &8746110877693093768 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 883752100616965295, guid: 4dd25573aa6f5440892c022173d6e68b,
+    type: 3}
+  m_PrefabInstance: {fileID: 8440830212976159527}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &6507632769335737527 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3417136854026590096, guid: 4dd25573aa6f5440892c022173d6e68b,
+    type: 3}
+  m_PrefabInstance: {fileID: 8440830212976159527}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8563681373604011315
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 6432359610209792728}
+    m_Modifications:
+    - target: {fileID: 883752100616965295, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_Name
+      value: PrimaryButtonHoverIcon
+      objectReference: {fileID: 0}
+    - target: {fileID: 883752100616965295, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -25
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -45
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7786638872158442796, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_textInfo.characterCount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7786638872158442796, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_textInfo.wordCount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7786638872158442796, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_textInfo.lineCount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7786638872158442796, guid: a4bb797156cca415b834c054d6affeb3,
+        type: 3}
+      propertyPath: m_textInfo.pageCount
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a4bb797156cca415b834c054d6affeb3, type: 3}
+--- !u!1 &8834928924649345436 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 883752100616965295, guid: a4bb797156cca415b834c054d6affeb3,
+    type: 3}
+  m_PrefabInstance: {fileID: 8563681373604011315}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &6463884872769161891 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3417136854026590096, guid: a4bb797156cca415b834c054d6affeb3,
+    type: 3}
+  m_PrefabInstance: {fileID: 8563681373604011315}
+  m_PrefabAsset: {fileID: 0}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/OnPointerEvent.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/OnPointerEvent.cs
@@ -71,13 +71,7 @@ namespace DCL.Components
             pointerEventColliders.refCount++;
 
             if (hoverCanvasController == null)
-            {
-                GameObject hoverCanvasGameObject = Object.Instantiate(Resources.Load("InteractionHoverCanvas"), PointerEventsController.i.transform) as GameObject;
-                hoverCanvasController = hoverCanvasGameObject.GetComponent<InteractionHoverCanvasController>();
-            }
-
-            hoverCanvasController.enabled = model.showFeedback;
-            hoverCanvasController.Setup(model.button, model.hoverText, entity);
+                hoverCanvasController = PointerEventsController.i.interactionHoverCanvasController;
         }
 
         public bool IsVisible()
@@ -100,19 +94,18 @@ namespace DCL.Components
             Initialize();
         }
 
-        protected override void RemoveComponent<T>(DecentralandEntity entity)
-        {
-            if (hoverCanvasController != null)
-            {
-                Destroy(hoverCanvasController.gameObject);
-            }
-        }
-
         public void SetHoverState(bool hoverState)
         {
             if (!enableInteractionHoverFeedback || !enabled) return;
 
-            hoverCanvasController.SetHoverState(hoverState);
+            hoverCanvasController.enabled = model.showFeedback;
+            if (model.showFeedback)
+            {
+                if (hoverState)
+                    hoverCanvasController.Setup(model.button, model.hoverText, entity);
+
+                hoverCanvasController.SetHoverState(hoverState);
+            }
         }
 
         public bool IsAtHoverDistance(Transform other)
@@ -137,11 +130,6 @@ namespace DCL.Components
                 {
                     Destroy(pointerEventColliders);
                 }
-            }
-
-            if (hoverCanvasController != null)
-            {
-                Destroy(hoverCanvasController.gameObject);
             }
         }
     }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/Tests/UUIDComponentTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/Tests/UUIDComponentTests.cs
@@ -1101,12 +1101,12 @@ namespace Tests
 
             yield return null;
 
-            var hoverCanvasController = PointerEventsController.i.GetComponentInChildren<InteractionHoverCanvasController>();
+            var hoverCanvasController = PointerEventsController.i.interactionHoverCanvasController;
             Assert.IsNotNull(hoverCanvasController);
             Assert.IsTrue(hoverCanvasController.canvas.enabled);
 
             // Check default properties
-            Assert.AreEqual(hoverCanvasController.GetComponentInChildren<Image>().name, "AnyButtonHoverIcon(Clone)");
+            Assert.AreEqual("AnyButtonHoverIcon", hoverCanvasController.GetCurrentHoverIcon().name);
             Assert.AreEqual("Interact", hoverCanvasController.text.text);
             yield return null;
 
@@ -1119,7 +1119,7 @@ namespace Tests
 
             yield return null;
 
-            Assert.AreEqual(hoverCanvasController.GetComponentInChildren<Image>().name, "PrimaryButtonHoverIcon(Clone)");
+            Assert.AreEqual("PrimaryButtonHoverIcon", hoverCanvasController.GetCurrentHoverIcon().name);
             Assert.AreEqual("Click!", hoverCanvasController.text.text);
 
             DCLCharacterController.i.ResumeGravity();

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ExpressionsHUD/ExpressionsHUDView.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ExpressionsHUD/ExpressionsHUDView.cs
@@ -49,7 +49,7 @@ public class ExpressionsHUDView : MonoBehaviour
 
     internal void Initialize(ExpressionClicked clickedDelegate)
     {
-        HideContent();
+        content.gameObject.SetActive(false);
 
         foreach (var buttonToExpression in buttonToExpressionMap)
         {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/PointerEventsController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/PointerEventsController.cs
@@ -10,6 +10,8 @@ namespace DCL
     {
         public static PointerEventsController i { get; private set; }
 
+        public InteractionHoverCanvasController interactionHoverCanvasController;
+
         private static bool renderingIsDisabled => !CommonScriptableObjects.rendererState.Get();
         public static System.Action OnPointerHoverStarts;
         public static System.Action OnPointerHoverEnds;


### PR DESCRIPTION
Improved hover feedback to use 1 canvas and recycle it instead of 1 per pointer event

Profiled at the genesis plaza spawn point and with this optimization:
- In Genesis plaza, Instead of having like 170 canvases for the hover feedback (one for each pointer event component) now we have always just 1 and recycle it (since there will never be more than 1 hover feedback at a time)
- We gain between 0.5 and 1.5 ms of CPU (measured looking at the editor player cpu stats)