### PR TITLE
fix: enable web3 when exporting scenes

### DIFF
--- a/kernel/static/export.html
+++ b/kernel/static/export.html
@@ -6,179 +6,655 @@
     <title>{{ scene.display.title }}</title>
     <style>
       html,
+    body {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+      overflow: hidden;
+      touch-action: none;
+
+      background: #74A4D5;
+      background-image: url(images/decentraland-connect/background.png);
+      background-size: 115%;
+      background-repeat: no-repeat;
+      background-position: right -90px bottom 25px;
+    }
+
+    #gameContainer {
+      width: 100vw;
+      height: 100vh;
+      position: relative;
+    }
+
+    #gameContainer.loaded {
+      width: 100%;
+      height: 100%;
+      margin: auto;
+    }
+
+    #gameContainer.loaded,
+    body {
+      background: #090909 url(images/decentraland-connect/DecentralandIsologotipo.png) no-repeat 50% 5% !important;
+      background-size: 170px 32px !important;
+    }
+    @media screen and (min-height: 500px) {
       body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        overflow: hidden;
-        touch-action: none;
+        background: #090909 url(images/decentraland-connect/DecentralandIsologotipo.png) no-repeat 50% 5% !important;
+        background-size: 170px 32px !important;
       }
-
-      #gameContainer {
-        width: 100vw;
-        height: 100vh;
-        position: relative;
-      }
-
-      #gameContainer.loaded {
-        width: 100%;
-        height: 100%;
-        margin: auto;
-      }
-
+    }
+    @media screen and (min-height: 800px) {
       #gameContainer.loaded,
       body {
-        background: #292631 url(images/progress-logo.png) no-repeat center !important;
-        background-size: 309px 58px !important;
+        background: #090909 url(images/decentraland-connect/DecentralandIsologotipo.png) no-repeat 50% 25% !important;
+        background-size: 170px 32px !important;
+      }
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      color: #fff;
+      font-family: 'open sans', roboto, 'helvetica neue', sans-serif;
+      font-size: 0.8em;
+    }
+
+    canvas {
+      position: relative;
+      z-index: 1000;
+      width: 100%;
+      height: 100%;
+    }
+
+    .dcl-loading .progress {
+      display: block;
+    }
+
+    #overlay {
+      display: block;
+      width: 100%;
+      height: 100%;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      z-index: 2;
+
+      background: #74A4D5;
+      background-image: url(images/decentraland-connect/background.png);
+      background-size: 115%;
+      background-repeat: no-repeat;
+      background-position: right -90px bottom 25px;
+
+      opacity: 0.15;
+    }
+
+    .progress {
+      position: absolute;
+      height: 30px;
+      width: 100%;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      border-style: solid;
+      border-width: thick;
+      border-left: none;
+      border-right: none;
+      border-top: 3px solid #090909;
+      border-bottom: 3px solid #090909;
+      text-align: center;
+      border-color: #090909;
+      background: #090909;
+      display: none;
+    }
+
+    .progress .full {
+      float: left;
+      width: 0%;
+      height: 100%;
+      display: inline-flex;
+      background: linear-gradient(270deg, #FC9965 4.62%, #FF5273 58.77%, #DE3959 100%);
+    }
+
+    .progress.loaded {
+      z-index: 9;
+    }
+
+    .progress.ingame .full {
+      animation: none;
+    }
+
+    #progress-bar-inner {
+      width: 0%;
+      transition: width 0.2s;
+      animation: none;
+    }
+
+    .hidden-error {
+      display: none !important;
+    }
+
+    body.error {
+      background: black !important;
+      background-image: none !important;
+    }
+
+    body.error #gameContainer {
+      display: none !important;
+    }
+
+    body.error #progress-bar {
+      display: none !important;
+      z-index: 10;
+    }
+
+    body.error #gameContainer {
+      background: black !important;
+      background-image: none !important;
+    }
+
+    @keyframes progress_30 {
+      from {
+        width: 0;
       }
 
-      * {
-        box-sizing: border-box;
+      to {
+        width: 30%;
+      }
+    }
+
+    @keyframes progress_50 {
+      from {
+        width: 30%;
       }
 
-      body {
-        color: #fff;
-        font-family: 'open sans', roboto, 'helvetica neue', sans-serif;
-        font-size: 0.8em;
+      to {
+        width: 50%;
       }
+    }
 
-      canvas {
-        position: relative;
-        z-index: 1000;
-        width: 100%;
-        height: 100%;
-      }
+    body.dcl-loading #load-messages-wrapper {
+      display: flex;
+    }
+    #load-messages-wrapper {
+      display: none;
+      justify-content: center;
+      align-items: center;
+      flex-direction: column;
+      z-index: 8;
 
-      .dcl-loading .progress {
-        display: block;
-      }
+      position: fixed;
+      top: 80px;
 
-      #overlay {
-        display: none;
-        width: 100%;
-        height: 100%;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        z-index: 2;
-      }
+      min-width: 100%;
+      padding-left: 0;
+      padding-right: 0;
 
-      .progress {
-        position: absolute;
-        height: 30px;
-        width: 100%;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        border-style: solid;
-        border-width: thick;
-        border-left: none;
-        border-right: none;
-        text-align: center;
-        border-color: #3a383b;
-        background: #3a383b;
-        display: none;
-      }
+      color: white;
+      text-align: center;
+      font-size: 1.25em;
+      font-family: sfsemibold, "Helvetica Neue", Arial, sans-serif;
+    }
 
-      .progress .full {
-        float: left;
-        width: 0%;
-        height: 100%;
-        display: inline-flex;
-        background-color: #eb455a;
-        animation: progress_30 10s forwards;
-      }
+    #load-messages-wrapper div {
+        max-width: 820px;
+    }
 
-      .progress.loaded {
-        z-index: 1;
-      }
-
-      .progress.loaded .full {
-        animation: progress_50 5s forwards;
-      }
-
-      .progress.ingame .full {
-        animation: progress_100 50s forwards;
-      }
-
-      @keyframes progress_30 {
-        from {
-          width: 0;
-        }
-
-        to {
-          width: 30%;
-        }
-      }
-
-      @keyframes progress_50 {
-        from {
-          width: 30%;
-        }
-
-        to {
-          width: 50%;
-        }
-      }
-
-      @keyframes progress_100 {
-        from {
-          width: 0%;
-        }
-
-        to {
-          width: 100%;
-        }
-      }
-
-      body.dcl-loading #load-messages-wrapper {
-        display: flex;
-      }
+    @media screen and (min-height: 500px) {
       #load-messages-wrapper {
-        display: none;
-        justify-content: center;
-        align-items: center;
-        flex-direction: column;
-        min-width: 100%;
-        z-index: 2000;
-        bottom: 10%;
-        position: fixed;
-        color: white;
+        top: 20%;
+
         padding-left: 20%;
         padding-right: 20%;
-        text-align: center;
-        font-family: -apple-system, system-ui, system-ui, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-        font-size: 1.25em;
-        font-stretch: 125%;
-        font-weight: 400;
       }
+    }
+    @media screen and (min-height: 800px) {
+      #load-messages-wrapper {
+        top: 35%;
 
-      #load-messages-wrapper div {
-        max-width: 820px;
+        padding-left: 10%;
+        padding-right: 10%;
       }
+    }
 
-      #subtext-messages {
-        margin-top: 25px;
-        font-size: 1em;
-        color: #353535;
+    @media screen and (min-height: 1000px) {
+      #load-messages-wrapper {
+        top: 38%;
+
+        padding-left: 10%;
+        padding-right: 10%;
       }
+    }
+
+    #load-images {
+      max-width: 306px;
+      max-height: 234px;
+    }
+    .load-images-wrapper {
+      height: 234px;
+      margin-bottom: 40px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+    }
+    #subtext-messages-container {
+      bottom: 40px;
+      left: 0;
+      position: fixed;
+
+      min-width: 100%;
+      padding-left: 20%;
+      padding-right: 20%;
+
+      text-align: center;
+
+      font-size: 1.0em;
+      color: #7D8385;
+    }
+
+    #subtext-messages-container div {
+      margin: auto;
+    }
+
+    div#check-wallet-prompt {
+      width: 395px;
+      text-align: center;
+      background: #43474B;
+      border-radius: 100px;
+      color: white;
+      padding: 14px;
+      margin-bottom: 10px;
+    }
+
+    #eth-connect-advice {
+      display: none;
+    }
+    #eth-sign-advice {
+      display: none;
+    }
+    .login {
+      background:#74A4D5;
+      background-image: url(images/decentraland-connect/background.png);
+      background-size: 100%;
+      background-repeat: no-repeat;
+      background-position: left 50% bottom 33px;
+
+      position: absolute;
+      z-index: 9;
+      top: 0;
+      left:0;
+      width: 100%;
+      height: 100%;
+    }
+    #eth-login {
+      display: none;
+    }
+    .eth-login-popup {
+      width: 70%;
+      max-width: 650px;
+      height: 446px;
+
+      position: absolute;
+      left: 50%;
+      top: 40px;
+      transform: translate(-50%, 0);
+      padding: 34px 44px;
+
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    #eth-login-confirmation-wrapper {
+      width: 100%;
+
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+    @font-face {
+      font-family: sfregular;
+      src: url(images/decentraland-connect/SF-UI-Text-Regular.otf);
+    }
+    @font-face {
+      font-family: sfsemibold;
+      src: url(images/decentraland-connect/SF-UI-Text-Semibold.otf);
+    }
+    .eth-login-description {
+      color: white;
+      margin-top: 50px;
+      margin-bottom: 50px;
+      text-align: center;
+      font-size: 16px;
+      font-family: sfregular, "Helvetica Neue", Arial, sans-serif;
+    }
+    .eth-login-welcome {
+      color: white;
+      font-family: sfregular, "Helvetica Neue", Arial, sans-serif;
+      font-size: 16px;
+      margin-bottom: 2px;
+    }
+    .code {
+      font-family: 'Courier New', Courier, monospace;
+    }
+    .eth-login-confirm-button1 {
+      color: white;
+      cursor: pointer;
+
+      background-color: #FF5273;
+      box-shadow: 0px 3.66316px 0px #E12F4F;
+
+      line-height: 40px;
+      width: 214px;
+
+      border: 0;
+      border-radius: 8px;
+
+      text-transform: uppercase;
+      font-size: 13px;
+      font-family: sfsemibold, "Helvetica Neue", Arial, sans-serif;
+    }
+    .eth-login-confirm-button1:disabled {
+      color: #B6C6D7;
+      background-color: #A08DB8;
+      box-shadow: 0px 3.66316px 0px #907CA8;
+    }
+    .eth-login-logo {
+      width: 262px;
+    }
+    .eth-login-wallet-icon {
+      margin-right: 10px;
+      width: 24px;
+      height: 23px;
+      vertical-align: middle;
+    }
+    .eth-login-tos {
+      max-width: 310px;
+      margin-bottom: 50px;
+      text-align: center;
+    }
+    .eth-login-tos-label {
+      font-size: 13px;
+      font-family: sfregular, "Helvetica Neue", Arial, sans-serif;
+      color: white;
+    }
+    .eth-login-tos-label > a:any-link {
+      color: white;
+      font-family: sfsemibold, "Helvetica Neue", Arial, sans-serif;
+    }
+    .eth-login-tos-agree {
+      width: 20px;
+      height: 20px;
+      vertical-align: middle;
+    }
+
+    .nav-bar {
+      background-color: rgba(0, 0, 0, 0.1);
+      height: 40px;
+      display: flex;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      z-index: 3;
+    }
+    .nav-bar-content {
+      position: absolute;
+      right: 50px;
+      height: 100%;
+      display: flex;
+      width: fit-content;
+
+      align-items: center;
+      vertical-align: middle;
+    }
+    @media screen and (min-width: 1200px) {
+      .nav-bar-content {
+        right: 285px;
+      }
+    }
+    .nav-text {
+      color: white;
+      font-family: sfregular, "Helvetica Neue", Arial, sans-serif;
+    }
+    .nav-discord {
+      width: fit-content;
+
+      vertical-align: middle;
+      margin: 6px 0 8px 10px;
+
+      border: 1px solid rgba(255, 255, 255, 0.6);
+      padding: 4px 12.15px;
+
+      box-sizing: border-box;
+      border-radius: 6px;
+      text-decoration: none;
+    }
+    .nav-discord-img {
+      width: 14px;
+      vertical-align: middle;
+    }
+    .nav-discord-text {
+      margin-left: 2px;
+      font-size: 9px;
+    }
+    .nav-need-support {
+      width: fit-content;
+      font-size: 11px;
+    }
+
+    .footer-bar {
+      background: #1C191F;
+      height: 33px;
+      display: flex;
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      z-index: 3;
+    }
+    .footer-bar-content {
+      position: absolute;
+      right: 50px;
+      height: 100%;
+      display: flex;
+      width: fit-content;
+
+      align-items: center;
+      vertical-align: middle;
+    }
+    @media screen and (min-width: 1200px) {
+      .footer-bar-content {
+        right: 285px;
+      }
+    }
+    .footer-link {
+      margin-left: 34px;
+    }
+    .footer-text {
+      margin-left: 45px;
+      vertical-align: middle;
+      color: #736E7D;
+      font-family: sfregular, "Helvetica Neue", Arial, sans-serif;
+    }
+    .footer-icon {
+      max-height: 18px;
+    }
+    .loader {
+      --thickness: 5px;
+      --diameter: 35px;
+
+      border: var(--thickness) solid #f3f3f3;
+      border-top: var(--thickness) solid #FF5273;
+      border-radius: 50%;
+      width: var(--diameter);
+      height: var(--diameter);
+      animation: spin 1.24s linear infinite;
+    }
+
+    @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+
+    /* Preview only style */
+
+    .network-warning-bar {
+      display: none;
+
+      width: 100%;
+      height: 50px;
+      padding: 5px 0;
+
+      position: absolute;
+      top: 0%;
+      z-index: 1001;
+
+      background-color: rgb(241, 163, 72);
+
+      box-shadow: 0 2px 5px 1px rgba(241, 163, 72, 0.9);
+    }
+    .network-warning-title {
+      text-align: center;
+
+      font-size: 1rem;
+      margin-bottom: 4px;
+    }
+    .network-warning-description {
+      text-align: center;
+
+      font-size: 0.85rem;
+    }
+    .network-warning-button {
+      position: absolute;
+      right: 20px;
+      top: 50%;
+
+      transform: translate(-50%, -50%);
+
+      color: white;
+
+      font-size: 1.5rem;
+      font-weight: 600;
+      cursor: pointer;
+
+      border: 0;
+      background-color: transparent;
+    }
+    .network-warning-button:active,
+    .network-warning-button:focus,
+    .network-warning-button:focus:active {
+      background-image: none;
+      outline: 0;
+      box-shadow: none;
+    }
     </style>
+    <script>
+      window['staticWorld'] = true
+      function checkTos() {
+        document.getElementById('eth-login-confirm-button').disabled = !document.getElementById('agree-check').checked;
+      }
+    </script>
   </head>
 
   <body class="dcl-loading">
     <div id="load-messages-wrapper">
       <div id="load-messages"></div>
-      <div id="subtext-messages"></div>
+      <div id="subtext-messages-container">
+        <div id="check-wallet-prompt" style="display: none;">Please check your wallet (i.e MetaMask) and look for the Signature Request.</div>
+        <div id="subtext-messages"></div>
+      </div>
     </div>
     <div id="overlay"></div>
     <div id="progress-bar" class="progress ingame">
-      <div class="full"></div>
+      <div id="progress-bar-inner" class="full"></div>
     </div>
+    <div id="eth-login" class="login">
+      <nav class="nav-bar">
+        <div class="nav-bar-content">
+          <div class="nav-text nav-need-support"><span>Need support?</span></div>
+          <a class="nav-discord" href="https://dcl.gg/discord" target="about:blank"><img class="nav-discord-img" src="images/decentraland-connect/Discord.png"></img> <span class="nav-text nav-discord-text">JOIN OUR DISCORD</span></a>
+        </div>
+      </nav>
+      <div class="eth-login-popup">
+        <img class="eth-login-logo" src="images/decentraland-connect/Isologotipo.png"></img>
+        <div class="eth-login-description">Enter the first virtual world fully owned by its users.</div>
+        <div id="eth-login-confirmation-spinner" class="loader" style="display: block;"></div>
+        <div id="eth-login-confirmation-wrapper" style="display: none;">
+          <div class="eth-login-tos">
+            <input type="checkbox" id="agree-check" class="eth-login-tos-agree" onchange="checkTos()"></input>
+            <label for="agree-check" class="eth-login-tos-label">I am of legal age and I have read and agree to the <a href="https://decentraland.org/terms" target="_blank">Terms of Service</a> and <a href="https://decentraland.org/privacy" target="_blank">Privacy Policy</a></label>
+          </div>
+          <button id="eth-login-confirm-button" class="eth-login-confirm-button1" disabled>Start Exploring</button>
+        </div>
+      </div>
+      <footer class="footer-bar">
+        <div class="footer-bar-content">
+          <a class="footer-link" href="https://dcl.gg/discord" target="about:blank"><img class="footer-icon" src="images/decentraland-connect/footer/Discord.png"></img></a>
+          <a class="footer-link" href="https://www.reddit.com/r/decentraland/" target="about:blank"><img class="footer-icon" src="images/decentraland-connect/footer/Reddit.png"></img></a>
+          <a class="footer-link" href="http://github.com/decentraland" target="about:blank"><img class="footer-icon" src="images/decentraland-connect/footer/Git.png"></img></a>
+          <a class="footer-link" href="https://twitter.com/decentraland" target="about:blank"><img class="footer-icon" src="images/decentraland-connect/footer/Twitter.png"></img></a>
+          <span class="footer-text">© 2020 Decentraland</span>
+        </div>
+      </footer>
+    </div>
+    <div id="eth-connect-advice" class="login">
+      <nav class="nav-bar">
+        <div class="nav-bar-content">
+          <div class="nav-text nav-need-support"><span>Need support?</span></div>
+          <a class="nav-discord" href="https://dcl.gg/discord" target="about:blank"><img class="nav-discord-img" src="images/decentraland-connect/Discord.png"></img> <span class="nav-text nav-discord-text">JOIN OUR DISCORD</span></a>
+        </div>
+      </nav>
+      <div class="eth-login-popup" style="height: 450px">
+        <img class="eth-login-logo" src="images/decentraland-connect/Isologotipo.png"></img>
+        <div class="eth-login-description">Please, follow the instructions provided by your Ethereum wallet provider to complete login.<br></br>To proceed, <strong>login</strong> into your wallet and confirm with <strong>connecting</strong> to your Ethereum wallet extension.</div>
+        <button id="eth-relogin-confirm-button" class="eth-login-confirm-button1">
+          <img src="./images/decentraland-connect/walletIcon.png" class="eth-login-wallet-icon"></img>Connect wallet</buttonclass="eth-login-description">
+      </div>
+      <footer class="footer-bar">
+        <div class="footer-bar-content">
+          <a class="footer-link" href="https://dcl.gg/discord" target="about:blank"><img class="footer-icon" src="images/decentraland-connect/footer/Discord.png"></img></a>
+          <a class="footer-link" href="https://www.reddit.com/r/decentraland/" target="about:blank"><img class="footer-icon" src="images/decentraland-connect/footer/Reddit.png"></img></a>
+          <a class="footer-link" href="http://github.com/decentraland" target="about:blank"><img class="footer-icon" src="images/decentraland-connect/footer/Git.png"></img></a>
+          <a class="footer-link" href="https://twitter.com/decentraland" target="about:blank"><img class="footer-icon" src="images/decentraland-connect/footer/Twitter.png"></img></a>
+          <span class="footer-text">© 2020 Decentraland</span>
+        </div>
+      </footer>
+    </div>
+    <div id="eth-sign-advice" class="login">
+      <nav class="nav-bar">
+        <div class="nav-bar-content">
+          <div class="nav-text nav-need-support"><span>Need support?</span></div>
+          <a class="nav-discord" href="https://dcl.gg/discord" target="about:blank"><img class="nav-discord-img" src="images/decentraland-connect/Discord.png"></img> <span class="nav-text nav-discord-text">JOIN OUR DISCORD</span></a>
+        </div>
+      </nav>
+      <div class="eth-login-popup" >
+        <img class="eth-login-logo" src="images/decentraland-connect/Isologotipo.png"></img>
+        <div class="eth-login-description">Please, follow the instructions provided by your Ethereum wallet provider to complete login.</div>
+        <div class="eth-login-description" style="margin-top: 10px;">To proceed, confirm <strong>signing</strong> the following message in your wallet extension.</div>
+        <div id="eth-sign-advice-msg" class="eth-login-description code"></div>
+      </div>
+      <footer class="footer-bar">
+        <div class="footer-bar-content">
+          <a class="footer-link" href="https://dcl.gg/discord" target="about:blank"><img class="footer-icon" src="images/decentraland-connect/footer/Discord.png"></img></a>
+          <a class="footer-link" href="https://www.reddit.com/r/decentraland/" target="about:blank"><img class="footer-icon" src="images/decentraland-connect/footer/Reddit.png"></img></a>
+          <a class="footer-link" href="http://github.com/decentraland" target="about:blank"><img class="footer-icon" src="images/decentraland-connect/footer/Git.png"></img></a>
+          <a class="footer-link" href="https://twitter.com/decentraland" target="about:blank"><img class="footer-icon" src="images/decentraland-connect/footer/Twitter.png"></img></a>
+          <span class="footer-text">© 2020 Decentraland</span>
+        </div>
+      </footer>
+    </div>
+
+    <div id="network-warning" class="network-warning-bar">
+      <div class="network-warning-title"><strong>Warning:</strong> you’re running on the Ethereum Mainnet.</div>
+      <div class="network-warning-description">Blockchain transactions in this network have a cost and real consequences. We recommend you use the <strong>Ropsten</strong> test network instead.</div>
+      <button class="network-warning-button" onclick="document.getElementById('network-warning').style.display = 'none';">⨯</button>
+    </div>
+
     <div id="gameContainer"></div>
-    <script>
-      window['staticWorld'] = true
-    </script>
+    <script src="/unity/Build/hls.min.js"></script>
   </body>
   <script src="/unity/Build/DCLUnityLoader.js"></script>
   <script defer async src="/preview.js"></script>


### PR DESCRIPTION
During the last changes to the initial loading screen, the export page was not updated. Therefore, when exporting scenes, it wasn't possible to enable web3.

In order for it to work, we copied the current `preview.html`, and made a few little changes for it to be compatible with exporting scenes