### PR TITLE
fix: error when connecting comms on init not being handled

### DIFF
--- a/kernel/package-lock.json
+++ b/kernel/package-lock.json
@@ -2851,9 +2851,9 @@
       "dev": true
     },
     "decentraland-katalyst-peer": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/decentraland-katalyst-peer/-/decentraland-katalyst-peer-0.2.13.tgz",
-      "integrity": "sha512-DULKRvs/0GSU7ww4JPHfB18r3fisZ8yqZPhTVgph7qUNehA+aPRs0Un3bIIHQPSy2Vh3OlnatYSQQkBkKEWVTA==",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/decentraland-katalyst-peer/-/decentraland-katalyst-peer-0.2.14.tgz",
+      "integrity": "sha512-sVxsq1b+zdiQFqe/sOgbI1NXp+LlK9zZQc7GV/BIgvFTW2IMModGOtJlEiF1i+NXThuRybm8TjKPvaw0bv7Bbw==",
       "requires": {
         "eventemitter3": "^4.0.0",
         "fp-future": "^1.0.1",
@@ -8015,9 +8015,9 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
     },
     "protobufjs": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.9.0.tgz",
-      "integrity": "sha512-LlGVfEWDXoI/STstRDdZZKb/qusoAWUnmLg9R8OLSO473mBLWHowx8clbX5/+mKDEI+v7GzjoK9tRPZMMcoTrg==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.0.tgz",
+      "integrity": "sha512-Hdz1+CXkrlmGDKkP6DczxysdnUyUuhM1mjeaydnBxOcjxQPbJldLZ8eGE1gX0UTsgv+0QkFfn6dioo5yt9XORw==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -8035,9 +8035,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.12",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.12.tgz",
-          "integrity": "sha512-zWz/8NEPxoXNT9YyF2osqyA9WjssZukYpgI4UYZpOjcyqwIUqWGkcCionaEb9Ki+FULyPyvNFpg/329Kd2/pbw=="
+          "version": "13.13.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.14.tgz",
+          "integrity": "sha512-Az3QsOt1U/K1pbCQ0TXGELTuTkPLOiFIQf3ILzbOyo0FqgV9SxRnxbxM5QlAveERZMHpZY+7u3Jz2tKyl+yg6g=="
         }
       }
     },

--- a/kernel/package.json
+++ b/kernel/package.json
@@ -101,7 +101,7 @@
     "dcl-catalyst-client": "^1.2.5",
     "dcl-crypto": "^2.2.0",
     "dcl-social-client": "^1.3.10",
-    "decentraland-katalyst-peer": "0.2.13",
+    "decentraland-katalyst-peer": "0.2.14",
     "decentraland-renderer": "^1.8.24962",
     "decentraland-rpc": "^3.1.8",
     "devtools-protocol": "0.0.615714",

--- a/kernel/packages/shared/comms/index.ts
+++ b/kernel/packages/shared/comms/index.ts
@@ -44,7 +44,7 @@ import {
 import { BrokerWorldInstanceConnection } from '../comms/v1/brokerWorldInstanceConnection'
 import { profileToRendererFormat } from 'shared/profiles/transformations/profileToRendererFormat'
 import { ProfileForRenderer, uuid } from 'decentraland-ecs/src'
-import { worldRunningObservable, isWorldRunning } from '../world/worldState'
+import { worldRunningObservable, isWorldRunning, onNextWorldRunning } from '../world/worldState'
 import { WorldInstanceConnection } from './interface/index'
 
 import { LighthouseWorldInstanceConnection } from './v2/LighthouseWorldInstanceConnection'
@@ -71,6 +71,8 @@ import { messageReceived } from '../chat/actions'
 import { arrayEquals } from 'atomicHelpers/arrayEquals'
 import { getCommsConfig } from 'shared/meta/selectors'
 import { ensureMetaConfigurationInitialized } from 'shared/meta/index'
+import { ReportFatalError } from 'shared/loading/ReportFatalError'
+import { NEW_LOGIN, UNEXPECTED_ERROR } from 'shared/loading/types'
 
 export type CommsVersion = 'v1' | 'v2'
 export type CommsMode = CommsV1Mode | CommsV2Mode
@@ -709,10 +711,18 @@ export async function connect(userId: string) {
     if (isWorldRunning()) {
       await startCommunications(context)
     } else {
-      let observer = worldRunningObservable.add((isRunning) => {
-        if (isRunning) {
-          startCommunications(context!).catch((e) => defaultLogger.log('Error starting communications!', e))
-          worldRunningObservable.remove(observer)
+      onNextWorldRunning(async () => {
+        try {
+          await startCommunications(context!)
+        } catch (e) {
+          disconnect()
+          if (e instanceof IdTakenError) {
+            ReportFatalError(NEW_LOGIN)
+          } else {
+            // not a comms issue per se => rethrow error
+            defaultLogger.error(`error while trying to establish communications `, e)
+            ReportFatalError(UNEXPECTED_ERROR)
+          }
         }
       })
     }
@@ -720,8 +730,8 @@ export async function connect(userId: string) {
     return context
   } catch (e) {
     defaultLogger.error(e)
-    if (e.message && e.message.includes('is taken')) {
-      throw new IdTakenError(e.message)
+    if (e instanceof IdTakenError) {
+      throw e
     } else {
       throw new ConnectionEstablishmentError(e.message)
     }
@@ -811,7 +821,11 @@ export async function startCommunications(context: Context) {
       }
     }, 100)
   } catch (e) {
-    throw new ConnectionEstablishmentError(e.message)
+    if (e.message && e.message.includes('is taken')) {
+      throw new IdTakenError(e.message)
+    } else {
+      throw new ConnectionEstablishmentError(e.message)
+    }
   }
 }
 

--- a/kernel/packages/shared/comms/index.ts
+++ b/kernel/packages/shared/comms/index.ts
@@ -72,7 +72,7 @@ import { arrayEquals } from 'atomicHelpers/arrayEquals'
 import { getCommsConfig } from 'shared/meta/selectors'
 import { ensureMetaConfigurationInitialized } from 'shared/meta/index'
 import { ReportFatalError } from 'shared/loading/ReportFatalError'
-import { NEW_LOGIN, UNEXPECTED_ERROR } from 'shared/loading/types'
+import { NEW_LOGIN, UNEXPECTED_ERROR, commsEstablished } from 'shared/loading/types'
 
 export type CommsVersion = 'v1' | 'v2'
 export type CommsMode = CommsV1Mode | CommsV2Mode
@@ -628,6 +628,7 @@ export async function connect(userId: string) {
 
         const instance = new BrokerWorldInstanceConnection(commsBroker)
         await instance.isConnected
+        store.dispatch(commsEstablished())
 
         connection = instance
         break
@@ -745,6 +746,7 @@ export async function startCommunications(context: Context) {
     try {
       if (connection instanceof LighthouseWorldInstanceConnection) {
         await connection.connectPeer()
+        store.dispatch(commsEstablished())
       }
     } catch (e) {
       // Do nothing if layer is full. This will be handled by status handler

--- a/kernel/packages/shared/comms/reducer.ts
+++ b/kernel/packages/shared/comms/reducer.ts
@@ -1,0 +1,25 @@
+import { COMMS_ESTABLISHED } from '../loading/types'
+import { AnyAction } from 'redux'
+
+export type CommsState = {
+  initialized: boolean
+}
+
+const INITIAL_COMMS = {
+  initialized: false
+}
+
+export function commsReducer(state?: CommsState, action?: AnyAction): CommsState {
+  if (!state) {
+    return INITIAL_COMMS
+  }
+  if (!action) {
+    return state
+  }
+  switch (action.type) {
+    case COMMS_ESTABLISHED:
+      return { initialized: true }
+    default:
+      return state
+  }
+}

--- a/kernel/packages/shared/comms/v2/LighthouseWorldInstanceConnection.ts
+++ b/kernel/packages/shared/comms/v2/LighthouseWorldInstanceConnection.ts
@@ -154,15 +154,15 @@ export class LighthouseWorldInstanceConnection implements WorldInstanceConnectio
 
   private async syncRoomsWithPeer() {
     const currentRooms = this.peer.currentRooms
-    const joining = this.rooms.map(room => {
-      if (!currentRooms.some(current => current.id === room)) {
+    const joining = this.rooms.map((room) => {
+      if (!currentRooms.some((current) => current.id === room)) {
         return this.peer.joinRoom(room)
       } else {
         return Promise.resolve()
       }
     })
-    const leaving = currentRooms.map(current => {
-      if (!this.rooms.some(room => current.id === room)) {
+    const leaving = currentRooms.map((current) => {
+      if (!this.rooms.some((room) => current.id === room)) {
         return this.peer.leaveRoom(current.id)
       } else {
         return Promise.resolve()
@@ -172,7 +172,7 @@ export class LighthouseWorldInstanceConnection implements WorldInstanceConnectio
   }
 
   private async sendData(topic: string, messageData: MessageData, type: PeerMessageType) {
-    if (this.peer.currentRooms.some(it => it.id === topic)) {
+    if (this.peer.currentRooms.some((it) => it.id === topic)) {
       await this.peer.sendMessage(topic, createCommsMessage(messageData).serializeBinary(), type)
     } else {
       // TODO: We may want to queue some messages

--- a/kernel/packages/shared/store/rootReducer.ts
+++ b/kernel/packages/shared/store/rootReducer.ts
@@ -7,6 +7,7 @@ import { atlasReducer } from '../atlas/reducer'
 import { daoReducer } from '../dao/reducer'
 import { metaReducer } from '../meta/reducer'
 import { chatReducer } from '../chat/reducer'
+import { commsReducer } from '../comms/reducer'
 
 export const reducers = combineReducers({
   atlas: atlasReducer,
@@ -16,5 +17,6 @@ export const reducers = combineReducers({
   renderer: rendererReducer,
   protocol: protocolReducer,
   dao: daoReducer,
+  comms: commsReducer,
   meta: metaReducer
 })

--- a/kernel/packages/shared/store/rootTypes.ts
+++ b/kernel/packages/shared/store/rootTypes.ts
@@ -3,6 +3,8 @@ import { ProfileState } from '../profiles/types'
 import { DaoState } from '../dao/types'
 import { MetaState } from '../meta/types'
 import { ChatState } from '../chat/types'
+import { CommsState } from '../comms/reducer'
+
 import { Store } from 'redux'
 
 export type RootState = {
@@ -11,6 +13,7 @@ export type RootState = {
   dao: DaoState
   meta: MetaState
   chat: ChatState
+  comms: CommsState
 }
 
 export type StoreContainer = { globalStore: Store<RootState> }

--- a/kernel/packages/shared/world/worldState.ts
+++ b/kernel/packages/shared/world/worldState.ts
@@ -21,12 +21,16 @@ export async function ensureWorldRunning() {
     return result
   }
 
+  onNextWorldRunning(() => result.resolve())
+
+  return result
+}
+
+export function onNextWorldRunning(callback: Function) {
   const observer = worldRunningObservable.add((isRunning) => {
     if (isRunning) {
       worldRunningObservable.remove(observer)
-      result.resolve()
+      callback()
     }
   })
-
-  return result
 }


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Handles errors when trying to connect to comms service on initialization.

This fix reenables comms error screens, to warn the user about a possible issue or existing session as well as stop the client.