### PR TITLE
fix: avoid undefined name on SDK getUserData

### DIFF
--- a/kernel/packages/shared/apis/UserIdentity.ts
+++ b/kernel/packages/shared/apis/UserIdentity.ts
@@ -3,6 +3,7 @@ import { registerAPI, exposeMethod } from 'decentraland-rpc/lib/host'
 import { UserData } from 'shared/types'
 import { getCurrentUser } from 'shared/comms/peers'
 import { getIdentity } from 'shared/session'
+import { calculateDisplayName } from '../profiles/transformations/processServerProfile'
 
 import { ExposableAPI } from './ExposableAPI'
 
@@ -37,7 +38,7 @@ export class UserIdentity extends ExposableAPI implements IUserIdentity {
     if (!user || !user.profile || !user.userId) return null
 
     return {
-      displayName: user.profile.name,
+      displayName: calculateDisplayName(user.userId, user.profile),
       publicKey: identity.hasConnectedWeb3 ? user.userId : null,
       hasConnectedWeb3: !!identity.hasConnectedWeb3,
       userId: user.userId

--- a/kernel/packages/shared/profiles/transformations/processServerProfile.ts
+++ b/kernel/packages/shared/profiles/transformations/processServerProfile.ts
@@ -25,8 +25,12 @@ export function noExclusiveMismatches(inventory: WearableId[]) {
     return wearableId.startsWith('dcl://base-avatars') || inventory.indexOf(wearableId) !== -1
   }
 }
+
+export function calculateDisplayName(userId: string, profile: any): string {
+  return profile.name || 'Guest-' + userId.substr(2, 6)
+}
 export function processServerProfile(userId: string, receivedProfile: any): Profile {
-  const name = receivedProfile.name || 'Guest-' + userId.substr(2, 6)
+  const name = calculateDisplayName(userId, receivedProfile)
   const wearables = receivedProfile.avatar.wearables
     .map(fixWearableIds)
     .filter(dropDeprecatedWearables)


### PR DESCRIPTION
We are going a step forward into handling profiles consistently, whether they are other users' profiles, or our own.

In this case, we are defaulting to a `Guest-` name, if one is not defined