### PR TITLE
fix: chat heads container not expanding with it content

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/ChatHeadGroupView.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/ChatHeadGroupView.cs
@@ -18,6 +18,7 @@ public class ChatHeadGroupView : MonoBehaviour
     private IChatController chatController;
     private IFriendsController friendsController;
     private ulong rendererStateTimeMark;
+    private RectTransform contentParentRT;
 
     public void Initialize(IChatController chatController, IFriendsController friendsController)
     {
@@ -36,6 +37,19 @@ public class ChatHeadGroupView : MonoBehaviour
 
         CommonScriptableObjects.rendererState.OnChange -= RendererState_OnChange;
         CommonScriptableObjects.rendererState.OnChange += RendererState_OnChange;
+    }
+
+    private void Start()
+    {
+        contentParentRT = container.parent as RectTransform;
+        gameObject.SetActive(false);
+    }
+
+    private void Update()
+    {
+        // NOTE: Update is only enabled when SetParentContainerAsDirty is called 
+        DCL.Helpers.Utils.ForceUpdateLayout(contentParentRT);
+        this.enabled = false;
     }
 
     private void FriendsController_OnUpdateFriendship(string id, FriendshipAction action)
@@ -126,7 +140,7 @@ public class ChatHeadGroupView : MonoBehaviour
         }
     }
 
-    internal ChatHeadButton AddChatHead(string userId, ulong timestamp, bool saveStatusInStorage = true)
+    internal ChatHeadButton AddChatHead(string userId, ulong timestamp, bool saveStatusInStorage = true, bool forceLayoutUpdate = true)
     {
         var existingHead = chatHeads.FirstOrDefault(x => x.profile.userId == userId);
 
@@ -146,6 +160,11 @@ public class ChatHeadGroupView : MonoBehaviour
             }
 
             return existingHead;
+        }
+
+        if (!gameObject.activeSelf)
+        {
+            gameObject.SetActive(true);
         }
 
         GameObject prefab = Resources.Load(CHAT_HEAD_PATH) as GameObject;
@@ -180,7 +199,12 @@ public class ChatHeadGroupView : MonoBehaviour
         if (chatHeads.Count > MAX_GROUP_SIZE)
         {
             var lastChatHead = chatHeads[chatHeads.Count - 1];
-            RemoveChatHead(lastChatHead, saveStatusInStorage);
+            RemoveChatHead(lastChatHead, saveStatusInStorage, forceLayoutUpdate: false);
+        }
+
+        if (forceLayoutUpdate)
+        {
+            SetParentContainerAsDirty();
         }
 
         return chatHead;
@@ -192,16 +216,17 @@ public class ChatHeadGroupView : MonoBehaviour
 
         for (int i = 0; i < chatHeadsToRemove.Length; i++)
         {
-            RemoveChatHead(chatHeadsToRemove[i]);
+            RemoveChatHead(chatHeadsToRemove[i], forceLayoutUpdate: false);
         }
+        SetParentContainerAsDirty();
     }
 
-    internal void RemoveChatHead(string userId)
+    internal void RemoveChatHead(string userId, bool forceLayoutUpdate = true)
     {
-        RemoveChatHead(chatHeads.FirstOrDefault(x => x.profile.userId == userId));
+        RemoveChatHead(chatHeads.FirstOrDefault(x => x.profile.userId == userId), true, forceLayoutUpdate);
     }
 
-    internal void RemoveChatHead(ChatHeadButton chatHead, bool saveStatusInStorage = true)
+    internal void RemoveChatHead(ChatHeadButton chatHead, bool saveStatusInStorage = true, bool forceLayoutUpdate = true)
     {
         if (chatHead == null)
             return;
@@ -216,7 +241,7 @@ public class ChatHeadGroupView : MonoBehaviour
         }
         else
         {
-            Destroy(chatHead.gameObject);
+            DestroyChatHead(chatHead.gameObject, forceLayoutUpdate);
         }
 
         chatHeads.Remove(chatHead);
@@ -232,7 +257,7 @@ public class ChatHeadGroupView : MonoBehaviour
     private void Animator_OnWillFinishHide(ShowHideAnimator animator)
     {
         animator.OnWillFinishHide -= Animator_OnWillFinishHide;
-        Destroy(animator.gameObject);
+        DestroyChatHead(animator.gameObject, true);
     }
 
     private void SaveLatestOpenChats()
@@ -253,8 +278,28 @@ public class ChatHeadGroupView : MonoBehaviour
                     continue;
 
                 CommonScriptableObjects.latestOpenChats.Add(item);
-                AddChatHead(item.userId, item.lastTimestamp, false);
+                AddChatHead(item.userId, item.lastTimestamp, false, forceLayoutUpdate: false);
             }
+            SetParentContainerAsDirty();
         }
+    }
+
+    private void DestroyChatHead(GameObject chatHeadGO, bool forceLayoutUpdate)
+    {
+        Destroy(chatHeadGO);
+
+        if (container.childCount <= 1)
+        {
+            gameObject.SetActive(false);
+        }
+        else if (forceLayoutUpdate)
+        {
+            SetParentContainerAsDirty();
+        }
+    }
+
+    private void SetParentContainerAsDirty()
+    {
+        this.enabled = true;
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/ChatHeadGroupView.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/ChatHeadGroupView.cs
@@ -48,7 +48,7 @@ public class ChatHeadGroupView : MonoBehaviour
     private void Update()
     {
         // NOTE: Update is only enabled when SetParentContainerAsDirty is called 
-        DCL.Helpers.Utils.ForceUpdateLayout(contentParentRT);
+        DCL.Helpers.Utils.ForceUpdateLayout(contentParentRT, delayed: true);
         this.enabled = false;
     }
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/Resources/Taskbar.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/Resources/Taskbar.prefab
@@ -76,7 +76,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1745068193824896935}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_UiScaleMode: 1
@@ -98,7 +98,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1745068193824896935}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
@@ -115,7 +115,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1745068193824896935}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1297475563, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Padding:
@@ -241,11 +241,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: Press Enter or click here and start talking
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -387,7 +386,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 4146330243079072463}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -405508275, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Padding:
@@ -461,6 +460,7 @@ GameObject:
   - component: {fileID: 122910220119158566}
   - component: {fileID: 1163524797233769629}
   - component: {fileID: 7246136140831879644}
+  - component: {fileID: 7413513556630383227}
   m_Layer: 5
   m_Name: Chat Heads Container
   m_TagString: Untagged
@@ -484,8 +484,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 0}
+  m_AnchoredPosition: {x: 131, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1163524797233769629
 MonoBehaviour:
@@ -509,7 +509,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 4898883456557843566}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -405508275, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Padding:
@@ -525,6 +525,20 @@ MonoBehaviour:
   m_ChildControlHeight: 0
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
+--- !u!114 &7413513556630383227
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4898883456557843566}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 0
 --- !u!1 &5243503511411348015
 GameObject:
   m_ObjectHideFlags: 0
@@ -582,17 +596,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 5243503511411348015}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 21300000, guid: 24c3c5f961cc64b788832e6bcb64ff7a, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
@@ -602,6 +615,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!95 &3460400505786178648
 Animator:
   serializedVersion: 3
@@ -734,7 +748,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 5619377175013390775}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -405508275, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Padding:
@@ -815,17 +829,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 6367743213003561031}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 21300000, guid: f0a40db225b774307b56e6cfbc73889a, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
@@ -835,6 +848,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &1628654731514149087
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -844,7 +858,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 6367743213003561031}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1679637790, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_IgnoreLayout: 1
@@ -947,17 +961,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 7772005873924984123}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 21300000, guid: 604176a988cdc416ca612d5e95156254, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
@@ -967,6 +980,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &3686269489964235905
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -976,7 +990,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 7772005873924984123}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -1010,8 +1024,6 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!1 &7984381791258128339
 GameObject:
   m_ObjectHideFlags: 0
@@ -1121,17 +1133,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 8012558485580923328}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 21300000, guid: 64b96cebc797f4e75ad10e05ff68466f, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
@@ -1141,6 +1152,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &5681366293077149653
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1150,7 +1162,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 8012558485580923328}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -1195,8 +1207,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!1 &9020917434462224825
 GameObject:
   m_ObjectHideFlags: 0
@@ -1254,17 +1264,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 9020917434462224825}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 21300000, guid: 24c3c5f961cc64b788832e6bcb64ff7a, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
@@ -1274,6 +1283,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!95 &6782242860724703173
 Animator:
   serializedVersion: 3
@@ -1336,6 +1346,193 @@ PrefabInstance:
     - target: {fileID: 2845107033472647055, guid: 2fc88af23bad36741becd2e487a423f4,
         type: 3}
       propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4206135554152958384, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4206135554152958384, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4206135554152958384, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4206135554152958384, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4206135554152958384, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4206135554152958384, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4206135554152958384, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4206135554152958384, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6334302917501517762, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 6334302917501517762, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 6334302917501517762, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6334302917501517762, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 6336046026291867439, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.1764706
+      objectReference: {fileID: 0}
+    - target: {fileID: 6336046026291867439, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0.33333334
+      objectReference: {fileID: 0}
+    - target: {fileID: 6336046026291867439, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: e36f3569fbdef4c609c33f7a1cebace5,
+        type: 3}
+    - target: {fileID: 6336046026291867439, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6336046026291867439, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_Type
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6336046026291867439, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_UseSpriteMesh
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_fontSizeBase
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61,
+        type: 2}
+    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_sharedMaterial
+      value: 
+      objectReference: {fileID: 2100000, guid: cbef7abfd5b4443bf9d5c298a464b5a6, type: 2}
+    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_fontColor.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_fontColor.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_fontColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_fontColor32.rgba
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_text
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_firstOverflowCharacterIndex
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_textInfo.characterCount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_textInfo.spaceCount
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_textInfo.wordCount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_textInfo.lineCount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_textInfo.pageCount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_enableAutoSizing
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_fontSizeMax
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_fontSizeMin
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
+        type: 3}
+      propertyPath: m_enableWordWrapping
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8819543312367979352, guid: 2fc88af23bad36741becd2e487a423f4,
@@ -1443,193 +1640,6 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 6334302917501517762, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 18
-      objectReference: {fileID: 0}
-    - target: {fileID: 6334302917501517762, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 18
-      objectReference: {fileID: 0}
-    - target: {fileID: 6334302917501517762, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -10
-      objectReference: {fileID: 0}
-    - target: {fileID: 6334302917501517762, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 18
-      objectReference: {fileID: 0}
-    - target: {fileID: 4206135554152958384, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4206135554152958384, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4206135554152958384, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4206135554152958384, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4206135554152958384, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4206135554152958384, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: -2
-      objectReference: {fileID: 0}
-    - target: {fileID: 4206135554152958384, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: -2
-      objectReference: {fileID: 0}
-    - target: {fileID: 4206135554152958384, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_fontSize
-      value: 12
-      objectReference: {fileID: 0}
-    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_fontSizeBase
-      value: 12
-      objectReference: {fileID: 0}
-    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_fontAsset
-      value: 
-      objectReference: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61,
-        type: 2}
-    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_sharedMaterial
-      value: 
-      objectReference: {fileID: 2100000, guid: cbef7abfd5b4443bf9d5c298a464b5a6, type: 2}
-    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_fontColor.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_fontColor.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_fontColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_fontColor32.rgba
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_text
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_firstOverflowCharacterIndex
-      value: -1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_textInfo.characterCount
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_textInfo.spaceCount
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_textInfo.wordCount
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_textInfo.lineCount
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_textInfo.pageCount
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_enableAutoSizing
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_fontSizeMax
-      value: 12
-      objectReference: {fileID: 0}
-    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_fontSizeMin
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 8818213553393692271, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_enableWordWrapping
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6336046026291867439, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.1764706
-      objectReference: {fileID: 0}
-    - target: {fileID: 6336046026291867439, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_Color.b
-      value: 0.33333334
-      objectReference: {fileID: 0}
-    - target: {fileID: 6336046026291867439, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: e36f3569fbdef4c609c33f7a1cebace5,
-        type: 3}
-    - target: {fileID: 6336046026291867439, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6336046026291867439, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_Type
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6336046026291867439, guid: 2fc88af23bad36741becd2e487a423f4,
-        type: 3}
-      propertyPath: m_UseSpriteMesh
-      value: 1
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2fc88af23bad36741becd2e487a423f4, type: 3}
 --- !u!224 &1751635272093186199 stripped
@@ -1645,11 +1655,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 4478478436062547217}
     m_Modifications:
-    - target: {fileID: 8022463139147755279, guid: ffadaebc1af107142a4c7fd23524095c,
-        type: 3}
-      propertyPath: m_Name
-      value: UnreadWorldNotificationBadge
-      objectReference: {fileID: 0}
     - target: {fileID: 4429308612254855752, guid: ffadaebc1af107142a4c7fd23524095c,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -1765,21 +1770,6 @@ PrefabInstance:
       propertyPath: m_SizeDelta.y
       value: 18
       objectReference: {fileID: 0}
-    - target: {fileID: 6643461750668719960, guid: ffadaebc1af107142a4c7fd23524095c,
-        type: 3}
-      propertyPath: m_Color.r
-      value: 0.22258809
-      objectReference: {fileID: 0}
-    - target: {fileID: 6643461750668719960, guid: ffadaebc1af107142a4c7fd23524095c,
-        type: 3}
-      propertyPath: m_Color.g
-      value: 0.45996222
-      objectReference: {fileID: 0}
-    - target: {fileID: 6643461750668719960, guid: ffadaebc1af107142a4c7fd23524095c,
-        type: 3}
-      propertyPath: m_Color.b
-      value: 0.7735849
-      objectReference: {fileID: 0}
     - target: {fileID: 5156119195053263761, guid: ffadaebc1af107142a4c7fd23524095c,
         type: 3}
       propertyPath: m_textInfo.characterCount
@@ -1809,6 +1799,26 @@ PrefabInstance:
         type: 3}
       propertyPath: m_fontSizeMax
       value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 6643461750668719960, guid: ffadaebc1af107142a4c7fd23524095c,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.22258809
+      objectReference: {fileID: 0}
+    - target: {fileID: 6643461750668719960, guid: ffadaebc1af107142a4c7fd23524095c,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.45996222
+      objectReference: {fileID: 0}
+    - target: {fileID: 6643461750668719960, guid: ffadaebc1af107142a4c7fd23524095c,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0.7735849
+      objectReference: {fileID: 0}
+    - target: {fileID: 8022463139147755279, guid: ffadaebc1af107142a4c7fd23524095c,
+        type: 3}
+      propertyPath: m_Name
+      value: UnreadWorldNotificationBadge
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ffadaebc1af107142a4c7fd23524095c, type: 3}


### PR DESCRIPTION
This issue make impossible to add new buttons to the taskbar.

<img width="521" alt="Screen Shot 2020-07-29 at 19 42 51" src="https://user-images.githubusercontent.com/4195708/88946407-9b76b780-d265-11ea-8718-fbca2dc247ba.png">


* added content size fitter to the chat heads container
* force container's parent layout to update when content change
* hide container if there is no content to show