### PR TITLE
chore: modifications in HotScenesController test

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HotScenesController/AssemblyInfo.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HotScenesController/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("HotScenesControllerTests")]

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HotScenesController/AssemblyInfo.cs.meta
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HotScenesController/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a69b5cd1db9a4e489894ca493843485
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HotScenesController/HotScenesController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HotScenesController/HotScenesController.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using DCL.Helpers;
 using UnityEngine;
 
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("HotScenesControllerTests")]
-
 public class HotScenesController : MonoBehaviour
 {
     public static HotScenesController i { get; private set; }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HotScenesController/Tests/HotScenesControllerTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HotScenesController/Tests/HotScenesControllerTests.cs
@@ -10,7 +10,7 @@ public class HotScenesControllerTests : TestsBase
     [UnityTest]
     public IEnumerator HotScenesControllerShouldParseJsonCorrectly()
     {
-        var controller = new HotScenesController();
+        var controller = HotScenesController.i;
 
         var hotSceneList = GetTestHotSceneList();
 


### PR DESCRIPTION
- Test was creating a new instance of `HotScenesController` using `new` keyword and was prompting a warning cause `HotScenesController` inherits from `MonoBehaviour` 
plus this didn't make any sense cause `HotScenesController` is a singleton.

- Added `AssemblyInfo` file
