### PR TITLE
feat: URL parameter to skip start button

### DIFF
--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -136,6 +136,8 @@ export const ENGINE_DEBUG_PANEL = location.search.indexOf('ENGINE_DEBUG_PANEL') 
 export const SCENE_DEBUG_PANEL = location.search.indexOf('SCENE_DEBUG_PANEL') !== -1 && !ENGINE_DEBUG_PANEL
 export const SHOW_FPS_COUNTER = location.search.indexOf('SHOW_FPS_COUNTER') !== -1 || DEBUG
 export const HAS_INITIAL_POSITION_MARK = location.search.indexOf('position') !== -1
+export const SKIP_START_BUTTON = location.search.indexOf('SKIP_START_BUTTON') !== -1
+
 export const NO_ASSET_BUNDLES = location.search.indexOf('NO_ASSET_BUNDLES') !== -1
 
 export const PIN_CATALYST = qs.PIN_CATALYST

--- a/kernel/packages/shared/ethereum/provider.ts
+++ b/kernel/packages/shared/ethereum/provider.ts
@@ -1,7 +1,7 @@
 import { WebSocketProvider, RequestManager } from 'eth-connect'
 import { future, IFuture } from 'fp-future'
 
-import { ethereumConfigurations, ETHEREUM_NETWORK } from 'config'
+import { ethereumConfigurations, ETHEREUM_NETWORK, SKIP_START_BUTTON } from 'config'
 import { defaultLogger } from 'shared/logger'
 import { Account } from 'web3x/account'
 import { getUserProfile } from 'shared/comms/peers'
@@ -85,6 +85,10 @@ export async function awaitWeb3Approval(): Promise<void> {
       let response = future()
 
       button!.onclick = processLoginAttempt(response)
+
+      if (SKIP_START_BUTTON) {
+        processLoginAttempt(response)()
+      }
 
       let result
       while (true) {

--- a/kernel/scripts/runLoops.ts
+++ b/kernel/scripts/runLoops.ts
@@ -2,22 +2,26 @@ const puppeteer = require('puppeteer')
 
 const position = process.env.BOT_POSITION ? process.env.BOT_POSITION : '20,20'
 const host = process.env.HOST ? process.env.HOST : 'https://explorer.decentraland.zone'
+const env = process.env.EXPLORER_ENV ? process.env : 'zone'
 
 async function main() {
   const browser = await puppeteer.launch({
     args: ['--no-sandbox']
-  });
+  })
   const page = await browser.newPage()
 
-  page.on('console', msg => {
+  page.on('console', (msg) => {
     for (let i = 0; i < msg.args().length; ++i) {
       console.info(`${i}: ${msg.args()[i]}`)
     }
   })
 
-  await page.goto(`${host}/?position=${position}&ws=ws%3A%2F%2Flocalhost%3A5001%2Floop&NO_TUTORIAL`, {
-    waitUntil: 'networkidle2'
-  })
+  await page.goto(
+    `${host}/?position=${position}&ws=ws%3A%2F%2Flocalhost%3A5001%2Floop&NO_TUTORIAL&SKIP_START_BUTTON&ENV=${env}`,
+    {
+      waitUntil: 'networkidle2'
+    }
+  )
 
   while (true) {
     // await page.screenshot({ path: `example-${i++}.png` })


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
This PR adds support for a URL parameter that can be used to skip the "start exploring" button

# Why? <!-- Explain the reason -->
Because bots we use for testing require to be able to login automatically
