### PR TITLE
fix: upload visual test artifacts to CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,7 @@ jobs:
           key: unity-tests-{{ checksum "../.unitysources-checksum" }}
           paths:
             - /tmp/explorer/unity-client/testlog/log.txt
+            - /tmp/explorer/unity-client/TestResources/VisualTests/CurrentTestImages/*.png
       - store_artifacts:
           name: Store test result as artifacts
           path: /tmp/explorer/unity-client/testlog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,10 +117,11 @@ jobs:
             - /tmp/explorer/unity-client/testlog/log.txt
             - /tmp/explorer/unity-client/TestResources/VisualTests/CurrentTestImages/*.png
       - store_artifacts:
-          name: Store test result as artifacts
-          paths:
-            - /tmp/explorer/unity-client/testlog
-            - /tmp/explorer/unity-client/TestResources/VisualTests/CurrentTestImages
+          name: Store tests result as artifacts
+          path: /tmp/explorer/unity-client/testlog
+      - store_artifacts:
+          name: Store visual tests result as artifacts
+          path: /tmp/explorer/unity-client/TestResources/VisualTests/CurrentTestImages
 
   build-unity:
     <<: *working_directory_unity

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,9 @@ jobs:
             - /tmp/explorer/unity-client/TestResources/VisualTests/CurrentTestImages/*.png
       - store_artifacts:
           name: Store test result as artifacts
-          path: /tmp/explorer/unity-client/testlog
+          paths:
+            - /tmp/explorer/unity-client/testlog
+            - /tmp/explorer/unity-client/TestResources/VisualTests/CurrentTestImages
 
   build-unity:
     <<: *working_directory_unity

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIContainer/Tests/UIContainerRectVisualTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIContainer/Tests/UIContainerRectVisualTests.cs
@@ -29,7 +29,7 @@ public class UIContainerRectVisualTests : UIVisualTestsBase
         {
             parentComponent = screenSpaceId,
             color = Color.green,
-            width = new UIValue(50f, UIValue.Unit.PERCENT),
+            width = new UIValue(40f, UIValue.Unit.PERCENT),
             height = new UIValue(50f, UIValue.Unit.PERCENT)
         }, mainContainerId);
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIContainer/Tests/UIContainerRectVisualTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIContainer/Tests/UIContainerRectVisualTests.cs
@@ -29,7 +29,7 @@ public class UIContainerRectVisualTests : UIVisualTestsBase
         {
             parentComponent = screenSpaceId,
             color = Color.green,
-            width = new UIValue(40f, UIValue.Unit.PERCENT),
+            width = new UIValue(50f, UIValue.Unit.PERCENT),
             height = new UIValue(50f, UIValue.Unit.PERCENT)
         }, mainContainerId);
 


### PR DESCRIPTION
For better test debugging, this PR adds to CircleCI the visual test results as additional artifacts:

![image](https://user-images.githubusercontent.com/6875814/91904274-0a876780-ec7b-11ea-9730-0e3411caa5a2.png)
