### PR TITLE
chore: CylinderShape now defaults its top radius to 1, matching the bottom one.

### DIFF
--- a/kernel/packages/decentraland-ecs/src/decentraland/Components.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Components.ts
@@ -281,7 +281,7 @@ export class CylinderShape extends Shape {
    * The radius of the top of the cylinder. Defaults to 0.
    */
   @ObservableComponent.field
-  radiusTop: number = 0
+  radiusTop: number = 1
 
   /**
    * The radius of the base of the cylinder. Defaults to 1.


### PR DESCRIPTION
#937 
