### PR TITLE
fix: animation cull issues

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/RendereableAssetLoadHelper.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/RendereableAssetLoadHelper.cs
@@ -104,7 +104,9 @@ namespace DCL.Components
 
         public void Unload()
         {
-            Environment.i.cullingController.RemoveRenderersFromGameObject(this.loadedAsset);
+            if (this.loadedAsset != null)
+                Environment.i.cullingController.RemoveRenderersFromGameObject(this.loadedAsset);
+
             AssetPromiseKeeper_GLTF.i.Forget(gltfPromise);
             AssetPromiseKeeper_AB_GameObject.i.Forget(abPromise);
         }
@@ -192,7 +194,14 @@ namespace DCL.Components
             }
 
             this.loadedAsset = loadedAsset.container;
-            Environment.i.cullingController.AddRenderersFromGameObject(this.loadedAsset);
+
+            var renderers = loadedAsset.container.GetComponentsInChildren<Renderer>(true);
+
+            if (loadedAsset.hasAnimation)
+                Environment.i.cullingController.AddAnimatedRenderers(renderers);
+            else
+                Environment.i.cullingController.AddRenderers(renderers);
+
             OnSuccess?.Invoke(loadedAsset.container);
             ClearEvents();
         }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/RendereableAssetLoadHelper.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/RendereableAssetLoadHelper.cs
@@ -104,6 +104,7 @@ namespace DCL.Components
 
         public void Unload()
         {
+            Environment.i.cullingController.RemoveRenderersFromGameObject(this.loadedAsset);
             AssetPromiseKeeper_GLTF.i.Forget(gltfPromise);
             AssetPromiseKeeper_AB_GameObject.i.Forget(abPromise);
         }
@@ -191,6 +192,7 @@ namespace DCL.Components
             }
 
             this.loadedAsset = loadedAsset.container;
+            Environment.i.cullingController.AddRenderersFromGameObject(this.loadedAsset);
             OnSuccess?.Invoke(loadedAsset.container);
             ClearEvents();
         }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager.meta
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager.meta
@@ -1,3 +1,3 @@
 ﻿fileFormatVersion: 2
-guid: acbd583ff60d4463b807f27a5a1c2c3a
-timeCreated: 1597783005
+guid: 0ca85b86101e4961976c28212ffa087e
+timeCreated: 1598481788

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/AssetPromise_AB_GameObject.cs
@@ -140,16 +140,18 @@ namespace DCL
                     break;
 
                 GameObject assetBundleModelGO = UnityEngine.Object.Instantiate(goList[i], asset.container.transform);
-                var list = new List<Renderer>(assetBundleModelGO.GetComponentsInChildren<Renderer>(true));
+
+                List<Renderer> renderers = new List<Renderer>(assetBundleModelGO.GetComponentsInChildren<Renderer>(true));
 
                 //NOTE(Brian): Renderers are enabled in settings.ApplyAfterLoad
-                yield return MaterialCachingHelper.Process(list, enableRenderers: false, settings.cachingFlags);
+                yield return MaterialCachingHelper.Process(renderers, enableRenderers: false, settings.cachingFlags);
 
                 var animators = assetBundleModelGO.GetComponentsInChildren<Animation>(true);
 
                 for (int animIndex = 0; animIndex < animators.Length; animIndex++)
                 {
                     animators[animIndex].cullingType = AnimationCullingType.BasedOnRenderers;
+                    asset.hasAnimation = true;
                 }
 
 #if UNITY_EDITOR

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/Asset_AB_GameObject.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB_GameObject/Asset_AB_GameObject.cs
@@ -8,11 +8,10 @@ namespace DCL
     {
         internal AssetPromise_AB ownerPromise;
         public override GameObject container { get; set; }
-        public bool isInstantiated;
+        public override bool hasAnimation { get; set; }
 
         public Asset_AB_GameObject()
         {
-            isInstantiated = false;
             container = new GameObject("AB Container");
             // Hide gameobject until it's been correctly processed, otherwise it flashes at 0,0,0
             container.transform.position = EnvironmentSettings.MORDOR;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/Asset.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Common/Asset.cs
@@ -5,6 +5,7 @@ namespace DCL
     public abstract class Asset_WithPoolableContainer : Asset
     {
         public abstract GameObject container { get; set; }
+        public abstract bool hasAnimation { get; set; }
     }
 
     /// <summary>

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/AssetPromise_GLTF.cs
@@ -1,4 +1,5 @@
 using DCL.Helpers;
+using UnityEngine;
 using UnityGLTF;
 
 namespace DCL
@@ -35,6 +36,7 @@ namespace DCL
         protected override void OnAfterLoadOrReuse()
         {
             settings.ApplyAfterLoad(asset.container.transform);
+            asset.hasAnimation = asset.container.GetComponentsInChildren<Animation>() != null;
         }
 
         public override object GetId()

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Asset_GLTF.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/GLTF/Asset_GLTF.cs
@@ -7,9 +7,10 @@ namespace DCL
     public class Asset_GLTF : Asset_WithPoolableContainer
     {
         public override GameObject container { get; set; }
+        public override bool hasAnimation { get; set; }
+
         public string name;
         public bool visible = true;
-
         Coroutine showCoroutine;
 
         public Asset_GLTF()

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Rendering/CullingController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Rendering/CullingController.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace DCL
+{
+    /// <summary>
+    /// CullingController is in charge of handling all the specific renderer culling tasks.
+    /// List of responsibilities include:
+    ///     - Handling animation culling setting depending on distance
+    ///     - Any LOD related tasks 
+    /// </summary>
+    public class CullingController
+    {
+        private RendererTracker animationCullingTracker;
+        private Dictionary<Renderer, Animation> animatorsCache = new Dictionary<Renderer, Animation>();
+
+        public CullingController(Transform playerTransform)
+        {
+            animationCullingTracker = new RendererTracker(playerTransform, Camera.main, 20f);
+            animationCullingTracker.OnRendererChangeState += AnimationCullingTracker_OnChangeState;
+        }
+
+        public void AddRenderer(Renderer r)
+        {
+            if (r is SkinnedMeshRenderer)
+                animationCullingTracker.AddRenderer(r);
+        }
+
+        public void RemoveRenderer(Renderer r)
+        {
+            if (r is SkinnedMeshRenderer)
+                animationCullingTracker.RemoveRenderer(r);
+        }
+
+        public void AddRenderers(Renderer[] rs)
+        {
+            for (int i = 0; i < rs.Length; i++)
+            {
+                AddRenderer(rs[i]);
+            }
+        }
+
+        public void RemoveRenderers(Renderer[] rs)
+        {
+            for (int i = 0; i < rs.Length; i++)
+            {
+                RemoveRenderer(rs[i]);
+            }
+        }
+
+        public void AddRenderersFromGameObject(GameObject go)
+        {
+            var rs = go.GetComponentsInChildren<Renderer>(true);
+            AddRenderers(rs);
+        }
+
+        public void RemoveRenderersFromGameObject(GameObject go)
+        {
+            var rs = go.GetComponentsInChildren<Renderer>(true);
+            RemoveRenderers(rs);
+        }
+
+        private void AnimationCullingTracker_OnChangeState(Renderer r, CullingGroupEvent e)
+        {
+            if (!animatorsCache.ContainsKey(r))
+            {
+                var anim = r.GetComponentInParent<Animation>();
+                animatorsCache[r] = anim;
+            }
+
+            animatorsCache[r].cullingType = e.currentDistance == 0 ? AnimationCullingType.AlwaysAnimate : AnimationCullingType.BasedOnRenderers;
+        }
+    }
+}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Rendering/CullingController.cs.meta
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Rendering/CullingController.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 169d84f9eb164dfb9e4875cd943b03af
+timeCreated: 1598483475

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Rendering/RendererTracker.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Rendering/RendererTracker.cs
@@ -1,0 +1,78 @@
+﻿using System.Collections.Generic;
+using UnityEditor.Experimental.TerrainAPI;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+namespace DCL
+{
+    public class RendererTracker
+    {
+        private Dictionary<Renderer, int> rendererToIndex = new Dictionary<Renderer, int>();
+        private Dictionary<int, Renderer> indexToRenderer = new Dictionary<int, Renderer>();
+
+        BoundingSphere[] boundingSpheres = new BoundingSphere[10000];
+        private int boundingSpheresSize = 0;
+        private CullingGroup group;
+
+        public event System.Action<Renderer, CullingGroupEvent> OnRendererChangeState;
+
+        public void AddRenderer(Renderer r)
+        {
+            int index = boundingSpheresSize;
+            var bounds = r.bounds;
+            boundingSpheres[index] = new BoundingSphere(bounds.center, bounds.size.magnitude);
+            boundingSpheresSize++;
+
+            indexToRenderer.Add(index, r);
+            rendererToIndex.Add(r, index);
+            this.group.SetBoundingSphereCount(boundingSpheresSize);
+        }
+
+        public void RemoveRenderer(Renderer r)
+        {
+            int index = rendererToIndex[r];
+
+            indexToRenderer.Remove(index);
+            rendererToIndex.Remove(r);
+
+            CullingGroup.EraseSwapBack(index, boundingSpheres, ref boundingSpheresSize);
+            this.group.SetBoundingSphereCount(boundingSpheresSize);
+        }
+
+        public void AddRenderersFromGameObject(GameObject go)
+        {
+            var rs = go.GetComponentsInChildren<Renderer>(true);
+
+            for (int i = 0; i < rs.Length; i++)
+            {
+                AddRenderer(rs[i]);
+            }
+        }
+
+        public void RemoveRenderersFromGameObject(GameObject go)
+        {
+            var rs = go.GetComponentsInChildren<Renderer>(true);
+
+            for (int i = 0; i < rs.Length; i++)
+            {
+                RemoveRenderer(rs[i]);
+            }
+        }
+
+        public RendererTracker(Transform referencePoint, Camera camera, float distanceLimit)
+        {
+            group = new CullingGroup();
+            group.targetCamera = camera;
+            group.SetBoundingSpheres(boundingSpheres);
+            group.SetBoundingDistances(new[] {distanceLimit, float.PositiveInfinity});
+            group.SetDistanceReferencePoint(referencePoint);
+            group.SetBoundingSphereCount(0);
+            group.onStateChanged += OnStateChanged;
+        }
+
+        private void OnStateChanged(CullingGroupEvent sphere)
+        {
+            OnRendererChangeState?.Invoke(indexToRenderer[sphere.index], sphere);
+        }
+    }
+}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Rendering/RendererTracker.cs.meta
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Rendering/RendererTracker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5ac307a0b3c40c040905692790e83311
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Environment.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Environment.cs
@@ -1,10 +1,13 @@
-﻿namespace DCL
+﻿using UnityEngine;
+
+namespace DCL
 {
     public class Environment
     {
         public static readonly Environment i = new Environment();
 
         public readonly MessagingControllersManager messagingControllersManager;
+        public readonly CullingController cullingController;
 
         /*
          * TODO: Continue moving static instances to this class. Each static instance should be converted to a local instance inside this class.
@@ -19,6 +22,7 @@
         private Environment()
         {
             messagingControllersManager = new MessagingControllersManager();
+            cullingController = new CullingController(DCLCharacterController.i.transform);
         }
 
         public void Initialize(IMessageProcessHandler messageHandler)

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Environment.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Environment.cs
@@ -1,8 +1,9 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 namespace DCL
 {
-    public class Environment
+    public class Environment : IDisposable
     {
         public static readonly Environment i = new Environment();
 
@@ -33,8 +34,12 @@ namespace DCL
         public void Restart(IMessageProcessHandler messageHandler)
         {
             messagingControllersManager.Cleanup();
-
             this.Initialize(messageHandler);
+        }
+
+        public void Dispose()
+        {
+            cullingController.Dispose();
         }
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
@@ -975,7 +975,6 @@ namespace DCL
         private Vector2Int sortAuxiliaryVector = new Vector2Int(EnvironmentSettings.MORDOR_SCALAR, EnvironmentSettings.MORDOR_SCALAR);
 
 
-
         public const string EMPTY_GO_POOL_NAME = "Empty";
 
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
@@ -121,6 +121,7 @@ namespace DCL
             CommonScriptableObjects.rendererState.OnChange -= OnRenderingStateChange;
             DCLCharacterController.OnCharacterMoved -= SetPositionDirty;
             ParcelScene.parcelScenesCleaner.Stop();
+            Environment.i.Dispose();
         }
 
 


### PR DESCRIPTION
fixes: https://github.com/decentraland/explorer/issues/1217

- fix: When using the elevator going to the air trolley ride (or whatever that is) if you are not looking down, the elevator would never start.
- fix: If you get near any avatar, and the avatar is on the edge of the screen, you can see it going to pose T.
- fix: If you get near the scarface zeppelin in genesis plaza and face the opposite direction, you can see how the shadow stops.

The fix works by deactivating the animation culling (this means set it to `AlwaysAnimate`) when you get less than 20 meters of distance with relation to the closest point of the animated renderer bounds.

Also, this PR introduces the `CullingController` and `RendererTracker` systems that use the optimized `CullingGroup` Unity class. They will be useful when we implement small object culling for exteriors.

- [X] Basic systems implementation
- [X] Working fix
- [ ] Unit tests