### PR TITLE
fix: Added retry for catalyst requests

### DIFF
--- a/kernel/package-lock.json
+++ b/kernel/package-lock.json
@@ -2862,9 +2862,9 @@
       }
     },
     "decentraland-renderer": {
-      "version": "1.8.27220",
-      "resolved": "https://registry.npmjs.org/decentraland-renderer/-/decentraland-renderer-1.8.27220.tgz",
-      "integrity": "sha512-dt6CNsqWyemLYHh7u6RcO9uUKRwOIOtQ56p2cNPe3nlnGRinXaxBg23FlT4oX4Z+7BgYXlMQ+Wkj+IdiRJfBlQ=="
+      "version": "1.8.29271",
+      "resolved": "https://registry.npmjs.org/decentraland-renderer/-/decentraland-renderer-1.8.29271.tgz",
+      "integrity": "sha512-qD9vMxjdAZfdD2XRsZs5Ys1MTjI8rll2+cVKBqujnKe9yXLZn56GouVnAaDhIV5EVE4oBPuptQujGOCClcfr6A=="
     },
     "decentraland-rpc": {
       "version": "3.1.8",

--- a/kernel/package.json
+++ b/kernel/package.json
@@ -102,7 +102,7 @@
     "dcl-crypto": "^2.2.0",
     "dcl-social-client": "^1.3.10",
     "decentraland-katalyst-peer": "0.2.15",
-    "decentraland-renderer": "^1.8.27220",
+    "decentraland-renderer": "^1.8.29271",
     "decentraland-rpc": "^3.1.8",
     "devtools-protocol": "0.0.615714",
     "eth-connect": "^4.0.1",

--- a/kernel/packages/atomicHelpers/retry.ts
+++ b/kernel/packages/atomicHelpers/retry.ts
@@ -1,0 +1,20 @@
+export async function retry<T>(
+  operation: () => Promise<T>,
+  attempts: number = 5,
+  onEachFailure: (e: any) => void = (e) => {}
+): Promise<T> {
+  let error: any = undefined
+  let attempt = 0
+
+  while (attempt < attempts) {
+    attempt++
+    try {
+      return await operation()
+    } catch (e) {
+      onEachFailure(e)
+      error = e
+    }
+  }
+
+  throw error
+}

--- a/kernel/packages/atomicHelpers/retry.ts
+++ b/kernel/packages/atomicHelpers/retry.ts
@@ -1,7 +1,9 @@
 export async function retry<T>(
   operation: () => Promise<T>,
   attempts: number = 5,
-  onEachFailure: (e: any) => void = (e) => {}
+  onEachFailure: (e: any) => void = (e) => {
+    // Nothing
+  }
 ): Promise<T> {
   let error: any = undefined
   let attempt = 0

--- a/kernel/packages/config/contracts.ts
+++ b/kernel/packages/config/contracts.ts
@@ -86,7 +86,10 @@ export const contracts = {
     'PMOuttathisworldCollection': '0x75a3752579dc2d63ca229eebbe3537fbabf85a12',
     'DgtbleHeadspaceCollection': '0x574f64ac2e7215cba9752b85fc73030f35166bc0',
     'WonderzoneMeteorchaserCollection': '0x34ed0aa248f60f54dd32fbc9883d6137a491f4f3',
-    'BurningStore': '0x0822d44c2e2f96d4cccad80610134861802b2cca'
+    'BurningStore': '0x0822d44c2e2f96d4cccad80610134861802b2cca',
+    'BaseList': '0x21b6EFf834d7cc8c12A5Ec924939aa521F0FE83F',
+    'POIAllowListProxy': '0x0ef15a1c7a49429a36cb46d4da8c53119242b54e',
+    'NameDenyListProxy': '0x0c4c90a4f29872a2e9ef4c4be3d419792bca9a36'
   },
   'kovan': {
     'MANAToken': '0x230fc362413d9e862326c2c7084610a5a2fdf78a',

--- a/kernel/packages/shared/dao/sagas.ts
+++ b/kernel/packages/shared/dao/sagas.ts
@@ -33,6 +33,8 @@ import { getAddedServers, getContentWhitelist } from 'shared/meta/selectors'
 import { getAllCatalystCandidates, isRealmInitialized } from './selectors'
 import { saveToLocalStorage, getFromLocalStorage } from '../../atomicHelpers/localStorage'
 import defaultLogger from '../logger'
+import { ReportFatalError } from 'shared/loading/ReportFatalError'
+import { CATALYST_COULD_NOT_LOAD } from 'shared/loading/types'
 
 const CACHE_KEY = 'realm'
 const CATALYST_CANDIDATES_KEY = CACHE_KEY + '-' + SET_CATALYST_CANDIDATES
@@ -85,7 +87,12 @@ function* loadCatalystRealms() {
 
     // if no realm was selected, then do the whole initialization dance
     if (!realm) {
-      yield call(initializeCatalystCandidates)
+      try {
+        yield call(initializeCatalystCandidates)
+      } catch (e) {
+        ReportFatalError(CATALYST_COULD_NOT_LOAD)
+        throw e
+      }
 
       realm = yield call(selectRealm)
     }

--- a/kernel/packages/shared/loading/types.ts
+++ b/kernel/packages/shared/loading/types.ts
@@ -81,6 +81,8 @@ export const COMMS_ERROR_RETRYING = 'Communications channel error (will retry)'
 export const commsErrorRetrying = (attempt: number) => action(COMMS_ERROR_RETRYING, attempt)
 export const COMMS_COULD_NOT_BE_ESTABLISHED = 'Communications channel error'
 export const commsCouldNotBeEstablished = () => action(COMMS_COULD_NOT_BE_ESTABLISHED)
+export const CATALYST_COULD_NOT_LOAD = 'Catalysts Contract could not be queried'
+export const catalystCouldNotLoad = () => action(CATALYST_COULD_NOT_LOAD)
 export const MOBILE_NOT_SUPPORTED = 'Mobile is not supported'
 export const mobileNotSupported = () => action(MOBILE_NOT_SUPPORTED)
 export const NEW_LOGIN = 'New login'
@@ -109,6 +111,7 @@ export const ExecutionLifecycleNotifications = {
   failedFetchingUnity,
   commsErrorRetrying,
   commsCouldNotBeEstablished,
+  catalystCouldNotLoad,
   newLogin,
   networkMismatch
 }
@@ -135,6 +138,7 @@ export type ExecutionLifecycleEvent =
   | typeof FAILED_FETCHING_UNITY
   | typeof COMMS_ERROR_RETRYING
   | typeof COMMS_COULD_NOT_BE_ESTABLISHED
+  | typeof CATALYST_COULD_NOT_LOAD
   | typeof NEW_LOGIN
   | typeof NETWORK_MISMATCH
 
@@ -160,6 +164,7 @@ export const ExecutionLifecycleEventsList: ExecutionLifecycleEvent[] = [
   COMMS_ERROR_RETRYING,
   MOBILE_NOT_SUPPORTED,
   COMMS_COULD_NOT_BE_ESTABLISHED,
+  CATALYST_COULD_NOT_LOAD,
   NEW_LOGIN,
   NETWORK_MISMATCH
 ]

--- a/kernel/packages/shared/store/metricSaga.ts
+++ b/kernel/packages/shared/store/metricSaga.ts
@@ -26,7 +26,8 @@ import {
   COMMS_COULD_NOT_BE_ESTABLISHED,
   MOBILE_NOT_SUPPORTED,
   NOT_INVITED,
-  NEW_LOGIN
+  NEW_LOGIN,
+  CATALYST_COULD_NOT_LOAD
 } from '../loading/types'
 
 const trackingEvents: Record<ExecutionLifecycleEvent, string> = {
@@ -53,13 +54,14 @@ const trackingEvents: Record<ExecutionLifecycleEvent, string> = {
   [FAILED_FETCHING_UNITY]: 'error_fetchengine',
   [COMMS_ERROR_RETRYING]: 'error_comms_',
   [COMMS_COULD_NOT_BE_ESTABLISHED]: 'error_comms_failed',
+  [CATALYST_COULD_NOT_LOAD]: 'error_catalyst_loading',
   [MOBILE_NOT_SUPPORTED]: 'unsupported_mobile',
   [NOT_INVITED]: 'error_not_invited'
 }
 
 export function* metricSaga() {
   for (const event of ExecutionLifecycleEventsList) {
-    yield takeEvery(event, action => {
+    yield takeEvery(event, (action) => {
       const _action: any = action
       queueTrackingEvent('lifecycle event', toTrackingEvent(event, _action.payload))
     })


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->
We've observed some flakyness in requests that are made against the ethereum network using web3, resulting in the loading process stopping suddenly.

In order to try and avoid the flakyness, this PR adds retry functionality to requests made to query the Catalyst contract.

Hopefully, this mostly fixes the following error that sometimes appears in the console:
![image](https://user-images.githubusercontent.com/2048532/89819501-f17b1300-db21-11ea-84d4-24c3084a7a05.png)



