### PR TITLE
fix: pointer events controller prefab

### DIFF
--- a/unity-client/Assets/Prefabs/PointerEventsController.prefab
+++ b/unity-client/Assets/Prefabs/PointerEventsController.prefab
@@ -55,7 +55,7 @@ PrefabInstance:
     - target: {fileID: 6724603896333122190, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
         type: 3}
       propertyPath: m_Name
-      value: InteractionHoverCanvas
+      value: InteractionHoverFeedbackCanvas
       objectReference: {fileID: 0}
     - target: {fileID: 6724603896333122190, guid: 0efeabe527e0949d9aaa69eb2ea4d149,
         type: 3}


### PR DESCRIPTION
Renamed InteractionHoverCanvas child of PointerEventsController to force prefab update