### PR TITLE
fix: avoid rotating the player if no camera target is set

### DIFF
--- a/kernel/packages/shared/apis/RestrictedActionModule.ts
+++ b/kernel/packages/shared/apis/RestrictedActionModule.ts
@@ -62,6 +62,6 @@ export class RestrictedActionModule extends ExposableAPI implements IRestrictedA
       defaultLogger.error('Error: Player is not inside of scene', lastPlayerPosition)
       return
     }
-    unityInterface.Teleport({ position, cameraTarget })
+    unityInterface.Teleport({ position, cameraTarget }, false)
   }
 }

--- a/kernel/packages/unity-interface/UnityInterface.ts
+++ b/kernel/packages/unity-interface/UnityInterface.ts
@@ -147,7 +147,9 @@ export class UnityInterface {
 
     TeleportController.ensureTeleportAnimation()
     this.gameInstance.SendMessage('CharacterController', 'Teleport', JSON.stringify({ x, y: theY, z }))
-    this.gameInstance.SendMessage('CameraController', 'SetRotation', JSON.stringify({ x, y: theY, z, cameraTarget }))
+    if (cameraTarget) {
+      this.gameInstance.SendMessage('CameraController', 'SetRotation', JSON.stringify({ x, y: theY, z, cameraTarget }))
+    }
   }
 
   /** Tells the engine which scenes to load */

--- a/kernel/packages/unity-interface/UnityInterface.ts
+++ b/kernel/packages/unity-interface/UnityInterface.ts
@@ -142,12 +142,12 @@ export class UnityInterface {
 
   /** Sends the camera position & target to the engine */
 
-  public Teleport({ position: { x, y, z }, cameraTarget }: InstancedSpawnPoint) {
+  public Teleport({ position: { x, y, z }, cameraTarget }: InstancedSpawnPoint, rotateIfTargetIsNotSet: boolean = true) {
     const theY = y <= 0 ? 2 : y
 
     TeleportController.ensureTeleportAnimation()
     this.gameInstance.SendMessage('CharacterController', 'Teleport', JSON.stringify({ x, y: theY, z }))
-    if (cameraTarget) {
+    if (cameraTarget || rotateIfTargetIsNotSet) {
       this.gameInstance.SendMessage('CameraController', 'SetRotation', JSON.stringify({ x, y: theY, z, cameraTarget }))
     }
   }

--- a/kernel/test/unit/RestrictedActionModule.test.tsx
+++ b/kernel/test/unit/RestrictedActionModule.test.tsx
@@ -15,7 +15,7 @@ describe('RestrictedActionModule tests', () => {
       expose: sinon.stub(),
       notify: sinon.stub(),
       on: sinon.stub(),
-      getAPIInstance(name): any {}
+      getAPIInstance(name): any { }
     }
 
     const mockLastPlayerPosition = (inside: boolean = true) => {
@@ -61,7 +61,7 @@ describe('RestrictedActionModule tests', () => {
         .mock(unityInterface)
         .expects('Teleport')
         .once()
-        .withExactArgs({ position: { x: 8, y: 0, z: 1624 }, cameraTarget: undefined })
+        .withExactArgs({ position: { x: 8, y: 0, z: 1624 }, cameraTarget: undefined }, false)
 
       const module = new RestrictedActionModule(options)
 


### PR DESCRIPTION
Previously, we used to rotate the camera, even if no target was set, when teleporting the player.

Now, we keep this behaviour when the player teleports into a scene. But now, when using the method `movePlayerTo`, we maintain the same rotation if no `camera target` is set.