### PR TITLE
fix: hidden list for BodyShapeController is not being refreshed properly.

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
@@ -257,9 +257,9 @@ namespace DCL
 
             hiddenList = CreateHiddenList();
 
+            bodyShapeController.SetHiddenList(hiddenList);
             if (!bodyShapeController.isReady)
             {
-                bodyShapeController.SetHiddenList(hiddenList);
                 bodyShapeController.Load(transform, OnWearableLoadingSuccess, OnWearableLoadingFail);
             }
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/BodyShapeController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/BodyShapeController.cs
@@ -12,8 +12,15 @@ public class BodyShapeController : WearableController
     {
     }
 
-    protected BodyShapeController(WearableController original) : base(original)
+    protected BodyShapeController(BodyShapeController original) : base(original)
     {
+        headRenderer = original.headRenderer;
+        eyebrowsRenderer = original.eyebrowsRenderer;
+        eyesRenderer = original.eyesRenderer;
+        mouthRenderer = original.mouthRenderer;
+        feetRenderer = original.feetRenderer;
+        upperBodyRenderer = original.upperBodyRenderer;
+        lowerBodyRenderer = original.lowerBodyRenderer;
     }
 
     public SkinnedMeshRenderer skinnedMeshRenderer { get; private set; }
@@ -140,16 +147,34 @@ public class BodyShapeController : WearableController
                 lowerBodyRenderer = r;
             else if (parentName.Contains("feet"))
                 feetRenderer = r;
+            else if (parentName.Contains("head"))
+                headRenderer = r;
+            else if (parentName.Contains("eyebrows"))
+                eyebrowsRenderer = r;
+            else if (parentName.Contains("eyes"))
+                eyesRenderer = r;
+            else if (parentName.Contains("mouth"))
+                mouthRenderer = r;
         }
     }
 
+    public SkinnedMeshRenderer headRenderer { get; private set; }
+    public SkinnedMeshRenderer eyebrowsRenderer { get; private set; }
+    public SkinnedMeshRenderer eyesRenderer { get; private set; }
+    public SkinnedMeshRenderer mouthRenderer { get; private set; }
     public SkinnedMeshRenderer feetRenderer { get; private set; }
     public SkinnedMeshRenderer upperBodyRenderer { get; private set; }
     public SkinnedMeshRenderer lowerBodyRenderer { get; private set; }
 
     public override void UpdateVisibility()
     {
-        SetAssetRenderersEnabled(!hiddenList.Contains(WearableLiterals.Misc.HEAD));
+        bool headIsVisible = !hiddenList.Contains(WearableLiterals.Misc.HEAD);
+
+        headRenderer.enabled = headIsVisible;
+        eyebrowsRenderer.enabled = headIsVisible;
+        eyesRenderer.enabled = headIsVisible;
+        mouthRenderer.enabled = headIsVisible;
+
         feetRenderer.enabled = !hiddenList.Contains(WearableLiterals.Categories.FEET);
         upperBodyRenderer.enabled = !hiddenList.Contains(WearableLiterals.Categories.UPPER_BODY);
         lowerBodyRenderer.enabled = !hiddenList.Contains(WearableLiterals.Categories.LOWER_BODY);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/Tests/AvatarRendererShould.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/Tests/AvatarRendererShould.cs
@@ -179,6 +179,49 @@ namespace AvatarShape_Tests
         [UnityTest]
         [Category("Explicit")]
         [Explicit("Test too slow")]
+        public IEnumerator ProcessHideListProperly_HeadHidden()
+        {
+            //Clean hides/replaces to avoid interferences
+            CleanWearableHidesAndReplaces(SUNGLASSES_ID);
+            CleanWearableHidesAndReplaces(BLUE_BANDANA_ID);
+            catalog.Get(SUNGLASSES_ID).hides = new [] { WearableLiterals.Misc.HEAD};
+
+            avatarModel.wearables = new List<string>() {SUNGLASSES_ID};
+
+            bool ready = false;
+            avatarRenderer.ApplyModel(avatarModel, () => ready = true, null);
+            yield return new DCL.WaitUntil(() => ready);
+
+            Assert.IsFalse(AvatarRenderer_Mock.GetBodyShapeController(avatarRenderer).headRenderer.enabled);
+            Assert.IsFalse(AvatarRenderer_Mock.GetBodyShapeController(avatarRenderer).eyebrowsRenderer.enabled);
+            Assert.IsFalse(AvatarRenderer_Mock.GetBodyShapeController(avatarRenderer).eyesRenderer.enabled);
+            Assert.IsFalse(AvatarRenderer_Mock.GetBodyShapeController(avatarRenderer).mouthRenderer.enabled);
+        }
+
+        [UnityTest]
+        [Category("Explicit")]
+        [Explicit("Test too slow")]
+        public IEnumerator ProcessHideListProperly_HeadShowing()
+        {
+            //Clean hides/replaces to avoid interferences
+            CleanWearableHidesAndReplaces(SUNGLASSES_ID);
+            CleanWearableHidesAndReplaces(BLUE_BANDANA_ID);
+
+            avatarModel.wearables = new List<string>() {SUNGLASSES_ID};
+
+            bool ready = false;
+            avatarRenderer.ApplyModel(avatarModel, () => ready = true, null);
+            yield return new DCL.WaitUntil(() => ready);
+
+            Assert.IsTrue(AvatarRenderer_Mock.GetBodyShapeController(avatarRenderer).headRenderer.enabled);
+            Assert.IsTrue(AvatarRenderer_Mock.GetBodyShapeController(avatarRenderer).eyebrowsRenderer.enabled);
+            Assert.IsTrue(AvatarRenderer_Mock.GetBodyShapeController(avatarRenderer).eyesRenderer.enabled);
+            Assert.IsTrue(AvatarRenderer_Mock.GetBodyShapeController(avatarRenderer).mouthRenderer.enabled);
+        }
+
+        [UnityTest]
+        [Category("Explicit")]
+        [Explicit("Test too slow")]
         [TestCase(null, ExpectedResult = null)]
         [TestCase("wave", ExpectedResult = null)]
         public IEnumerator ProcessExpression(string expressionId)

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/Tests/AvatarShape_Helpers.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/Tests/AvatarShape_Helpers.cs
@@ -165,7 +165,7 @@ namespace AvatarShape_Tests
         {
         }
 
-        public BodyShapeController_Mock(WearableController original) : base(original)
+        public BodyShapeController_Mock(BodyShapeController original) : base(original)
         {
         }
 


### PR DESCRIPTION
#1241 

Hidden matrix was not working for bodyshapes

-----------------
Test instructions:
To see all wearables you should use `ZONE` environment and `ALL_WEARABLES&TEST_WEARABLES` URL PARAMS, for example the pirate skeleton head was one of the collectible wearables that wasn't hiding the avatar head correctly:

https://explorer.decentraland.zone/branch/fix/1241_head_not_hidden/index.html?ALL_WEARABLES&TEST_WEARABLES
