### PR TITLE
fix: transparency order issues

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.asmdef
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.asmdef
@@ -15,9 +15,9 @@
         "GUID:4a37c94d8d2dc8242af4c424d0b4a8ae",
         "GUID:2fe41b558b0755a499a0dae91e369bc7",
         "GUID:4973650d2444c4561a15d50f24d91cd9",
-        "GUID:0e967802b778d404eac1ca5ea340e290"
+        "GUID:0e967802b778d404eac1ca5ea340e290",
+        "GUID:08b2edf8f14cdd3408988fd7746b749c"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
@@ -25,5 +25,6 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": []
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarUtils.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarUtils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using DCL.Helpers;
 using UnityEngine;
 
 public static class AvatarUtils
@@ -144,6 +145,11 @@ public static class AvatarUtils
 
                 if (_MatCap != null)
                     copy.SetTexture("_MatCap", _MatCap);
+
+                int zWrite = (int) copy.GetFloat(ShaderUtils._ZWrite);
+
+                if (zWrite == 0)
+                    copy.renderQueue = (int) UnityEngine.Rendering.RenderQueue.Transparent;
 
                 result.Add(copy);
                 return copy;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/MaterialHelpers/SRPBatchingHelper/SRPBatchingHelper.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/MaterialHelpers/SRPBatchingHelper/SRPBatchingHelper.cs
@@ -39,6 +39,7 @@ namespace DCL.Helpers
     public static class SRPBatchingHelper
     {
         static Dictionary<int, int> crcToQueue = new Dictionary<int, int>();
+
         public static void OptimizeMaterial(Renderer renderer, Material material)
         {
             //NOTE(Brian): Just enable these keywords so the SRP batcher batches more stuff.
@@ -47,25 +48,26 @@ namespace DCL.Helpers
 
             material.enableInstancing = true;
 
+            int zWrite = (int) material.GetFloat(ShaderUtils._ZWrite);
+
+            //NOTE(Brian): for transparent meshes skip further variant optimization.
+            //             Transparency needs clip space z sorting to be displayed correctly.
+            if (zWrite == 0)
+                return;
+
+            int cullMode = (int) material.GetFloat(ShaderUtils._Cull);
+
             int baseQueue;
 
-            int cullMode = (int)material.GetFloat(ShaderUtils._Cull);
-            int zWrite = (int)material.GetFloat(ShaderUtils._ZWrite);
-
-            if (zWrite == 0)
-                baseQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
-            else if (material.renderQueue == (int)UnityEngine.Rendering.RenderQueue.AlphaTest)
-                baseQueue = (int)UnityEngine.Rendering.RenderQueue.AlphaTest;
+            if (material.renderQueue == (int) UnityEngine.Rendering.RenderQueue.AlphaTest)
+                baseQueue = (int) UnityEngine.Rendering.RenderQueue.AlphaTest;
             else
-                baseQueue = (int)UnityEngine.Rendering.RenderQueue.Geometry;
+                baseQueue = (int) UnityEngine.Rendering.RenderQueue.Geometry;
 
-            if (baseQueue != (int)UnityEngine.Rendering.RenderQueue.Transparent)
-            {
-                material.DisableKeyword("_ENVIRONMENTREFLECTIONS_OFF");
-                material.DisableKeyword("_SPECULARHIGHLIGHTS_OFF");
-                material.SetFloat(ShaderUtils._SpecularHighlights, 1);
-                material.SetFloat(ShaderUtils._EnvironmentReflections, 1);
-            }
+            material.DisableKeyword("_ENVIRONMENTREFLECTIONS_OFF");
+            material.DisableKeyword("_SPECULARHIGHLIGHTS_OFF");
+            material.SetFloat(ShaderUtils._SpecularHighlights, 1);
+            material.SetFloat(ShaderUtils._EnvironmentReflections, 1);
 
             //NOTE(Brian): This guarantees grouping calls by same shader keywords. Needed to take advantage of SRP batching.
             string appendedKeywords = string.Join("", material.shaderKeywords);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/MaterialHelpers/SRPBatchingHelper/SRPBatchingHelper.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/MaterialHelpers/SRPBatchingHelper/SRPBatchingHelper.cs
@@ -53,7 +53,10 @@ namespace DCL.Helpers
             //NOTE(Brian): for transparent meshes skip further variant optimization.
             //             Transparency needs clip space z sorting to be displayed correctly.
             if (zWrite == 0)
+            {
+                material.renderQueue = (int) UnityEngine.Rendering.RenderQueue.Transparent;
                 return;
+            }
 
             int cullMode = (int) material.GetFloat(ShaderUtils._Cull);
 


### PR DESCRIPTION
This PR address the "z-fighting" artifact described in this issue:
https://app.zenhub.com/workspaces/explorer-5dc988c462b0b700019b0b42/issues/decentraland/explorer/1072

The fix presented here aims to fix the transparency rendering order issue for the majority of causes. However, remember that universal solutions for this issue haven't been discovered yet in non-raycast rendering engines.

Just found this answer that summarizes the issue correctly (the first one): https://stackoverflow.com/questions/55431754/why-does-unity-material-not-render-semi-transparency-properly/55438217

To quote the recommendations presented in the first answer:

> The first and most important thing you can do is limit transparent materials to areas that are explicitly transparent. I believe the rendering order is based on materials above all else, so having a mesh with several opaque materials and a single transparent one will probably work fine, with the opaque parts being rendered before the single transparent part, but don't quote me on that. 

He's right, so completely quoting him on that.

> Secondly, if you have alternatives, use them. The reason "cutout" mode seems to be a binary mask rather than real transparency is because it is. Because it's not really transparent, you don't run into any of the depth sorting issues that you typically would. It's a trade-off. 

Note that cutout means `ALPHA_TEST` mode.
 
> Third, try to avoid large intersecting objects with transparent materials. Large bodies of water are notorious for causing problems in this regard. Think carefully about what you have to work with.
 
> Finally, if you absolutely must have multiple large intersecting transparent objects, consider breaking them up into multiple pieces.
 
