### PR TITLE
fix: wait for renderer enable before nft requests

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/LoadWrapper_NFT.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/LoadWrapper_NFT.cs
@@ -42,7 +42,7 @@ namespace DCL.Components
 
             assetUrl = src;
 
-            if (CommonScriptableObjects.rendererState)
+            if (CommonScriptableObjects.rendererState.Get())
             {
                 LoadAsset();
             }
@@ -64,7 +64,7 @@ namespace DCL.Components
 
         void LoadAsset()
         {
-            loaderController.LoadAsset(assetUrl, true);
+            loaderController?.LoadAsset(assetUrl, true);
         }
 
         void OnRendererStateChanged(bool current, bool previous)

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/LoadWrapper_NFT.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/LoadWrapper_NFT.cs
@@ -14,6 +14,7 @@ namespace DCL.Components
 
         public override void Unload()
         {
+            CommonScriptableObjects.rendererState.OnChange -= OnRendererStateChanged;
             loaderController.OnLoadingAssetSuccess -= CallOnComponentUpdated;
             Object.Destroy(loaderController);
 


### PR DESCRIPTION
Don't try to load nft images when renderer is deactivated.
