### PR TITLE
test: static workers termination

### DIFF
--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -142,6 +142,7 @@ export const FORCE_SEND_MESSAGE = location.search.indexOf('FORCE_SEND_MESSAGE') 
 export const ENABLE_EXPLORE_HUD = location.search.indexOf('ENABLE_EXPLORE_HUD') !== -1
 export const ENABLE_MANA_HUD = location.search.indexOf('ENABLE_MANA_HUD') !== -1
 export const ENABLE_NEW_TASKBAR = location.search.indexOf('ENABLE_NEW_TASKBAR') !== -1 /* NOTE(Santi): This is temporal, until we remove the old taskbar */
+export const STATIC_WORKERS_TERMINATION = location.search.indexOf('STATIC_WORKERS_TERMINATION') !== -1
 
 export const PIN_CATALYST = qs.PIN_CATALYST
 

--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -142,7 +142,6 @@ export const FORCE_SEND_MESSAGE = location.search.indexOf('FORCE_SEND_MESSAGE') 
 export const ENABLE_EXPLORE_HUD = location.search.indexOf('ENABLE_EXPLORE_HUD') !== -1
 export const ENABLE_MANA_HUD = location.search.indexOf('ENABLE_MANA_HUD') !== -1
 export const ENABLE_NEW_TASKBAR = location.search.indexOf('ENABLE_NEW_TASKBAR') !== -1 /* NOTE(Santi): This is temporal, until we remove the old taskbar */
-export const STATIC_WORKERS_TERMINATION = location.search.indexOf('STATIC_WORKERS_TERMINATION') !== -1
 
 export const PIN_CATALYST = qs.PIN_CATALYST
 

--- a/kernel/packages/scene-system/scene.system.ts
+++ b/kernel/packages/scene-system/scene.system.ts
@@ -111,6 +111,7 @@ export default class GamekitScene extends Script {
 
   scenePosition: Vector2 = new Vector2()
   parcels: Array<{ x: number; y: number }> = []
+  allowedFirstStaticSceneWorker = false
 
   private allowOpenExternalUrl: boolean = false
 
@@ -244,6 +245,7 @@ export default class GamekitScene extends Script {
 
       const fullData = sceneData.data as LoadableParcelScene
       const sceneId = fullData.id
+      defaultLogger.log("scene id: " + sceneId)
 
       let loadingModules: Record<string, IFuture<void>> = {}
 
@@ -518,8 +520,9 @@ export default class GamekitScene extends Script {
       }
 
       try {
+        // defaultLogger.log('scene: ' + source)
         sceneIsStatic = !(source.indexOf('ISystem') !== -1 || source.indexOf('OnPointer') !== -1)
-        // defaultLogger.log('static??? ' + sceneIsStatic)/
+        // defaultLogger.log('static??? ' + sceneIsStatic)
 
         await customEval((source as any) as string, getES5Context({ dcl }))
 
@@ -562,7 +565,12 @@ export default class GamekitScene extends Script {
     if(sceneIsStatic) {
       // KILL WORKER
 
-      ;((this.engine as any) as IEngineAPI).disposeWorker()
+      // Horrible hack to skip the global-scene
+      if(!this.allowedFirstStaticSceneWorker) {
+        this.allowedFirstStaticSceneWorker = true
+      } else {
+        ((this.engine as any) as IEngineAPI).disposeWorker()
+      }
     }
   }
 

--- a/kernel/packages/scene-system/scene.system.ts
+++ b/kernel/packages/scene-system/scene.system.ts
@@ -26,7 +26,6 @@ import { PB_Transform, PB_Vector3, PB_Quaternion } from '../shared/proto/enginei
 import { worldToGrid } from 'atomicHelpers/parcelScenePositions'
 import { sleep } from 'atomicHelpers/sleep'
 import future, { IFuture } from 'fp-future'
-import { STATIC_WORKERS_TERMINATION } from 'config'
 
 // tslint:disable-next-line:whitespace
 type IEngineAPI = import('shared/apis/EngineAPI').IEngineAPI
@@ -560,7 +559,7 @@ export default class GamekitScene extends Script {
       this.didStart = true
     }
 
-    if(STATIC_WORKERS_TERMINATION && sceneIsStatic) {
+    if(sceneIsStatic) {
       // KILL WORKER
 
       ;((this.engine as any) as IEngineAPI).disposeWorker()

--- a/kernel/packages/scene-system/scene.system.ts
+++ b/kernel/packages/scene-system/scene.system.ts
@@ -111,7 +111,6 @@ export default class GamekitScene extends Script {
 
   scenePosition: Vector2 = new Vector2()
   parcels: Array<{ x: number; y: number }> = []
-  allowedFirstStaticSceneWorker = false
 
   private allowOpenExternalUrl: boolean = false
 
@@ -245,7 +244,6 @@ export default class GamekitScene extends Script {
 
       const fullData = sceneData.data as LoadableParcelScene
       const sceneId = fullData.id
-      defaultLogger.log("scene id: " + sceneId)
 
       let loadingModules: Record<string, IFuture<void>> = {}
 
@@ -520,9 +518,8 @@ export default class GamekitScene extends Script {
       }
 
       try {
-        // defaultLogger.log('scene: ' + source)
         sceneIsStatic = !(source.indexOf('ISystem') !== -1 || source.indexOf('OnPointer') !== -1)
-        // defaultLogger.log('static??? ' + sceneIsStatic)
+        // defaultLogger.log('static??? ' + sceneIsStatic)/
 
         await customEval((source as any) as string, getES5Context({ dcl }))
 
@@ -565,12 +562,7 @@ export default class GamekitScene extends Script {
     if(sceneIsStatic) {
       // KILL WORKER
 
-      // Horrible hack to skip the global-scene
-      if(!this.allowedFirstStaticSceneWorker) {
-        this.allowedFirstStaticSceneWorker = true
-      } else {
-        ((this.engine as any) as IEngineAPI).disposeWorker()
-      }
+      ;((this.engine as any) as IEngineAPI).disposeWorker()
     }
   }
 

--- a/kernel/packages/shared/apis/EngineAPI.ts
+++ b/kernel/packages/shared/apis/EngineAPI.ts
@@ -2,6 +2,7 @@ import { IEventNames, IEvents } from 'decentraland-ecs/src/decentraland/Types'
 import { APIOptions, exposeMethod, registerAPI } from 'decentraland-rpc/lib/host'
 import { EntityAction } from '../types'
 import { ExposableAPI } from './ExposableAPI'
+import {STATIC_WORKERS_TERMINATION} from "../../config";
 
 export interface IEngineAPI {
   /**
@@ -76,6 +77,8 @@ export class EngineAPI extends ExposableAPI implements IEngineAPI {
 
   @exposeMethod
   async disposeWorker() {
+    if (!STATIC_WORKERS_TERMINATION) return
+
     this.parcelSceneAPI.disposeWorker()
   }
 

--- a/kernel/packages/shared/apis/EngineAPI.ts
+++ b/kernel/packages/shared/apis/EngineAPI.ts
@@ -23,6 +23,8 @@ export interface IEngineAPI {
    */
   sendBatch(actions: EntityAction[]): Promise<void>
 
+  disposeWorker(): void
+
   /**
    * Start signal, sent after everything was initialized
    */
@@ -70,6 +72,11 @@ export class EngineAPI extends ExposableAPI implements IEngineAPI {
   @exposeMethod
   async sendBatch(actions: EntityAction[]): Promise<void> {
     this.parcelSceneAPI.sendBatch(actions)
+  }
+
+  @exposeMethod
+  async disposeWorker() {
+    this.parcelSceneAPI.disposeWorker()
   }
 
   @exposeMethod

--- a/kernel/packages/shared/apis/EngineAPI.ts
+++ b/kernel/packages/shared/apis/EngineAPI.ts
@@ -2,7 +2,7 @@ import { IEventNames, IEvents } from 'decentraland-ecs/src/decentraland/Types'
 import { APIOptions, exposeMethod, registerAPI } from 'decentraland-rpc/lib/host'
 import { EntityAction } from '../types'
 import { ExposableAPI } from './ExposableAPI'
-import {STATIC_WORKERS_TERMINATION} from "../../config";
+import { STATIC_WORKERS_TERMINATION } from "../../config"
 
 export interface IEngineAPI {
   /**

--- a/kernel/packages/shared/world/ParcelSceneAPI.ts
+++ b/kernel/packages/shared/world/ParcelSceneAPI.ts
@@ -4,6 +4,7 @@ export type ParcelSceneAPI = {
   data: EnvironmentData<any>
   sendBatch(actions: EntityAction[]): void
   registerWorker(event: any): void
+  disposeWorker(): void
   dispose(): void
   on(event: string, cb: (event: any) => void): void
 }

--- a/kernel/packages/unity-interface/UnityScene.ts
+++ b/kernel/packages/unity-interface/UnityScene.ts
@@ -78,6 +78,10 @@ export class UnityScene<T> implements ParcelSceneAPI {
     this.worker = worker
   }
 
+  disposeWorker(): void {
+    this.worker.dispose()
+  }
+
   dispose(): void {
     // TODO: do we need to release some resource after releasing a scene worker?
   }


### PR DESCRIPTION
**THIS IS A HACKY APPROACH TO SEE HOW MUCH PERFORMANCE IS AFFECTED IF WE TERMINATE STATIC WORKERS**

* flagging scenes as "static" based on their minified code usage of `ISystem` and `OnPointer`, as we checked that detects at least empty parcels and street parcels.
* termination of webworkers for static scenes, as they are accumulated as idle workers otherwise
* feature toggle URL param `STATIC_WORKERS_TERMINATION`

Doc with profiling info here: https://docs.google.com/document/d/1alngddAcBxyOHQQ3ieuEGv2H7Y1GXR1LLxje05406sY/edit

Test link: https://play.decentraland.zone/branch/test/StaticSceneWorkersTermination/index.html?ENV=org&STATIC_WORKERS_TERMINATION&position=-72%2C72

You can do your own comparison by using (or not) the `STATIC_WORKERS_TERMINATION` URL param