### PR TITLE
fix: backpack copy rolled back to Avatar

### DIFF
--- a/unity-client/Assets/Resources/Prefabs/AvatarHUD.prefab
+++ b/unity-client/Assets/Resources/Prefabs/AvatarHUD.prefab
@@ -1528,7 +1528,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_text: Backpack
+  m_text: Avatar
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
   m_sharedMaterial: {fileID: -6892909264025736228, guid: 26b03903800224f718b64e9afbc91b61,
@@ -1598,7 +1598,7 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 224962850558003141}
-    characterCount: 8
+    characterCount: 6
     spriteCount: 0
     spaceCount: 0
     wordCount: 1


### PR DESCRIPTION
Is too early to replace Avatars to Backpack because it is not conceptually implemented yet and will get confused our users.