### PR TITLE
fix: Circle-CI build apparently needs a new dependency to be installed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,10 @@ jobs:
     steps:
       - <<: *attach_root
       - run:
+          name: Install Puppeteer dependencies
+          command: |
+            sudo apt-get -y -qq install libxss1
+      - run:
           name: Get the hash of source files
           command: |
             find packages -type f \( -iname \*.ts -o -iname \*.tsx -o -iname \*.json -o -iname \*.proto -o -iname \*.sh \) \( -exec md5sum "$PWD"/{} \; \) | sort > ../.kernelsources-checksum


### PR DESCRIPTION
Our CI build is now broken. It seems something updated automatically and now we need to install a new dependency to run Puppeteer: `libxss1`