### PR TITLE
Bones in SkinnedMeshRenderer now are commanded by a mock SkinnedMeshR…

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/WearableController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/WearableController.cs
@@ -149,7 +149,7 @@ public class WearableController
         }
     }
 
-    public void SetAssetRenderersEnabled(bool active)
+    public virtual void SetAssetRenderersEnabled(bool active)
     {
         for (var i = 0; i < assetRenderers.Length; i++)
         {


### PR DESCRIPTION
A disabled SkinnedMeshRenderer will stop moving bones in animations. All the SkinnedMeshRenderer in a character (wearables included) are pinting its bones to the ones in the Head but if we disabled it due a wearable, the whole character will stop animating.

We solved it by creating a mock (no mesh) skinnedmeshrenderer that will act as a director for the bones and never gets disabled.
