### PR TITLE
feat: fixed canvas resolution

### DIFF
--- a/kernel/packages/shared/renderer/sagas.ts
+++ b/kernel/packages/shared/renderer/sagas.ts
@@ -99,7 +99,7 @@ function* handleMessageFromEngine(
   }
 }
 
-namespace DCL {
+export namespace DCL {
   // This exposes JSEvents emscripten's object
   export let JSEvents: any
 
@@ -116,6 +116,7 @@ namespace DCL {
 // The namespace DCL is exposed to global because the unity template uses it to
 // send the messages
 global['DCL'] = DCL
+;(window as any)['DCL'] = DCL
 
 /** This connects the local game to a native client via WebSocket */
 function initializeUnityEditor(webSocketUrl: string, container: HTMLElement): UnityGame {

--- a/kernel/packages/shared/renderer/sagas.ts
+++ b/kernel/packages/shared/renderer/sagas.ts
@@ -100,9 +100,8 @@ function* handleMessageFromEngine(
 }
 
 namespace DCL {
-
-  // This exposes JSEvents emscripten's object 
-  export let JSEvents:any
+  // This exposes JSEvents emscripten's object
+  export let JSEvents: any
 
   // This function get's called by the engine
   export function EngineStarted() {

--- a/kernel/packages/shared/renderer/sagas.ts
+++ b/kernel/packages/shared/renderer/sagas.ts
@@ -100,6 +100,10 @@ function* handleMessageFromEngine(
 }
 
 namespace DCL {
+
+  // This exposes JSEvents emscripten's object 
+  export let JSEvents:any
+
   // This function get's called by the engine
   export function EngineStarted() {
     globalThis.globalStore.dispatch(engineStarted())

--- a/kernel/packages/unity-interface/BrowserInterface.ts
+++ b/kernel/packages/unity-interface/BrowserInterface.ts
@@ -335,8 +335,8 @@ export class BrowserInterface {
     })
   }
 
-  public SetBaseResolution(data: { baseRes: number }) {
-    unityInterface.SetTargetHeight(data.baseRes)
+  public SetBaseResolution(data: { baseResolution: number }) {
+    unityInterface.SetTargetHeight(data.baseResolution)
   }
 }
 

--- a/kernel/packages/unity-interface/BrowserInterface.ts
+++ b/kernel/packages/unity-interface/BrowserInterface.ts
@@ -335,8 +335,8 @@ export class BrowserInterface {
     })
   }
 
-  public SetBaseResolution(data: { baseRes:number }) {
-    unityInterface.SetTargetHeight( data.baseRes )
+  public SetBaseResolution(data: { baseRes: number }) {
+    unityInterface.SetTargetHeight(data.baseRes)
   }
 }
 

--- a/kernel/packages/unity-interface/BrowserInterface.ts
+++ b/kernel/packages/unity-interface/BrowserInterface.ts
@@ -334,6 +334,10 @@ export class BrowserInterface {
       return defaultLogger.error('FetchHotScenes error', e)
     })
   }
+
+  public SetBaseResolution(data: { baseRes:number }) {
+    unityInterface.SetTargetHeight( data.baseRes )
+  }
 }
 
 export let browserInterface: BrowserInterface = new BrowserInterface()

--- a/kernel/packages/unity-interface/UnityInterface.ts
+++ b/kernel/packages/unity-interface/UnityInterface.ts
@@ -24,9 +24,12 @@ let _gameInstance: any = null
 let originalFillMouseEventData: any
 
 function fillMouseEventDataWrapper(eventStruct: any, e: any, target: any) {
+  let widthRatio = _gameInstance.Module.canvas.widthNative / (window.innerWidth * devicePixelRatio)
+  let heightRatio = _gameInstance.Module.canvas.heightNative / (window.innerHeight * devicePixelRatio)
+
   let eWrapper: any = {
-    clientX: (_gameInstance.Module.canvas.widthNative / _gameInstance.Module.canvas.clientWidth) * e.clientX * 0.8,
-    clientY: (_gameInstance.Module.canvas.heightNative / _gameInstance.Module.canvas.clientHeight) * e.clientY * 0.8,
+    clientX: e.clientX * widthRatio,
+    clientY: e.clientY * heightRatio,
     screenX: e.screenX,
     screenY: e.screenY,
     ctrlKey: e.ctrlKey,
@@ -349,11 +352,12 @@ export class UnityInterface {
   }
 
   private resizeCanvas(module: any) {
-    let innerWidth = window.innerWidth
-    let innerHeight = window.innerHeight
-    let ratio = innerWidth / innerHeight
     let desiredHeight = targetHeight
-    module.setCanvasSize(desiredHeight * ratio, desiredHeight)
+
+    if (module.canvas.height > desiredHeight) {
+      let ratio = desiredHeight / module.canvas.height
+      module.setCanvasSize(module.canvas.width * ratio, module.canvas.height * ratio)
+    }
   }
 }
 

--- a/kernel/packages/unity-interface/UnityInterface.ts
+++ b/kernel/packages/unity-interface/UnityInterface.ts
@@ -46,7 +46,18 @@ function fillMouseEventDataWrapper(eventStruct: any, e: any, target: any) {
   originalFillMouseEventData(eventStruct, eWrapper, target)
 }
 
-export let targetHeight: number = 720
+export let targetHeight: number = 1080
+
+function resizeCanvas(module: any) {
+  if (targetHeight > 2000) {
+    targetHeight = window.innerHeight * devicePixelRatio
+  }
+
+  let desiredHeight = targetHeight
+
+  let ratio = desiredHeight / module.canvas.height
+  module.setCanvasSize(module.canvas.width * ratio, module.canvas.height * ratio)
+}
 
 export class UnityInterface {
   public debug: boolean = false
@@ -54,17 +65,19 @@ export class UnityInterface {
   public Module: any
 
   public SetTargetHeight(height: number): void {
-    if ( targetHeight === height ) {
+    if (targetHeight === height) {
       return
     }
 
-    if ( !this.gameInstance.Module ) {
-      console.log(`Can't change base resolution height to ${height}! Are you running explorer in unity editor or native?`)
+    if (!this.gameInstance.Module) {
+      console.log(
+        `Can't change base resolution height to ${height}! Are you running explorer in unity editor or native?`
+      )
       return
     }
 
     targetHeight = height
-    this.resizeCanvasDelayed(null)
+    window.dispatchEvent(new Event('resize'))
   }
 
   public Init(gameInstance: any): void {
@@ -76,7 +89,7 @@ export class UnityInterface {
     this.Module = this.gameInstance.Module
     _gameInstance = gameInstance
 
-    if (this.Module) {
+    if (this.Module !== undefined) {
       window.addEventListener('resize', this.resizeCanvasDelayed)
       this.resizeCanvasDelayed(null)
       this.waitForFillMouseEventData()
@@ -358,20 +371,9 @@ export class UnityInterface {
   }
 
   private resizeCanvasDelayed(ev: UIEvent | null) {
-    setInterval(this.resizeCanvas, 100, _gameInstance.Module)
-  }
-
-  private resizeCanvas(module: any) {
-    if (targetHeight > 2000) {
-      return // NOTE(Brian): if > 2000, just use native resolution
-    }
-
-    let desiredHeight = targetHeight
-
-    if (module.canvas.height > desiredHeight) {
-      let ratio = desiredHeight / module.canvas.height
-      module.setCanvasSize(module.canvas.width * ratio, module.canvas.height * ratio)
-    }
+    window.setTimeout(() => {
+      resizeCanvas(_gameInstance.Module)
+    }, 100)
   }
 }
 

--- a/kernel/packages/unity-interface/UnityInterface.ts
+++ b/kernel/packages/unity-interface/UnityInterface.ts
@@ -352,6 +352,10 @@ export class UnityInterface {
   }
 
   private resizeCanvas(module: any) {
+    if (targetHeight > 2000) {
+      return //NOTE(Brian): if > 2000, just use native resolution
+    }
+
     let desiredHeight = targetHeight
 
     if (module.canvas.height > desiredHeight) {

--- a/kernel/packages/unity-interface/UnityInterface.ts
+++ b/kernel/packages/unity-interface/UnityInterface.ts
@@ -20,7 +20,7 @@ import { HotSceneInfo } from 'shared/social/hotScenes'
 
 const MINIMAP_CHUNK_SIZE = 100
 
-let _gameInstance:any = null
+let _gameInstance: any = null
 
 export class UnityInterface {
   public debug: boolean = false
@@ -39,18 +39,6 @@ export class UnityInterface {
     window.addEventListener('resize', this.resizeCanvasDelayed)
 
     this.resizeCanvasDelayed(null)
-  }
-
-  private resizeCanvasDelayed(ev: UIEvent | null) {
-    setInterval(this.resizeCanvas, 100, _gameInstance.Module)
-  }
-
-  private resizeCanvas(module:any) {
-    let innerWidth = window.innerWidth
-    let innerHeight = window.innerHeight
-    let ratio = innerWidth / innerHeight
-    let desiredHeight = 720
-    module.setCanvasSize(desiredHeight * ratio, desiredHeight)
   }
 
   public SendGenericMessage(object: string, method: string, payload: string) {
@@ -314,6 +302,18 @@ export class UnityInterface {
 
   public OnBuilderKeyDown(key: string) {
     this.SendBuilderMessage('OnBuilderKeyDown', key)
+  }
+
+  private resizeCanvasDelayed(ev: UIEvent | null) {
+    setInterval(this.resizeCanvas, 100, _gameInstance.Module)
+  }
+
+  private resizeCanvas(module: any) {
+    let innerWidth = window.innerWidth
+    let innerHeight = window.innerHeight
+    let ratio = innerWidth / innerHeight
+    let desiredHeight = 720
+    module.setCanvasSize(desiredHeight * ratio, desiredHeight)
   }
 }
 

--- a/kernel/packages/unity-interface/UnityInterface.ts
+++ b/kernel/packages/unity-interface/UnityInterface.ts
@@ -20,15 +20,37 @@ import { HotSceneInfo } from 'shared/social/hotScenes'
 
 const MINIMAP_CHUNK_SIZE = 100
 
+let _gameInstance:any = null
+
 export class UnityInterface {
   public debug: boolean = false
-  private gameInstance: any
+  public gameInstance: any
+  public Module: any
 
   public Init(gameInstance: any): void {
     if (!WSS_ENABLED) {
       nativeMsgBridge.initNativeMessages(gameInstance)
     }
+
     this.gameInstance = gameInstance
+    this.Module = this.gameInstance.Module
+    _gameInstance = gameInstance
+
+    window.addEventListener('resize', this.resizeCanvasDelayed)
+
+    this.resizeCanvasDelayed(null)
+  }
+
+  private resizeCanvasDelayed(ev: UIEvent | null) {
+    setInterval(this.resizeCanvas, 100, _gameInstance.Module)
+  }
+
+  private resizeCanvas(module:any) {
+    let innerWidth = window.innerWidth
+    let innerHeight = window.innerHeight
+    let ratio = innerWidth / innerHeight
+    let desiredHeight = 720
+    module.setCanvasSize(desiredHeight * ratio, desiredHeight)
   }
 
   public SendGenericMessage(object: string, method: string, payload: string) {

--- a/kernel/packages/unity-interface/UnityInterface.ts
+++ b/kernel/packages/unity-interface/UnityInterface.ts
@@ -353,7 +353,7 @@ export class UnityInterface {
 
   private resizeCanvas(module: any) {
     if (targetHeight > 2000) {
-      return //NOTE(Brian): if > 2000, just use native resolution
+      return // NOTE(Brian): if > 2000, just use native resolution
     }
 
     let desiredHeight = targetHeight

--- a/kernel/packages/unity-interface/UnityInterface.ts
+++ b/kernel/packages/unity-interface/UnityInterface.ts
@@ -17,6 +17,7 @@ import {
 } from 'shared/types'
 import { nativeMsgBridge } from './nativeMessagesBridge'
 import { HotSceneInfo } from 'shared/social/hotScenes'
+import { defaultLogger } from 'shared/logger'
 
 const MINIMAP_CHUNK_SIZE = 100
 
@@ -70,7 +71,8 @@ export class UnityInterface {
     }
 
     if (!this.gameInstance.Module) {
-      console.log(
+
+      defaultLogger.log(
         `Can't change base resolution height to ${height}! Are you running explorer in unity editor or native?`
       )
       return

--- a/kernel/packages/unity-interface/UnityInterface.ts
+++ b/kernel/packages/unity-interface/UnityInterface.ts
@@ -54,6 +54,15 @@ export class UnityInterface {
   public Module: any
 
   public SetTargetHeight(height: number): void {
+    if ( targetHeight === height ) {
+      return
+    }
+
+    if ( !this.gameInstance.Module ) {
+      console.log(`Can't change base resolution height to ${height}! Are you running explorer in unity editor or native?`)
+      return
+    }
+
     targetHeight = height
     this.resizeCanvasDelayed(null)
   }
@@ -67,10 +76,11 @@ export class UnityInterface {
     this.Module = this.gameInstance.Module
     _gameInstance = gameInstance
 
-    window.addEventListener('resize', this.resizeCanvasDelayed)
-
-    this.resizeCanvasDelayed(null)
-    this.waitForFillMouseEventData()
+    if (this.Module) {
+      window.addEventListener('resize', this.resizeCanvasDelayed)
+      this.resizeCanvasDelayed(null)
+      this.waitForFillMouseEventData()
+    }
   }
 
   public waitForFillMouseEventData() {

--- a/unity-client/Assets/Builder/Scripts/DCLBuilderBridge.cs
+++ b/unity-client/Assets/Builder/Scripts/DCLBuilderBridge.cs
@@ -623,7 +623,7 @@ namespace Builder
         {
             DCL.SettingsData.QualitySettings settings = new DCL.SettingsData.QualitySettings()
             {
-                textureQuality = DCL.SettingsData.QualitySettings.TextureQuality.FullRes,
+                baseResolution = DCL.SettingsData.QualitySettings.BaseResolution.BaseRes_1080,
                 antiAliasing = UnityEngine.Rendering.Universal.MsaaQuality._2x,
                 renderScale = 1,
                 shadows = true,

--- a/unity-client/Assets/Plugins/JSFunctions.jslib
+++ b/unity-client/Assets/Plugins/JSFunctions.jslib
@@ -4,6 +4,7 @@
 
 mergeInto(LibraryManager.library, {
   StartDecentraland: function() {
+    window.DCL.JSEvents = JSEvents
     window.DCL.EngineStarted();
   },
   MessageFromEngine: function(type, message) {

--- a/unity-client/Assets/Plugins/JSFunctions.jslib.meta
+++ b/unity-client/Assets/Plugins/JSFunctions.jslib.meta
@@ -5,8 +5,11 @@ PluginImporter:
   serializedVersion: 2
   iconMap: {}
   executionOrder: {}
+  defineConstraints: []
   isPreloaded: 0
   isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
   platformData:
   - first:
       Any: 

--- a/unity-client/Assets/Resources/ScriptableObjects/QualitySettingsData.asset
+++ b/unity-client/Assets/Resources/ScriptableObjects/QualitySettingsData.asset
@@ -15,9 +15,9 @@ MonoBehaviour:
   defaultPresetIndex: 1
   settings:
   - displayName: Basic
-    textureQuality: 1
+    baseResolution: 0
     antiAliasing: 1
-    renderScale: 0.8
+    renderScale: 0.7
     shadows: 0
     softShadows: 0
     shadowResolution: 256
@@ -25,7 +25,7 @@ MonoBehaviour:
     bloom: 0
     colorGrading: 0
   - displayName: Medium
-    textureQuality: 0
+    baseResolution: 1
     antiAliasing: 1
     renderScale: 0.8
     shadows: 1
@@ -35,7 +35,7 @@ MonoBehaviour:
     bloom: 1
     colorGrading: 1
   - displayName: High
-    textureQuality: 0
+    baseResolution: 2
     antiAliasing: 2
     renderScale: 1
     shadows: 1

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsHUD/Resources/SettingsHUD.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsHUD/Resources/SettingsHUD.prefab
@@ -1531,7 +1531,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   qualityPresetSpinBox: {fileID: 8528571613779276393}
-  baseResSpinBox: {fileID: 0}
+  baseResSpinBox: {fileID: 1755520278186876574}
   shadowResSpinBox: {fileID: 8988512653593649854}
   soundToggle: {fileID: 5257412117456053339}
   colorGradingToggle: {fileID: 3218635305569080034}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsHUD/Resources/SettingsHUD.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsHUD/Resources/SettingsHUD.prefab
@@ -90,17 +90,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 55523565219127364}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.078431375}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -1108781214270468041, guid: 68c3f9042241b4936b95bb8c6e3239b6,
     type: 3}
   m_Type: 1
@@ -111,6 +110,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &55691881094959187
 GameObject:
   m_ObjectHideFlags: 0
@@ -165,17 +165,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 55691881094959187}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.1764706, b: 0.33333334, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -1108781214270468041, guid: 68c3f9042241b4936b95bb8c6e3239b6,
     type: 3}
   m_Type: 1
@@ -186,6 +185,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &127145166132631912
 GameObject:
   m_ObjectHideFlags: 0
@@ -243,17 +243,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 127145166132631912}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -289537700610901239, guid: c6b2021a1730e40bbb26382621f0a453,
     type: 3}
   m_Type: 1
@@ -264,6 +263,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &2418106986231966341
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -273,7 +273,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 127145166132631912}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -307,8 +307,6 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!114 &1283848225
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -384,11 +382,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: 0
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -542,11 +539,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: Sound
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -696,17 +692,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 324781612248936819}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -289537700610901239, guid: c6b2021a1730e40bbb26382621f0a453,
     type: 3}
   m_Type: 1
@@ -717,6 +712,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &255916208
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -792,11 +788,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: RENDERING SCALE
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -944,17 +939,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 454239742979340944}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.1764706, b: 0.33333334, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -1108781214270468041, guid: 68c3f9042241b4936b95bb8c6e3239b6,
     type: 3}
   m_Type: 1
@@ -965,6 +959,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &485813445992243791
 GameObject:
   m_ObjectHideFlags: 0
@@ -1055,17 +1050,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 507631409979970607}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.078431375}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -1108781214270468041, guid: 68c3f9042241b4936b95bb8c6e3239b6,
     type: 3}
   m_Type: 1
@@ -1076,6 +1070,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &582568683595626146
 GameObject:
   m_ObjectHideFlags: 0
@@ -1132,17 +1127,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 582568683595626146}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.1764706, b: 0.33333334, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 21300000, guid: a3a66afb0cf6d49da8b0b2b18f7b20d0, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
@@ -1152,6 +1146,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &9057019394916313536
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1161,7 +1156,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 582568683595626146}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -1217,8 +1212,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!1 &813666442621547826
 GameObject:
   m_ObjectHideFlags: 0
@@ -1277,17 +1270,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 813666442621547826}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -289537700610901239, guid: c6b2021a1730e40bbb26382621f0a453,
     type: 3}
   m_Type: 1
@@ -1298,6 +1290,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &4045294040142311067
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1307,7 +1300,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 813666442621547826}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -1341,8 +1334,6 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!114 &1499722873399815798
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1428,17 +1419,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 830286309143222203}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.2, g: 0.2, b: 0.22745098, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 7034423813313189624, guid: fd507e98e14c344e3aec24b937e8af75,
     type: 3}
   m_Type: 0
@@ -1449,6 +1439,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &851296277194168379
 GameObject:
   m_ObjectHideFlags: 0
@@ -1519,7 +1510,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 851296277194168379}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
@@ -1540,7 +1531,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   qualityPresetSpinBox: {fileID: 8528571613779276393}
-  textureResSpinBox: {fileID: 1755520278186876574}
+  baseResSpinBox: {fileID: 0}
   shadowResSpinBox: {fileID: 8988512653593649854}
   soundToggle: {fileID: 5257412117456053339}
   colorGradingToggle: {fileID: 3218635305569080034}
@@ -1611,17 +1602,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 921185696992968264}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -289537700610901239, guid: c6b2021a1730e40bbb26382621f0a453,
     type: 3}
   m_Type: 1
@@ -1632,6 +1622,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &1237483652
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1701,17 +1692,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 1047896674606195576}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.078431375}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -1108781214270468041, guid: 68c3f9042241b4936b95bb8c6e3239b6,
     type: 3}
   m_Type: 1
@@ -1722,6 +1712,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &1291822922001914734
 GameObject:
   m_ObjectHideFlags: 0
@@ -1778,17 +1769,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 1291822922001914734}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -289537700610901239, guid: c6b2021a1730e40bbb26382621f0a453,
     type: 3}
   m_Type: 1
@@ -1799,6 +1789,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &1006178312
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1868,17 +1859,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 1329386392362328242}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.1764706, b: 0.33333334, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -1108781214270468041, guid: 68c3f9042241b4936b95bb8c6e3239b6,
     type: 3}
   m_Type: 1
@@ -1889,6 +1879,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &1359484827620253685
 GameObject:
   m_ObjectHideFlags: 0
@@ -1945,17 +1936,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 1359484827620253685}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -289537700610901239, guid: c6b2021a1730e40bbb26382621f0a453,
     type: 3}
   m_Type: 1
@@ -1966,6 +1956,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &767034402
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2038,17 +2029,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 1681096085663110834}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.9056604, g: 0.9056604, b: 0.9056604, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 21300000, guid: e7a4d1ec2b0e64ed8a62172ed98d7e9b, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
@@ -2058,6 +2048,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &2753986069255063991
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2067,7 +2058,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1681096085663110834}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -2123,8 +2114,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!114 &9087397109600482864
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2198,17 +2187,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 1802137367426154170}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -289537700610901239, guid: c6b2021a1730e40bbb26382621f0a453,
     type: 3}
   m_Type: 1
@@ -2219,6 +2207,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &3359325764951430806
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2228,7 +2217,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1802137367426154170}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -2262,8 +2251,6 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!114 &719208115309638727
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2355,11 +2342,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: 1.0
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -2513,11 +2499,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: ON
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -2671,11 +2656,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: OFF
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -2866,11 +2850,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: ON
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -3020,17 +3003,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 2387246530532513980}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -289537700610901239, guid: c6b2021a1730e40bbb26382621f0a453,
     type: 3}
   m_Type: 1
@@ -3041,6 +3023,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &512448497
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3112,17 +3095,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 2389731016940212704}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -289537700610901239, guid: c6b2021a1730e40bbb26382621f0a453,
     type: 3}
   m_Type: 1
@@ -3133,6 +3115,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &868835142
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3202,17 +3185,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 2424930893463056541}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.2, g: 0.2, b: 0.22745098, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 7034423813313189624, guid: fd507e98e14c344e3aec24b937e8af75,
     type: 3}
   m_Type: 0
@@ -3223,6 +3205,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &2599293015460482845
 GameObject:
   m_ObjectHideFlags: 0
@@ -3388,17 +3371,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 2691171868504435554}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -289537700610901239, guid: c6b2021a1730e40bbb26382621f0a453,
     type: 3}
   m_Type: 1
@@ -3409,6 +3391,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &1193150780
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3515,17 +3498,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 2712465703747417274}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.078431375}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -1108781214270468041, guid: 68c3f9042241b4936b95bb8c6e3239b6,
     type: 3}
   m_Type: 1
@@ -3536,6 +3518,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &2712474291421288326
 GameObject:
   m_ObjectHideFlags: 0
@@ -3596,11 +3579,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: ON
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -3778,7 +3760,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 2767302400350759514}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -113659843, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -3819,8 +3801,6 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.Slider+SliderEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!1 &2780345653779503707
 GameObject:
   m_ObjectHideFlags: 0
@@ -3875,17 +3855,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 2780345653779503707}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.078431375}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -1108781214270468041, guid: 68c3f9042241b4936b95bb8c6e3239b6,
     type: 3}
   m_Type: 1
@@ -3896,6 +3875,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &2787978242960726133
 GameObject:
   m_ObjectHideFlags: 0
@@ -3956,11 +3936,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: SOFT SHADOWS
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -4110,17 +4089,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 2832117303673772636}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -289537700610901239, guid: c6b2021a1730e40bbb26382621f0a453,
     type: 3}
   m_Type: 1
@@ -4131,6 +4109,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &1946794409
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4200,17 +4179,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 3006951611195025072}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0, b: 0.3882353, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 3356905124273276812, guid: 227a07f88949e4a34bd4ffe9b4bfc3a2,
     type: 3}
   m_Type: 1
@@ -4221,6 +4199,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &3185959970585236621
 GameObject:
   m_ObjectHideFlags: 0
@@ -4275,17 +4254,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 3185959970585236621}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0.49019608}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -1108781214270468041, guid: 68c3f9042241b4936b95bb8c6e3239b6,
     type: 3}
   m_Type: 1
@@ -4296,6 +4274,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &3225561354444461324
 GameObject:
   m_ObjectHideFlags: 0
@@ -4394,8 +4373,6 @@ MonoBehaviour:
   onValueChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: SpinBoxPresetted+OnValueChanged, UIHelpers, Version=0.0.0.0, Culture=neutral,
-      PublicKeyToken=null
 --- !u!1 &3294392116061312147
 GameObject:
   m_ObjectHideFlags: 0
@@ -4456,11 +4433,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: DONE
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -4608,17 +4584,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 3331497210994792692}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.2, g: 0.2, b: 0.22745098, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 7034423813313189624, guid: fd507e98e14c344e3aec24b937e8af75,
     type: 3}
   m_Type: 0
@@ -4629,6 +4604,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &3592788961254895189
 GameObject:
   m_ObjectHideFlags: 0
@@ -4677,7 +4653,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 3592788961254895189}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 2109663825, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -4714,8 +4690,6 @@ MonoBehaviour:
   onValueChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.Toggle+ToggleEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   m_IsOn: 1
 --- !u!114 &8114462220636300676
 MonoBehaviour:
@@ -4859,17 +4833,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 3700688252694515661}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.078431375}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -1108781214270468041, guid: 68c3f9042241b4936b95bb8c6e3239b6,
     type: 3}
   m_Type: 1
@@ -4880,6 +4853,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &3808685453050579936
 GameObject:
   m_ObjectHideFlags: 0
@@ -4939,17 +4913,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 3808685453050579936}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 21300000, guid: 6067442b4b5ee49e68ff2720d1aedddd, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
@@ -4959,6 +4932,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &3825091194160015031
 GameObject:
   m_ObjectHideFlags: 0
@@ -5019,11 +4993,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: GENERAL
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -5171,17 +5144,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 3850538031328863685}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.2, g: 0.2, b: 0.22745098, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 7034423813313189624, guid: fd507e98e14c344e3aec24b937e8af75,
     type: 3}
   m_Type: 0
@@ -5192,6 +5164,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &3874466767489152994
 GameObject:
   m_ObjectHideFlags: 0
@@ -5252,11 +5225,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: Basic
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -5398,7 +5370,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 4047436424187406078}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 2109663825, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -5435,8 +5407,6 @@ MonoBehaviour:
   onValueChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.Toggle+ToggleEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   m_IsOn: 1
 --- !u!114 &2812198542793630734
 MonoBehaviour:
@@ -5512,11 +5482,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: BLOOM
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -5676,8 +5645,6 @@ MonoBehaviour:
   onValueChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: SpinBoxPresetted+OnValueChanged, UIHelpers, Version=0.0.0.0, Culture=neutral,
-      PublicKeyToken=null
 --- !u!1 &4171367125799450014
 GameObject:
   m_ObjectHideFlags: 0
@@ -5734,17 +5701,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 4171367125799450014}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -289537700610901239, guid: c6b2021a1730e40bbb26382621f0a453,
     type: 3}
   m_Type: 1
@@ -5755,6 +5721,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &1957485370
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5824,17 +5791,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 4193966263461780902}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.1764706, b: 0.33333334, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -1108781214270468041, guid: 68c3f9042241b4936b95bb8c6e3239b6,
     type: 3}
   m_Type: 1
@@ -5845,6 +5811,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &4196299855106027335
 GameObject:
   m_ObjectHideFlags: 0
@@ -5930,7 +5897,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 4358594550214670189}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 2109663825, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -5967,8 +5934,6 @@ MonoBehaviour:
   onValueChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.Toggle+ToggleEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   m_IsOn: 0
 --- !u!114 &7243179010034562305
 MonoBehaviour:
@@ -6045,11 +6010,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: OFF
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -6191,7 +6155,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 4478668969954265669}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 2109663825, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -6228,8 +6192,6 @@ MonoBehaviour:
   onValueChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.Toggle+ToggleEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   m_IsOn: 1
 --- !u!114 &6702207611458349222
 MonoBehaviour:
@@ -6299,17 +6261,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 4538264455226914665}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.1764706, b: 0.33333334, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -1108781214270468041, guid: 68c3f9042241b4936b95bb8c6e3239b6,
     type: 3}
   m_Type: 1
@@ -6320,6 +6281,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &4633727294829471964
 GameObject:
   m_ObjectHideFlags: 0
@@ -6374,17 +6336,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 4633727294829471964}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.078431375}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -1108781214270468041, guid: 68c3f9042241b4936b95bb8c6e3239b6,
     type: 3}
   m_Type: 1
@@ -6395,6 +6356,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &4747736708912872040
 GameObject:
   m_ObjectHideFlags: 0
@@ -6453,17 +6415,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 4747736708912872040}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -289537700610901239, guid: c6b2021a1730e40bbb26382621f0a453,
     type: 3}
   m_Type: 1
@@ -6474,6 +6435,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &7211025621305926835
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6483,7 +6445,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 4747736708912872040}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -6517,8 +6479,6 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!114 &9183213968000119711
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6604,17 +6564,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 4799733724167739924}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.2, g: 0.2, b: 0.22745098, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 7034423813313189624, guid: fd507e98e14c344e3aec24b937e8af75,
     type: 3}
   m_Type: 0
@@ -6625,6 +6584,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &4881303800799335724
 GameObject:
   m_ObjectHideFlags: 0
@@ -6673,7 +6633,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 4881303800799335724}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 2109663825, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -6710,8 +6670,6 @@ MonoBehaviour:
   onValueChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.Toggle+ToggleEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   m_IsOn: 1
 --- !u!114 &8151220192830900983
 MonoBehaviour:
@@ -6781,17 +6739,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 5032506270117638535}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0, b: 0.3882353, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 3356905124273276812, guid: 227a07f88949e4a34bd4ffe9b4bfc3a2,
     type: 3}
   m_Type: 1
@@ -6802,6 +6759,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &5046264943934778358
 GameObject:
   m_ObjectHideFlags: 0
@@ -6858,17 +6816,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 5046264943934778358}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -289537700610901239, guid: c6b2021a1730e40bbb26382621f0a453,
     type: 3}
   m_Type: 1
@@ -6879,6 +6836,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &1364317252
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6954,11 +6912,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: ANTI-ALIASING
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -7112,11 +7069,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: ON
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -7323,17 +7279,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 5291931919771712396}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -289537700610901239, guid: c6b2021a1730e40bbb26382621f0a453,
     type: 3}
   m_Type: 1
@@ -7344,6 +7299,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &9196844728797876251
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7353,7 +7309,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 5291931919771712396}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -7387,8 +7343,6 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!114 &729428751
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7464,11 +7418,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: 256
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -7622,11 +7575,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: Settings
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -7774,17 +7726,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 5450446080754555979}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.1764706, b: 0.33333334, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -1108781214270468041, guid: 68c3f9042241b4936b95bb8c6e3239b6,
     type: 3}
   m_Type: 1
@@ -7795,6 +7746,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &5534395856956910234
 GameObject:
   m_ObjectHideFlags: 0
@@ -7889,17 +7841,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 5536576054995997515}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -289537700610901239, guid: c6b2021a1730e40bbb26382621f0a453,
     type: 3}
   m_Type: 1
@@ -7910,6 +7861,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &5767988554575048145
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7919,7 +7871,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 5536576054995997515}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -7953,8 +7905,6 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!114 &3827331910370202982
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8046,11 +7996,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: Players Moderation
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: c0f2e4affe3f2438d9042ca1db45764f, type: 2}
@@ -8204,11 +8153,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: COLOR GRADING
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -8395,17 +8343,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 5851289774421921301}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -289537700610901239, guid: c6b2021a1730e40bbb26382621f0a453,
     type: 3}
   m_Type: 1
@@ -8416,6 +8363,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &2085722324
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8516,7 +8464,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 6220115971320945187}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -113659843, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -8557,8 +8505,6 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.Slider+SliderEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!1 &6243670894477728396
 GameObject:
   m_ObjectHideFlags: 0
@@ -8607,7 +8553,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 6243670894477728396}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 2109663825, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -8644,8 +8590,6 @@ MonoBehaviour:
   onValueChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.Toggle+ToggleEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   m_IsOn: 1
 --- !u!114 &7401460056358862189
 MonoBehaviour:
@@ -8721,11 +8665,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: SHADOW
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -8875,17 +8818,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 6319017270304317721}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -289537700610901239, guid: c6b2021a1730e40bbb26382621f0a453,
     type: 3}
   m_Type: 1
@@ -8896,6 +8838,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &2083475739
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8995,7 +8938,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 6383964814392464805}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -113659843, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -9036,8 +8979,6 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.Slider+SliderEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!1 &6440427499198514267
 GameObject:
   m_ObjectHideFlags: 0
@@ -9086,7 +9027,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 6440427499198514267}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 2109663825, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -9123,8 +9064,6 @@ MonoBehaviour:
   onValueChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.Toggle+ToggleEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   m_IsOn: 0
 --- !u!114 &3492478774971658978
 MonoBehaviour:
@@ -9212,7 +9151,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 6498655820486328905}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_UiScaleMode: 1
@@ -9234,7 +9173,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 6498655820486328905}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
@@ -9314,11 +9253,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: ON
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -9472,11 +9410,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: 0
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -9624,17 +9561,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 6569194446374460553}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.078431375}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -1108781214270468041, guid: 68c3f9042241b4936b95bb8c6e3239b6,
     type: 3}
   m_Type: 1
@@ -9645,6 +9581,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &6623835670503921786
 GameObject:
   m_ObjectHideFlags: 0
@@ -9693,7 +9630,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 6623835670503921786}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 2109663825, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -9730,8 +9667,6 @@ MonoBehaviour:
   onValueChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.Toggle+ToggleEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   m_IsOn: 1
 --- !u!114 &6375045102031456374
 MonoBehaviour:
@@ -9801,17 +9736,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 6636245586041926516}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0.49019608}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -1108781214270468041, guid: 68c3f9042241b4936b95bb8c6e3239b6,
     type: 3}
   m_Type: 1
@@ -9822,6 +9756,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &6724851797245449190
 GameObject:
   m_ObjectHideFlags: 0
@@ -9882,11 +9817,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: GRAPHICS QUALITY
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -10040,11 +9974,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: Medium
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -10192,17 +10125,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 6943472270556294779}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.2, g: 0.2, b: 0.22745098, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 7034423813313189624, guid: fd507e98e14c344e3aec24b937e8af75,
     type: 3}
   m_Type: 0
@@ -10213,6 +10145,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &6966791964694467538
 GameObject:
   m_ObjectHideFlags: 0
@@ -10261,7 +10194,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 6966791964694467538}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -113659843, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -10302,8 +10235,6 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.Slider+SliderEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
 --- !u!1 &7096692695379579470
 GameObject:
   m_ObjectHideFlags: 0
@@ -10364,12 +10295,11 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_text: TEXTURE RESOLUTION
+  m_text: BASE RESOLUTION
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
   m_sharedMaterial: {fileID: -6892909264025736228, guid: 26b03903800224f718b64e9afbc91b61,
@@ -10439,7 +10369,7 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0.46817017}
   m_textInfo:
     textComponent: {fileID: 7995742500303865753}
-    characterCount: 18
+    characterCount: 15
     spriteCount: 0
     spaceCount: 1
     wordCount: 2
@@ -10558,11 +10488,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: OFF
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -10712,17 +10641,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 7188058084100074751}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -289537700610901239, guid: c6b2021a1730e40bbb26382621f0a453,
     type: 3}
   m_Type: 1
@@ -10733,6 +10661,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &858949984
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -10808,11 +10737,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: ADVANCED
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -10966,11 +10894,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: SHADOW RESOLUTION
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -11112,7 +11039,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 7453095871334388546}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -405508275, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Padding:
@@ -11182,17 +11109,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 7563670603967591318}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.1764706, b: 0.33333334, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -1108781214270468041, guid: 68c3f9042241b4936b95bb8c6e3239b6,
     type: 3}
   m_Type: 1
@@ -11203,6 +11129,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &7656603970560744930
 GameObject:
   m_ObjectHideFlags: 0
@@ -11263,12 +11190,11 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_text: Full Resolution
+  m_text: Match 720p
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
   m_sharedMaterial: {fileID: -6892909264025736228, guid: 26b03903800224f718b64e9afbc91b61,
@@ -11338,7 +11264,7 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0.46817017}
   m_textInfo:
     textComponent: {fileID: 4577359464310573081}
-    characterCount: 15
+    characterCount: 10
     spriteCount: 0
     spaceCount: 1
     wordCount: 2
@@ -11421,11 +11347,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: Key bindings
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: c0f2e4affe3f2438d9042ca1db45764f, type: 2}
@@ -11574,17 +11499,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 7714050804149696899}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -131390822890367112, guid: 607bb3a0be6f94088977f57354ec95b9,
     type: 3}
   m_Type: 0
@@ -11595,6 +11519,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &8706670563725164795
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -11604,7 +11529,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 7714050804149696899}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1679637790, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_IgnoreLayout: 0
@@ -11712,11 +11637,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: OFF
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -11864,17 +11788,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 8003597563260032217}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.1764706, b: 0.33333334, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -1108781214270468041, guid: 68c3f9042241b4936b95bb8c6e3239b6,
     type: 3}
   m_Type: 1
@@ -11885,6 +11808,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &8105266719113735891
 GameObject:
   m_ObjectHideFlags: 0
@@ -11975,17 +11899,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 8157791294429895584}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.078431375}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -1108781214270468041, guid: 68c3f9042241b4936b95bb8c6e3239b6,
     type: 3}
   m_Type: 1
@@ -11996,6 +11919,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &8158604383651933892
 GameObject:
   m_ObjectHideFlags: 0
@@ -12050,17 +11974,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 8158604383651933892}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.1764706, b: 0.33333334, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -1108781214270468041, guid: 68c3f9042241b4936b95bb8c6e3239b6,
     type: 3}
   m_Type: 1
@@ -12071,6 +11994,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &8364449934863326309
 GameObject:
   m_ObjectHideFlags: 0
@@ -12244,11 +12168,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: OFF
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -12402,11 +12325,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: 'DRAW DISTANCE
 
 '
@@ -12562,11 +12484,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: 'MOUSE SENSITIVITY
 
 '
@@ -12753,17 +12674,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 8683371989255988128}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0.49019608}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -1108781214270468041, guid: 68c3f9042241b4936b95bb8c6e3239b6,
     type: 3}
   m_Type: 1
@@ -12774,6 +12694,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &8970586516094381607
 GameObject:
   m_ObjectHideFlags: 0
@@ -12785,7 +12706,7 @@ GameObject:
   - component: {fileID: 5479964593668586314}
   - component: {fileID: 1755520278186876574}
   m_Layer: 5
-  m_Name: SpinBoxTextureResolution
+  m_Name: SpinBoxBaseResolution
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -12830,15 +12751,14 @@ MonoBehaviour:
   increaseButton: {fileID: 7211025621305926835}
   decreaseButton: {fileID: 4045294040142311067}
   labels:
-  - Full Resolution
-  - Half Resolution
+  - Match 720p
+  - Match 1080p
+  - Unlimited
   startingValue: 0
   loop: 0
   onValueChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: SpinBoxPresetted+OnValueChanged, UIHelpers, Version=0.0.0.0, Culture=neutral,
-      PublicKeyToken=null
 --- !u!1 &8971261579329471998
 GameObject:
   m_ObjectHideFlags: 0
@@ -12899,11 +12819,10 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: OFF
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
@@ -13051,17 +12970,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 8993852277762028468}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0, b: 0.3882353, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 3356905124273276812, guid: 227a07f88949e4a34bd4ffe9b4bfc3a2,
     type: 3}
   m_Type: 1
@@ -13072,6 +12990,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &9101157973253599486
 GameObject:
   m_ObjectHideFlags: 0
@@ -13126,17 +13045,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 9101157973253599486}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.8627451}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 3356905124273276812, guid: 227a07f88949e4a34bd4ffe9b4bfc3a2,
     type: 3}
   m_Type: 1
@@ -13147,6 +13065,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &9141079458602309697
 GameObject:
   m_ObjectHideFlags: 0
@@ -13201,17 +13120,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 9141079458602309697}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 21300000, guid: 62bd3ddb5cddf43a2a8f7bd6125b37b4, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
@@ -13221,6 +13139,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &9159735932050961674
 GameObject:
   m_ObjectHideFlags: 0
@@ -13277,17 +13196,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 9159735932050961674}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: -289537700610901239, guid: c6b2021a1730e40bbb26382621f0a453,
     type: 3}
   m_Type: 1
@@ -13298,6 +13216,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!114 &678239183
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsHUD/SettingsGeneralView.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsHUD/SettingsGeneralView.cs
@@ -11,7 +11,7 @@ namespace DCL.SettingsHUD
         public const string TEXT_OFF = "OFF";
 
         public SpinBoxPresetted qualityPresetSpinBox = null;
-        public SpinBoxPresetted textureResSpinBox = null;
+        public SpinBoxPresetted baseResSpinBox = null;
         public SpinBoxPresetted shadowResSpinBox = null;
         public Toggle soundToggle = null;
         public Toggle colorGradingToggle = null;
@@ -46,9 +46,9 @@ namespace DCL.SettingsHUD
                 shouldSetAsCustom = false;
             });
 
-            textureResSpinBox.onValueChanged.AddListener(value =>
+            baseResSpinBox.onValueChanged.AddListener(value =>
             {
-                tempQualitySetting.textureQuality = (DCL.SettingsData.QualitySettings.TextureQuality)value;
+                tempQualitySetting.baseResolution = (DCL.SettingsData.QualitySettings.BaseResolution)value;
                 shouldSetAsCustom = true;
                 isDirty = true;
             });
@@ -198,7 +198,7 @@ namespace DCL.SettingsHUD
 
         void UpdateQualitySettings()
         {
-            textureResSpinBox.value = (int)tempQualitySetting.textureQuality;
+            baseResSpinBox.value = (int)tempQualitySetting.baseResolution;
             shadowResSpinBox.value = (int)Mathf.Log((int)tempQualitySetting.shadowResolution, 2) - 8;
             soundToggle.isOn = tempGeneralSetting.sfxVolume > 0 ? true : false;
             colorGradingToggle.isOn = tempQualitySetting.colorGrading;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsHUD/Test/SettingsHUDControllerShould.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsHUD/Test/SettingsHUDControllerShould.cs
@@ -20,7 +20,7 @@ namespace Tests
 
             testQualitySettings = new QualitySettings()
             {
-                textureQuality = QualitySettings.TextureQuality.HalfRes,
+                baseResolution = QualitySettings.BaseResolution.BaseRes_1080,
                 antiAliasing = UnityEngine.Rendering.Universal.MsaaQuality._4x,
                 renderScale = 0.1f,
                 shadows = false,
@@ -61,7 +61,7 @@ namespace Tests
         {
             SettingsGeneralView generalContent = controller.view.GetComponentInChildren<SettingsGeneralView>();
             Assert.IsTrue(generalContent.qualityPresetSpinBox.label == SettingsGeneralView.TEXT_QUALITY_CUSTOM, "qualityPresetSpinBox missmatch");
-            Assert.IsTrue(generalContent.textureResSpinBox.value == 1, "textureResSpinBox missmatch");
+            Assert.IsTrue(generalContent.baseResSpinBox.value == 1, "textureResSpinBox missmatch");
             Assert.IsTrue(generalContent.shadowResSpinBox.label == "512", "shadowResSpinBox missmatch");
             Assert.IsTrue(generalContent.soundToggle.isOn == false, "soundToggle missmatch");
             Assert.IsTrue(generalContent.colorGradingToggle.isOn == true, "colorGradingToggle missmatch");

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputController.cs
@@ -15,6 +15,7 @@ public enum DCLAction_Trigger
     ToggleWorldChat = 122,
     ToggleUIVisibility = 123,
     ToggleControlsHud = 124,
+    ToggleSettings = 125,
 
     OpenExpressions = 200,
     Expression_Wave = 201,
@@ -184,7 +185,7 @@ public class InputController : MonoBehaviour
 
 public static class InputProcessor
 {
-    private static readonly KeyCode[] MODIFIER_KEYS = new[] { KeyCode.LeftControl, KeyCode.LeftAlt, KeyCode.LeftShift };
+    private static readonly KeyCode[] MODIFIER_KEYS = new[] {KeyCode.LeftControl, KeyCode.LeftAlt, KeyCode.LeftShift};
 
     [Flags]
     public enum Modifier
@@ -265,8 +266,8 @@ public static class InputProcessor
 
     public static bool IsModifierSet(Modifier modifiers, Modifier value)
     {
-        int flagsValue = (int)modifiers;
-        int flagValue = (int)value;
+        int flagsValue = (int) modifiers;
+        int flagValue = (int) value;
 
         return (flagsValue & flagValue) != 0;
     }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Settings/QualitySettingsData.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Settings/QualitySettingsData.cs
@@ -14,26 +14,40 @@ namespace DCL.SettingsData
             get { return settings[i]; }
         }
 
-        public int Length { get { return settings.Length; } }
-        public QualitySettings defaultPreset { get { return settings[defaultPresetIndex]; } }
-        public int defaultIndex { get { return defaultPresetIndex; } }
+        public int Length
+        {
+            get { return settings.Length; }
+        }
+
+        public QualitySettings defaultPreset
+        {
+            get { return settings[defaultPresetIndex]; }
+        }
+
+        public int defaultIndex
+        {
+            get { return defaultPresetIndex; }
+        }
     }
 
     [Serializable]
     public struct QualitySettings
     {
-        public enum TextureQuality { FullRes = 0, HalfRes, QuarterRes, EighthRes }
+        public enum BaseResolution
+        {
+            BaseRes_720,
+            BaseRes_1080,
+            BaseRes_Unlimited
+        }
 
         public string displayName;
 
-        [Tooltip("Base texture level")]
-        public TextureQuality textureQuality;
+        [Tooltip("Base resolution level")] public BaseResolution baseResolution;
 
         [Tooltip("Controls the global anti aliasing setting")]
         public UnityEngine.Rendering.Universal.MsaaQuality antiAliasing;
 
-        [Tooltip("Scales the camera render target allowing the game to render at a resolution different than native resolution. UI is always rendered at native resolution")]
-        [Range(0.5f, 1)]
+        [Tooltip("Scales the camera render target allowing the game to render at a resolution different than native resolution. UI is always rendered at native resolution")] [Range(0.5f, 1)]
         public float renderScale;
 
         [Tooltip("If enabled the main light can be a shadow casting light")]
@@ -45,19 +59,17 @@ namespace DCL.SettingsData
         [Tooltip("Resolution of the main light shadowmap texture")]
         public UnityEngine.Rendering.Universal.ShadowResolution shadowResolution;
 
-        [Tooltip("Camera Far")]
-        [Range(40, 100)]
+        [Tooltip("Camera Far")] [Range(40, 100)]
         public float cameraDrawDistance;
 
-        [Tooltip("Enable bloom post process")]
-        public bool bloom;
+        [Tooltip("Enable bloom post process")] public bool bloom;
 
         [Tooltip("Enable color grading post process")]
         public bool colorGrading;
 
         public bool Equals(QualitySettings otherSetting)
         {
-            if (textureQuality != otherSetting.textureQuality) return false;
+            if (baseResolution != otherSetting.baseResolution) return false;
             if (antiAliasing != otherSetting.antiAliasing) return false;
             if (renderScale != otherSetting.renderScale) return false;
             if (shadows != otherSetting.shadows) return false;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/QualitySettingsController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/QualitySettingsController.cs
@@ -1,8 +1,10 @@
 using Cinemachine;
 using System.Reflection;
+using DCL.Interface;
 using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.Universal;
+using QualitySettings = DCL.SettingsData.QualitySettings;
 using UnitySettings = UnityEngine.QualitySettings;
 
 namespace DCL.SettingsController
@@ -46,9 +48,24 @@ namespace DCL.SettingsController
             Settings.i.OnQualitySettingsChanged -= ApplyQualitySettings;
         }
 
-        void ApplyQualitySettings(SettingsData.QualitySettings qualitySettings)
+        void ApplyQualitySettings(QualitySettings qualitySettings)
         {
-            UnitySettings.masterTextureLimit = (int) qualitySettings.textureQuality;
+#if !UNITY_EDITOR
+            switch (qualitySettings.baseResolution)
+            {
+                case QualitySettings.BaseResolution.BaseRes_720:
+                    WebInterface.SetBaseResolution(720);
+                    break;
+                case QualitySettings.BaseResolution.BaseRes_1080:
+                    WebInterface.SetBaseResolution(1080);
+                    break;
+                case QualitySettings.BaseResolution.BaseRes_Unlimited:
+                    WebInterface.SetBaseResolution(9999);
+                    break;
+            }
+#else
+            Debug.Log("This setting is only applicable in WASM build!");
+#endif
 
             if (lightweightRenderPipelineAsset)
             {
@@ -78,6 +95,7 @@ namespace DCL.SettingsController
                 {
                     bloom.active = qualitySettings.bloom;
                 }
+
                 Tonemapping toneMapping;
                 if (postProcessVolume.profile.TryGet<Tonemapping>(out toneMapping))
                 {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/QualitySettingsController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/QualitySettingsController.cs
@@ -50,7 +50,6 @@ namespace DCL.SettingsController
 
         void ApplyQualitySettings(QualitySettings qualitySettings)
         {
-#if !UNITY_EDITOR
             switch (qualitySettings.baseResolution)
             {
                 case QualitySettings.BaseResolution.BaseRes_720:
@@ -63,9 +62,6 @@ namespace DCL.SettingsController
                     WebInterface.SetBaseResolution(9999);
                     break;
             }
-#else
-            Debug.Log("This setting is only applicable in WASM build!");
-#endif
 
             if (lightweightRenderPipelineAsset)
             {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/QualitySettingsController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/QualitySettingsController.cs
@@ -23,7 +23,7 @@ namespace DCL.SettingsController
         public CinemachineFreeLook thirdPersonCamera = null;
         public CinemachineVirtualCamera firstPersonCamera = null;
 
-        void Awake()
+        void Start()
         {
             if (lightweightRenderPipelineAsset == null)
             {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SettingsControllers.asmdef
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/SettingsControllers.asmdef
@@ -5,7 +5,8 @@
         "GUID:15fc0a57446b3144c949da3e2b9737a9",
         "GUID:301149363e31a4bdaa1943465a825c8e",
         "GUID:b1087c5731ff68448a0a9c625bb7e52d",
-        "GUID:df380645f10b7bc4b97d4f5eb6303d95"
+        "GUID:df380645f10b7bc4b97d4f5eb6303d95",
+        "GUID:4973650d2444c4561a15d50f24d91cd9"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/Tests/GeneralSettingsShould.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/Tests/GeneralSettingsShould.cs
@@ -34,7 +34,7 @@ namespace Tests
 
             testQualitySettings = new QualitySettings()
             {
-                textureQuality = QualitySettings.TextureQuality.HalfRes,
+                baseResolution = QualitySettings.BaseResolution.BaseRes_720,
                 antiAliasing = MsaaQuality._4x,
                 renderScale = 0.1f,
                 shadows = false,
@@ -55,12 +55,6 @@ namespace Tests
             DCL.Settings.i.ApplyQualitySettings(testQualitySettings);
             DCL.Settings.i.ApplyGeneralSettings(testGeneralSettings);
         }
-
-        // public IEnumerator InitScene()
-        // {
-        //     yield return InitUnityScene("InitialScene");
-        //     Object.DestroyImmediate(DCL.WSSController.i.gameObject);
-        // }
 
         protected override IEnumerator TearDown()
         {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -268,6 +268,12 @@ namespace DCL.Interface
             public int y;
         };
 
+        [System.Serializable]
+        public class BaseResolution
+        {
+            public int baseResolution;
+        };
+
 
         //-----------------------------------------------------
         // Raycast
@@ -479,6 +485,7 @@ namespace DCL.Interface
         private static JumpInPayload jumpInPayload = new JumpInPayload();
         private static GotoEvent gotoEvent = new GotoEvent();
         private static SendChatMessageEvent sendChatMessageEvent = new SendChatMessageEvent();
+        private static BaseResolution baseResEvent = new BaseResolution();
 
         public static void SendSceneEvent<T>(string sceneId, string eventType, T payload)
         {
@@ -902,6 +909,12 @@ namespace DCL.Interface
         public static void FetchHotScenes()
         {
             SendMessage("FetchHotScenes");
+        }
+
+        public static void SetBaseResolution(int resolution)
+        {
+            baseResEvent.baseResolution = resolution;
+            SendMessage("SetBaseResolution", baseResEvent);
         }
     }
 }

--- a/unity-client/ProjectSettings/QualitySettings.asset
+++ b/unity-client/ProjectSettings/QualitySettings.asset
@@ -21,7 +21,7 @@ QualitySettings:
     skinWeights: 4
     textureQuality: 0
     anisotropicTextures: 2
-    antiAliasing: 0
+    antiAliasing: 2
     softParticles: 0
     softVegetation: 0
     realtimeReflectionProbes: 0


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
This PR adds the ability of setting a fixed canvas base resolution, configurable from client settings. The available options are:

* Match 720p -> Will try to set canvas size with a maximum height of 720 pixels regardless of the O.S. resolution.
* Match 1080p -> Will try to set canvas size with a maximum height of 1080 pixels regardless of the O.S. resolution.
* Unlimited -> Will try to set canvas size that matches O.S. resolution.

# Why? <!-- what is this PR? -->
On retina or 4K, we were setting canvas sizes that matched very big resolutions by default, slowing performance to a crawl. This PR should enable big performance improvements on 4K/retina monitors with intel GPUs.