### PR TITLE
fix: scene's ui rendering over client's ui

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIScreenSpace/UIScreenSpace.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIScreenSpace/UIScreenSpace.cs
@@ -134,6 +134,8 @@ namespace DCL.Components
             }
             else
             {
+                canvas.sortingOrder = -1;
+
                 // "Constrained" panel mask (to avoid rendering parcels UI on the viewport's top 10%)
                 GameObject constrainedPanel = new GameObject("ConstrainedPanel");
                 constrainedPanel.AddComponent<RectMask2D>();


### PR DESCRIPTION
Explicitly set canvas' sortingOrder instead of depending on it default value. It was set to -1 just in case but setting it to 0 also works.

BEFORE: https://play.decentraland.org/?position=-55%2C1 or https://play.decentraland.zone/?ENV=org&position=-55%2C1
TEST LINK: https://play.decentraland.zone/branch/fix/scene-ui-over-dcl/index.html?ENV=org&position=-55%2C1

NOTE: Can also be reproduced opening the "controls" HUD (C key)
THE ISSUE
<img width="502" alt="Screen Shot 2020-08-13 at 14 54 56" src="https://user-images.githubusercontent.com/4195708/90170078-de608100-dd75-11ea-952e-c30f8d19e38e.png">
