### PR TITLE
fix: Don't send position if it hasn't change since last time

### DIFF
--- a/kernel/packages/atomicHelpers/arrayEquals.ts
+++ b/kernel/packages/atomicHelpers/arrayEquals.ts
@@ -1,7 +1,7 @@
-export function arrayEquals(a: any[] | undefined, b: any[] | undefined): boolean {
+export function arrayEquals(a: any[] | undefined | null, b: any[] | undefined | null): boolean {
   if (a === b) return true
-  if (a == null || b == null) return false
-  if (a.length != b.length) return false
+  if (a === undefined || b === undefined || a === null || b === null) return false
+  if (a.length !== b.length) return false
 
   for (let i = 0; i < a.length; ++i) {
     if (a[i] !== b[i]) return false

--- a/kernel/packages/atomicHelpers/arrayEquals.ts
+++ b/kernel/packages/atomicHelpers/arrayEquals.ts
@@ -1,0 +1,11 @@
+export function arrayEquals(a: any[] | undefined, b: any[] | undefined): boolean {
+  if (a === b) return true
+  if (a == null || b == null) return false
+  if (a.length != b.length) return false
+
+  for (let i = 0; i < a.length; ++i) {
+    if (a[i] !== b[i]) return false
+  }
+
+  return true
+}


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
To reduce bandwidth usage, we send positions through comms only if they have changed or if 5 seconds have passed since last update (to ensure eventual consistency if the last position didn't reach the other peers)