### PR TITLE
fix: ignore publish-renderer on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -431,9 +431,11 @@ workflows:
             - build-unity
 
       - publish-renderer:
-          <<: *all_branches_and_tags
           requires:
             - package
+          filters:
+            branches:
+              only: /(.*)/ # run on all branches, but no tags
 
       # ecs publishing
       - hold-ecs:


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Remove the publish renderer stage from the ECS release pipeline

# Why?
This task is used as part of our development process and should not be triggered by the release of a new ECS version