### PR TITLE
fix: reconnection issues & realm optimization

### DIFF
--- a/kernel/packages/shared/comms/index.ts
+++ b/kernel/packages/shared/comms/index.ts
@@ -872,6 +872,7 @@ async function doStartCommunications(context: Context) {
     }
   }
 }
+
 function handleReconnectionError() {
   const realm = getRealm(store.getState())
 

--- a/kernel/packages/shared/comms/index.ts
+++ b/kernel/packages/shared/comms/index.ts
@@ -53,7 +53,7 @@ import { Authenticator } from 'dcl-crypto'
 import { getCommsServer, getRealm, getAllCatalystCandidates } from '../dao/selectors'
 import { Realm, LayerUserInfo } from 'shared/dao/types'
 import { Store } from 'redux'
-import { RootState, StoreContainer } from 'shared/store/rootTypes'
+import { RootState } from 'shared/store/rootTypes'
 import { store } from 'shared/store/store'
 import {
   setCatalystRealmCommsStatus,
@@ -71,8 +71,15 @@ import { arrayEquals } from 'atomicHelpers/arrayEquals'
 import { getCommsConfig } from 'shared/meta/selectors'
 import { ensureMetaConfigurationInitialized } from 'shared/meta/index'
 import { ReportFatalError } from 'shared/loading/ReportFatalError'
-import { NEW_LOGIN, UNEXPECTED_ERROR, commsEstablished } from 'shared/loading/types'
+import {
+  NEW_LOGIN,
+  UNEXPECTED_ERROR,
+  commsEstablished,
+  COMMS_COULD_NOT_BE_ESTABLISHED,
+  commsErrorRetrying
+} from 'shared/loading/types'
 import { getIdentity } from 'shared/session'
+import { createLogger } from '../logger'
 
 export type CommsVersion = 'v1' | 'v2'
 export type CommsMode = CommsV1Mode | CommsV2Mode
@@ -101,7 +108,9 @@ type CommsContainer = {
   }
 }
 
-declare const globalThis: StoreContainer & CommsContainer
+declare const globalThis: CommsContainer
+
+const logger = createLogger('comms: ')
 
 export class PeerTrackingInfo {
   public position: Position | null = null
@@ -276,7 +285,7 @@ function ensurePeerTrackingInfo(context: Context, alias: string): PeerTrackingIn
 
 export function processChatMessage(context: Context, fromAlias: string, message: Package<ChatMessage>) {
   const msgId = message.data.id
-  const profile = getProfile(globalThis.globalStore.getState(), getIdentity().address)
+  const profile = getProfile(store.getState(), getIdentity().address)
 
   const peerTrackingInfo = ensurePeerTrackingInfo(context, fromAlias)
   if (!peerTrackingInfo.receivedPublicChatMessages.has(msgId)) {
@@ -304,7 +313,7 @@ export function processChatMessage(context: Context, fromAlias: string, message:
             body: text,
             timestamp: message.time
           }
-          globalThis.globalStore.dispatch(messageReceived(messageEntry))
+          store.dispatch(messageReceived(messageEntry))
         }
       }
     }
@@ -635,7 +644,6 @@ export async function connect(userId: string) {
       }
       case 'v2': {
         await ensureMetaConfigurationInitialized()
-        const store: Store<RootState> = globalThis.globalStore
         const lighthouseUrl = getCommsServer(store.getState())
         const realm = getRealm(store.getState())
         const commsConfig = getCommsConfig(store.getState())
@@ -740,8 +748,42 @@ export async function connect(userId: string) {
 }
 
 export async function startCommunications(context: Context) {
-  const connection = context.worldInstanceConnection!
+  const maxAttemps = 5
+  for (let i = 1; ; ++i) {
+    try {
+      logger.info(`Attempt number ${i}...`)
+      await doStartCommunications(context)
 
+      break
+    } catch (e) {
+      if (e instanceof IdTakenError) {
+        disconnect()
+        ReportFatalError(NEW_LOGIN)
+        throw e
+      } else if (e instanceof ConnectionEstablishmentError) {
+        if (i >= maxAttemps) {
+          // max number of attemps reached => rethrow error
+          logger.info(`Max number of attemps reached (${maxAttemps}), unsuccessful connection`)
+          disconnect()
+          ReportFatalError(COMMS_COULD_NOT_BE_ESTABLISHED)
+          throw e
+        } else {
+          // max number of attempts not reached => continue with loop
+          store.dispatch(commsErrorRetrying(i))
+        }
+      } else {
+        // not a comms issue per se => rethrow error
+        logger.error(`error while trying to establish communications `, e)
+        disconnect()
+        const realm = getRealm(store.getState())
+        store.dispatch(markCatalystRealmConnectionError(realm!))
+      }
+    }
+  }
+}
+
+async function doStartCommunications(context: Context) {
+  const connection = context.worldInstanceConnection!
   try {
     try {
       if (connection instanceof LighthouseWorldInstanceConnection) {
@@ -830,9 +872,7 @@ export async function startCommunications(context: Context) {
     }
   }
 }
-
 function handleReconnectionError() {
-  const store: Store<RootState> = globalThis.globalStore
   const realm = getRealm(store.getState())
 
   if (realm) {
@@ -853,7 +893,6 @@ function handleReconnectionError() {
 }
 
 function handleFullLayer() {
-  const store: Store<RootState> = globalThis.globalStore
   const realm = getRealm(store.getState())
 
   if (realm) {
@@ -911,7 +950,6 @@ export function disconnect() {
 }
 
 export async function fetchLayerUsersParcels(): Promise<ParcelArray[]> {
-  const store: Store<RootState> = globalThis.globalStore
   const realm = getRealm(store.getState())
   const commsUrl = getCommsServer(store.getState())
 

--- a/kernel/packages/shared/comms/sagas.ts
+++ b/kernel/packages/shared/comms/sagas.ts
@@ -2,18 +2,13 @@ import { put, takeEvery, select, call } from 'redux-saga/effects'
 
 import { STATIC_WORLD } from 'config'
 
-import { createLogger } from 'shared/logger'
-import { establishingComms, NEW_LOGIN, COMMS_COULD_NOT_BE_ESTABLISHED, commsErrorRetrying } from 'shared/loading/types'
+import { establishingComms } from 'shared/loading/types'
 import { USER_AUTHENTIFIED } from 'shared/session/actions'
 import { getCurrentIdentity } from 'shared/session/selectors'
 import { setWorldContext } from 'shared/protocol/actions'
-import { ReportFatalError } from 'shared/loading/ReportFatalError'
 import { ensureRealmInitialized } from 'shared/dao/sagas'
 
-import { connect, disconnect } from '.'
-import { IdTakenError, ConnectionEstablishmentError } from './interface/types'
-
-const logger = createLogger('comms: ')
+import { connect } from '.'
 
 export function* commsSaga() {
   yield takeEvery(USER_AUTHENTIFIED, establishCommunications)
@@ -28,41 +23,9 @@ function* establishCommunications() {
 
   const identity = yield select(getCurrentIdentity)
 
-  console['group']('connect#comms')
   yield put(establishingComms())
-  const maxAttemps = 5
-  for (let i = 1; ; ++i) {
-    try {
-      logger.info(`Attempt number ${i}...`)
-      const context = yield connect(identity.address)
-      if (context !== undefined) {
-        yield put(setWorldContext(context))
-      }
-
-      break
-    } catch (e) {
-      if (e instanceof IdTakenError) {
-        disconnect()
-        ReportFatalError(NEW_LOGIN)
-        throw e
-      } else if (e instanceof ConnectionEstablishmentError) {
-        if (i >= maxAttemps) {
-          // max number of attemps reached => rethrow error
-          logger.info(`Max number of attemps reached (${maxAttemps}), unsuccessful connection`)
-          disconnect()
-          ReportFatalError(COMMS_COULD_NOT_BE_ESTABLISHED)
-          throw e
-        } else {
-          // max number of attempts not reached => continue with loop
-          yield put(commsErrorRetrying(i))
-        }
-      } else {
-        // not a comms issue per se => rethrow error
-        logger.error(`error while trying to establish communications `, e)
-        disconnect()
-        throw e
-      }
-    }
+  const context = yield connect(identity.address)
+  if (context !== undefined) {
+    yield put(setWorldContext(context))
   }
-  console['groupEnd']()
 }

--- a/kernel/packages/shared/comms/sagas.ts
+++ b/kernel/packages/shared/comms/sagas.ts
@@ -1,4 +1,4 @@
-import { put, takeEvery, select, call } from 'redux-saga/effects'
+import { put, takeEvery, select, call, takeLatest } from 'redux-saga/effects'
 
 import { STATIC_WORLD } from 'config'
 
@@ -6,12 +6,21 @@ import { establishingComms } from 'shared/loading/types'
 import { USER_AUTHENTIFIED } from 'shared/session/actions'
 import { getCurrentIdentity } from 'shared/session/selectors'
 import { setWorldContext } from 'shared/protocol/actions'
-import { ensureRealmInitialized } from 'shared/dao/sagas'
+import { ensureRealmInitialized, selectRealm } from 'shared/dao/sagas'
+import { getRealm } from 'shared/dao/selectors'
+import { CATALYST_REALMS_SCAN_SUCCESS, setCatalystRealm } from 'shared/dao/actions'
+import { Realm } from 'shared/dao/types'
+import { realmToString } from 'shared/dao/utils/realmToString'
+import { createLogger } from 'shared/logger'
 
 import { connect } from '.'
 
+const DEBUG = false
+const logger = createLogger('comms: ')
+
 export function* commsSaga() {
   yield takeEvery(USER_AUTHENTIFIED, establishCommunications)
+  yield takeLatest(CATALYST_REALMS_SCAN_SUCCESS, changeRealm)
 }
 
 function* establishCommunications() {
@@ -28,4 +37,26 @@ function* establishCommunications() {
   if (context !== undefined) {
     yield put(setWorldContext(context))
   }
+}
+
+function* changeRealm() {
+  const currentRealm: ReturnType<typeof getRealm> = yield select(getRealm)
+  if (!currentRealm) {
+    DEBUG && logger.info(`No realm set, wait for actual DAO initialization`)
+    // if not realm is set => wait for actual dao initialization
+    return
+  }
+
+  const otherRealm = yield call(selectRealm)
+
+  if (!sameRealm(currentRealm, otherRealm)) {
+    logger.info(`Changing realm from ${realmToString(currentRealm)} to ${realmToString(otherRealm)}`)
+    yield put(setCatalystRealm(otherRealm))
+  } else {
+    DEBUG && logger.info(`Realm already set ${realmToString(currentRealm)}`)
+  }
+}
+
+function sameRealm(realm1: Realm, realm2: Realm) {
+  return realm1.catalystName === realm2.catalystName && realm1.layer === realm2.layer
 }

--- a/kernel/packages/shared/dao/actions.ts
+++ b/kernel/packages/shared/dao/actions.ts
@@ -43,3 +43,11 @@ export type MarkCatalystRealmFull = ReturnType<typeof markCatalystRealmFull>
 export const MARK_CATALYST_REALM_CONNECTION_ERROR = 'Mark Catalyst Realm Connection Error'
 export const markCatalystRealmConnectionError = (realm: Realm) => action(MARK_CATALYST_REALM_CONNECTION_ERROR, realm)
 export type MarkCatalystRealmConnectionError = ReturnType<typeof markCatalystRealmConnectionError>
+
+export const CATALYST_REALMS_SCAN_REQUESTED = '[Request] Catalyst Realms scan'
+export const catalystRealmsScanRequested = () => action(CATALYST_REALMS_SCAN_REQUESTED)
+export type CatalystRealmsScanRequested = ReturnType<typeof catalystRealmsScanRequested>
+
+export const CATALYST_REALMS_SCAN_SUCCESS = '[Success] Catalyst Realms scan'
+export const catalystRealmsScanSuccess = () => action(CATALYST_REALMS_SCAN_SUCCESS)
+export type CatalystRealmsScanSuccess = ReturnType<typeof catalystRealmsScanSuccess>

--- a/kernel/packages/shared/profiles/sagas.ts
+++ b/kernel/packages/shared/profiles/sagas.ts
@@ -153,7 +153,6 @@ function* initialProfileLoad() {
   yield call(ensureRealmInitialized)
 
   // initialize profile
-  console['group']('connect#profile')
   const userId = yield select(getCurrentUserId)
   let profile = yield ProfileAsPromise(userId)
 
@@ -200,7 +199,6 @@ function* initialProfileLoad() {
     version: profile.version,
     profile: profileToRendererFormat(profile, identity)
   })
-  console['groupEnd']()
 }
 
 /**

--- a/kernel/packages/shared/session/sagas.ts
+++ b/kernel/packages/shared/session/sagas.ts
@@ -54,8 +54,6 @@ function* initializeTos() {
 }
 
 function* login() {
-  console['group']('connect#login')
-
   let userId: string
   let identity: ExplorerIdentity
 
@@ -93,7 +91,6 @@ function* login() {
       }
     } catch (e) {
       logger.error(e)
-      console['groupEnd']()
       ReportFatalError(AUTH_ERROR_LOGGED_OUT)
       throw e
     }
@@ -116,10 +113,6 @@ function* login() {
 
   logger.log(`User ${userId} logged in`)
 
-  console['groupEnd']()
-
-  console['group']('connect#ethereum')
-
   let net: ETHEREUM_NETWORK = ETHEREUM_NETWORK.MAINNET
   if (WORLD_EXPLORER) {
     net = yield getAppNetwork()
@@ -133,8 +126,6 @@ function* login() {
 
   yield loginCompleted
   yield put(loginCompletedAction())
-
-  console['groupEnd']()
 }
 
 async function checkTldVsNetwork() {


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
This PR comprises of two changes:
- Fixes reconnection strategy for comms initial connection
- Triggers a reconnection whenever the DAO scan is completed to avoid using a cached realm when a better option is available (it still honors the realm configured by the user)