### PR TITLE
chore: add param to disable asset bundles

### DIFF
--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -136,6 +136,7 @@ export const ENGINE_DEBUG_PANEL = location.search.indexOf('ENGINE_DEBUG_PANEL') 
 export const SCENE_DEBUG_PANEL = location.search.indexOf('SCENE_DEBUG_PANEL') !== -1 && !ENGINE_DEBUG_PANEL
 export const SHOW_FPS_COUNTER = location.search.indexOf('SHOW_FPS_COUNTER') !== -1 || DEBUG
 export const HAS_INITIAL_POSITION_MARK = location.search.indexOf('position') !== -1
+export const NO_ASSET_BUNDLES = location.search.indexOf('NO_ASSET_BUNDLES') !== -1
 
 export namespace commConfigurations {
   export const debug = true

--- a/kernel/packages/unity-interface/dcl.ts
+++ b/kernel/packages/unity-interface/dcl.ts
@@ -17,7 +17,8 @@ import {
   ENGINE_DEBUG_PANEL,
   playerConfigurations,
   SCENE_DEBUG_PANEL,
-  SHOW_FPS_COUNTER
+  SHOW_FPS_COUNTER,
+  NO_ASSET_BUNDLES
 } from '../config'
 import { Quaternion, ReadOnlyQuaternion, ReadOnlyVector3, Vector3 } from '../decentraland-ecs/src/decentraland/math'
 import { IEventNames, IEvents, ProfileForRenderer, MinimapSceneInfo } from '../decentraland-ecs/src/decentraland/Types'
@@ -576,6 +577,9 @@ export const unityInterface = {
   SetEngineDebugPanel() {
     gameInstance.SendMessage('SceneController', 'SetEngineDebugPanel')
   },
+  SetDisableAssetBundles() {
+    gameInstance.SendMessage('SceneController', 'SetDisableAssetBundles')
+  },
   ActivateRendering() {
     gameInstance.SendMessage('SceneController', 'ActivateRendering')
   },
@@ -962,6 +966,10 @@ export async function initializeEngine(_gameInstance: GameInstance) {
 
   if (SCENE_DEBUG_PANEL) {
     unityInterface.SetSceneDebugPanel()
+  }
+
+  if (NO_ASSET_BUNDLES) {
+    unityInterface.SetDisableAssetBundles()
   }
 
   if (SHOW_FPS_COUNTER) {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using DCL.Components;
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -366,6 +367,11 @@ namespace DCL
         {
             sceneDebugPanel.SetActive(false);
             engineDebugPanel.SetActive(true);
+        }
+
+        public void SetDisableAssetBundles()
+        {
+            RendereableAssetLoadHelper.loadingType = RendereableAssetLoadHelper.LoadingType.GLTF_ONLY;
         }
 
         public bool IsCharacterInsideScene(ParcelScene scene)

--- a/unity-client/Assets/Scripts/MainScripts/Debugging/WSS/WSSController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/Debugging/WSS/WSSController.cs
@@ -413,6 +413,9 @@ namespace DCL
                             case "RequestTeleport":
                                 HUDController.i.RequestTeleport(msg.payload);
                                 break;
+                            case "SetDisableAssetBundles":
+                                SceneController.i.SetDisableAssetBundles();
+                                break;
                             default:
                                 Debug.Log(
                                     "<b><color=#FF0000>WSSController:</color></b> received an unknown message from kernel to renderer: " +


### PR DESCRIPTION
With `NO_ASSET_BUNDLES` as a url param, we force all the assets to load as GLTFs. This will help to diagnose issues related to asset bundles conversion.

To test: https://play.decentraland.zone/branch/chore/new-disable-asset-bundles-param/index.html?ENV=org&NO_ASSET_BUNDLES