### PR TITLE
fix: set avatar colliders as triggers

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.prefab
@@ -839,7 +839,7 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9158508182074433445}
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/Resources/Prefabs/CharacterController.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/CharacterController/Resources/Prefabs/CharacterController.prefab
@@ -353,7 +353,7 @@ BoxCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5357437800171952595}
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}


### PR DESCRIPTION
In https://github.com/decentraland/explorer/pull/1304, we added colliders to avatars. However, since they were not set as triggers, they collided with each other. We are now fixing this.