### PR TITLE
fix: make attachable changes backwards compatible

### DIFF
--- a/kernel/package-lock.json
+++ b/kernel/package-lock.json
@@ -2754,9 +2754,9 @@
       }
     },
     "decentraland-renderer": {
-      "version": "1.8.33768",
-      "resolved": "https://registry.npmjs.org/decentraland-renderer/-/decentraland-renderer-1.8.33768.tgz",
-      "integrity": "sha512-/uQ4UuqyQSFVj0wJXssRYa4FM+SkI3/Zlvp53Uan+yFPpBpkIOZu63D2ttti3NDr+6f8KuqyTk5I9EBp+JvjiQ=="
+      "version": "1.8.33953",
+      "resolved": "https://registry.npmjs.org/decentraland-renderer/-/decentraland-renderer-1.8.33953.tgz",
+      "integrity": "sha512-C/cwCRTT5t6pVfKn9dctAE4rDNbZHSdmnNcAYPrz3to1mJ/XjO+TQ3n4bppULiRcylhhZgwx1rav0tG99yNawg=="
     },
     "decentraland-rpc": {
       "version": "3.1.8",

--- a/kernel/package.json
+++ b/kernel/package.json
@@ -101,7 +101,7 @@
     "dcl-crypto": "^2.2.0",
     "dcl-social-client": "^1.3.10",
     "decentraland-katalyst-peer": "0.2.15",
-    "decentraland-renderer": "^1.8.33768",
+    "decentraland-renderer": "^1.8.33953",
     "decentraland-rpc": "^3.1.8",
     "devtools-protocol": "0.0.615714",
     "eth-connect": "^4.0.1",

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScene.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScene.cs
@@ -469,7 +469,7 @@ namespace DCL.Controllers
 
             if (me != null)
             {
-                if (parentId == "FirstPersonCameraEntityReference")
+                if (parentId == "FirstPersonCameraEntityReference" || parentId == "PlayerEntityReference") // PlayerEntityReference is for compatibility purposes
                 {
                     // In this case, the entity will attached to the first person camera
                     // On first person mode, the entity will rotate with the camera. On third person mode, the entity will rotate with the avatar
@@ -477,7 +477,7 @@ namespace DCL.Controllers
                     SceneController.i.boundariesChecker.AddPersistent(me);
                     SceneController.i.physicsSyncController.MarkDirty();
                 }
-                else if (parentId == "AvatarEntityReference")
+                else if (parentId == "AvatarEntityReference" || parentId == "AvatarPositionEntityReference") // AvatarPositionEntityReference is for compatibility purposes
                 {
                     // In this case, the entity will be attached to the avatar
                     // It will simply rotate with the avatar, regardless of where the camera is pointing


### PR DESCRIPTION
In https://github.com/decentraland/explorer/pull/1271, we changed the name of the attachable entities. The problem is that we also changed the name of the parent id sent to the renderer. 

For old scenes to work, we will support the new and old parent id for the time being. It is important to mention however, that we did move the pivot point for the `Attachable.PLAYER` (now `Attachable.FIRST_PERSON_CAMERA`), so a change will happen