### PR TITLE
fix: onboarding performance issues

### DIFF
--- a/kernel/packages/entryPoints/unity.ts
+++ b/kernel/packages/entryPoints/unity.ts
@@ -4,7 +4,7 @@ declare const global: any
 // IMPORTANT! This should be execd before loading 'config' module to ensure that init values are successfully loaded
 global.enableWeb3 = true
 
-import defaultLogger, { createLogger } from 'shared/logger'
+import { createLogger } from 'shared/logger'
 import { ReportFatalError } from 'shared/loading/ReportFatalError'
 import { experienceStarted, NOT_INVITED, AUTH_ERROR_LOGGED_OUT, FAILED_FETCHING_UNITY } from 'shared/loading/types'
 import { worldToGrid } from '../atomicHelpers/parcelScenePositions'
@@ -83,7 +83,7 @@ initializeUnity(container)
           .then((profile) => {
             i.ConfigureTutorial(profile.tutorialStep, HAS_INITIAL_POSITION_MARK)
           })
-          .catch((e) => defaultLogger.log(`error getting profile ${e}`))
+          .catch((e) => logger.error(`error getting profile ${e}`))
       }
     } catch (e) {
       logger.error('error on configuring friends hud')

--- a/kernel/packages/entryPoints/unity.ts
+++ b/kernel/packages/entryPoints/unity.ts
@@ -4,7 +4,7 @@ declare const global: any
 // IMPORTANT! This should be execd before loading 'config' module to ensure that init values are successfully loaded
 global.enableWeb3 = true
 
-import { createLogger } from 'shared/logger'
+import defaultLogger, { createLogger } from 'shared/logger'
 import { ReportFatalError } from 'shared/loading/ReportFatalError'
 import { experienceStarted, NOT_INVITED, AUTH_ERROR_LOGGED_OUT, FAILED_FETCHING_UNITY } from 'shared/loading/types'
 import { worldToGrid } from '../atomicHelpers/parcelScenePositions'
@@ -13,7 +13,8 @@ import {
   DEBUG_PM,
   OPEN_AVATAR_EDITOR,
   ENABLE_MANA_HUD,
-  ENABLE_NEW_TASKBAR
+  ENABLE_NEW_TASKBAR,
+  HAS_INITIAL_POSITION_MARK
 } from '../config/index'
 import { signalRendererInitialized, signalParcelLoadingStarted } from 'shared/renderer/actions'
 import { lastPlayerPosition, teleportObservable } from 'shared/world/positionThings'
@@ -25,6 +26,7 @@ import { worldRunningObservable, onNextWorldRunning } from 'shared/world/worldSt
 import { getCurrentIdentity } from 'shared/session/selectors'
 import { userAuthentified } from 'shared/session'
 import { realmInitialized } from 'shared/dao'
+import { ProfileAsPromise } from 'shared/profiles/ProfileAsPromise'
 
 const container = document.getElementById('gameContainer')
 
@@ -46,7 +48,11 @@ initializeUnity(container)
     const i = (await instancedJS).unityInterface
 
     i.ConfigureHUDElement(HUDElementID.MINIMAP, { active: true, visible: true })
-    i.ConfigureHUDElement(HUDElementID.PROFILE_HUD, { active: true, visible: true }, { useNewVersion: ENABLE_NEW_TASKBAR })
+    i.ConfigureHUDElement(
+      HUDElementID.PROFILE_HUD,
+      { active: true, visible: true },
+      { useNewVersion: ENABLE_NEW_TASKBAR }
+    )
     i.ConfigureHUDElement(HUDElementID.NOTIFICATION, { active: true, visible: true })
     i.ConfigureHUDElement(HUDElementID.AVATAR_EDITOR, { active: true, visible: OPEN_AVATAR_EDITOR })
     i.ConfigureHUDElement(HUDElementID.SETTINGS, { active: true, visible: false })
@@ -67,7 +73,18 @@ initializeUnity(container)
       await userAuthentified()
       const identity = getCurrentIdentity(globalThis.globalStore.getState())!
       i.ConfigureHUDElement(HUDElementID.FRIENDS, { active: identity.hasConnectedWeb3, visible: false })
-      i.ConfigureHUDElement(HUDElementID.MANA_HUD, { active: ENABLE_MANA_HUD && identity.hasConnectedWeb3, visible: true })
+      i.ConfigureHUDElement(HUDElementID.MANA_HUD, {
+        active: ENABLE_MANA_HUD && identity.hasConnectedWeb3,
+        visible: true
+      })
+
+      if (ENABLE_NEW_TASKBAR) {
+        ProfileAsPromise(identity.address)
+          .then((profile) => {
+            i.ConfigureTutorial(profile.tutorialStep, HAS_INITIAL_POSITION_MARK)
+          })
+          .catch((e) => defaultLogger.log(`error getting profile ${e}`))
+      }
     } catch (e) {
       logger.error('error on configuring friends hud')
     }

--- a/kernel/packages/unity-interface/dcl.ts
+++ b/kernel/packages/unity-interface/dcl.ts
@@ -1,5 +1,5 @@
 import { TeleportController } from 'shared/world/TeleportController'
-import { DEBUG, EDITOR, ENGINE_DEBUG_PANEL, SCENE_DEBUG_PANEL, SHOW_FPS_COUNTER, NO_ASSET_BUNDLES, ENABLE_NEW_TASKBAR, HAS_INITIAL_POSITION_MARK } from 'config'
+import { DEBUG, EDITOR, ENGINE_DEBUG_PANEL, SCENE_DEBUG_PANEL, SHOW_FPS_COUNTER, NO_ASSET_BUNDLES, ENABLE_NEW_TASKBAR } from 'config'
 import { aborted } from 'shared/loading/ReportFatalError'
 import { loadingScenes, teleportTriggered } from 'shared/loading/types'
 import { defaultLogger } from 'shared/logger'
@@ -22,7 +22,6 @@ import { UnityInterface, unityInterface } from './UnityInterface'
 import { BrowserInterface, browserInterface } from './BrowserInterface'
 import { UnityScene } from './UnityScene'
 import { ensureUiApis } from 'shared/world/uiSceneInitializer'
-import { getUserProfile } from 'shared/comms/peers'
 
 declare const globalThis: UnityInterfaceContainer &
   BrowserInterfaceContainer &
@@ -121,10 +120,6 @@ export async function initializeEngine(_gameInstance: GameInstance) {
 
   if (ENGINE_DEBUG_PANEL) {
     unityInterface.SetEngineDebugPanel()
-  }
-
-  if (!DEBUG && ENABLE_NEW_TASKBAR) {
-    unityInterface.ConfigureTutorial(getUserProfile().profile.tutorialStep, HAS_INITIAL_POSITION_MARK)
   }
 
   if (!EDITOR) {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
@@ -294,7 +294,6 @@ public class HUDController : MonoBehaviour
 
                         taskbarHud.AddSettingsWindow(settingsHud);
                         taskbarHud.AddBackpackWindow(avatarEditorHud);
-                        taskbarHud.AddGoToGenesisWindow(goToGenesisPlazaHud);
                     }
                 }
                 else
@@ -337,6 +336,7 @@ public class HUDController : MonoBehaviour
                 break;
             case HUDElementID.GO_TO_GENESIS_PLAZA_HUD:
                 CreateHudElement<GoToGenesisPlazaHUDController>(configuration, hudElementId);
+                taskbarHud?.AddGoToGenesisWindow(goToGenesisPlazaHud);
                 break;
         }
 

--- a/unity-client/Assets/Tutorial/Prefabs/Common/TutorialRobot/Materials/Black_MTL.mat
+++ b/unity-client/Assets/Tutorial/Prefabs/Common/TutorialRobot/Materials/Black_MTL.mat
@@ -9,17 +9,21 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: Black_MTL
   m_Shader: {fileID: 4800000, guid: 7bc4dc8666ba3c94e80873a8e72e5b06, type: 3}
-  m_ShaderKeywords: VERTEX_COLOR_ON _EMISSION _NORMALMAP
-  m_LightmapFlags: 1
-  m_EnableInstancingVariants: 1
+  m_ShaderKeywords: 
+  m_LightmapFlags: 6
+  m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 2302
+  m_CustomRenderQueue: 2000
   stringTagMap:
     RenderType: Opaque
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
+    - _AlphaTexture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _BaseMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}

--- a/unity-client/Assets/Tutorial/Prefabs/Common/TutorialRobot/Materials/Glow_MTL.mat
+++ b/unity-client/Assets/Tutorial/Prefabs/Common/TutorialRobot/Materials/Glow_MTL.mat
@@ -9,9 +9,9 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: Glow_MTL
   m_Shader: {fileID: 4800000, guid: 7bc4dc8666ba3c94e80873a8e72e5b06, type: 3}
-  m_ShaderKeywords: VERTEX_COLOR_ON _EMISSION _NORMALMAP
-  m_LightmapFlags: 1
-  m_EnableInstancingVariants: 1
+  m_ShaderKeywords: _EMISSION
+  m_LightmapFlags: 2
+  m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: 2000
   stringTagMap:
@@ -20,6 +20,10 @@ Material:
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
+    - _AlphaTexture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _BaseMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}

--- a/unity-client/Assets/Tutorial/Prefabs/Common/TutorialRobot/Materials/Red_MTL.mat
+++ b/unity-client/Assets/Tutorial/Prefabs/Common/TutorialRobot/Materials/Red_MTL.mat
@@ -9,17 +9,21 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: Red_MTL
   m_Shader: {fileID: 4800000, guid: 7bc4dc8666ba3c94e80873a8e72e5b06, type: 3}
-  m_ShaderKeywords: VERTEX_COLOR_ON _EMISSION _NORMALMAP
+  m_ShaderKeywords: _EMISSION
   m_LightmapFlags: 1
-  m_EnableInstancingVariants: 1
+  m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 2302
+  m_CustomRenderQueue: 2000
   stringTagMap:
     RenderType: Opaque
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
+    - _AlphaTexture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _BaseMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}

--- a/unity-client/Assets/Tutorial/Prefabs/Common/TutorialRobot/Materials/White_MTL.mat
+++ b/unity-client/Assets/Tutorial/Prefabs/Common/TutorialRobot/Materials/White_MTL.mat
@@ -9,17 +9,21 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: White_MTL
   m_Shader: {fileID: 4800000, guid: 7bc4dc8666ba3c94e80873a8e72e5b06, type: 3}
-  m_ShaderKeywords: VERTEX_COLOR_ON _EMISSION _NORMALMAP
-  m_LightmapFlags: 1
-  m_EnableInstancingVariants: 1
+  m_ShaderKeywords: 
+  m_LightmapFlags: 6
+  m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 2302
+  m_CustomRenderQueue: 2000
   stringTagMap:
     RenderType: Opaque
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
+    - _AlphaTexture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _BaseMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}

--- a/unity-client/Assets/Tutorial/Prefabs/Resources/TutorialController.prefab
+++ b/unity-client/Assets/Tutorial/Prefabs/Resources/TutorialController.prefab
@@ -177,6 +177,7 @@ MonoBehaviour:
   - {fileID: 4712031868617782090, guid: 54219e5d1e0415f4ab74ddc2ee0adbfa, type: 3}
   - {fileID: 3037048280107810980, guid: e5f5e18a835a34e45830f29570029838, type: 3}
   - {fileID: 3680644473237013901, guid: 92afb818b93335f4c91c56034d82f56e, type: 3}
+  teacherCamera: {fileID: 604084521501385079}
   teacherRawImage: {fileID: 6732306866191114328}
   teacher: {fileID: 977289631841785178}
   teacherMovementSpeed: 0.8

--- a/unity-client/Assets/Tutorial/Scripts/TutorialController.cs
+++ b/unity-client/Assets/Tutorial/Scripts/TutorialController.cs
@@ -39,6 +39,7 @@ namespace DCL.Tutorial
         [SerializeField] internal List<TutorialStep> stepsOnGenesisPlazaAfterDeepLink = new List<TutorialStep>();
 
         [Header("3D Model Teacher")]
+        [SerializeField] internal Camera teacherCamera;
         [SerializeField] internal RawImage teacherRawImage;
         [SerializeField] internal TutorialTeacher teacher;
         [SerializeField] internal float teacherMovementSpeed = 4f;
@@ -63,12 +64,11 @@ namespace DCL.Tutorial
         private void Awake()
         {
             i = this;
+            ShowTeacher3DModel(false);
         }
 
         private void Start()
         {
-            ShowTeacher3DModel(false);
-
             if (debugRunTutorial)
                 SetTutorialEnabled(debugOpenedFromDeepLink.ToString());
         }
@@ -179,6 +179,7 @@ namespace DCL.Tutorial
         /// <param name="active">True for show the teacher.</param>
         public void ShowTeacher3DModel(bool active)
         {
+            teacherCamera.gameObject.SetActive(active);
             teacherRawImage.gameObject.SetActive(active);
         }
 


### PR DESCRIPTION
* the new materials GPU Instantiation were generating extreme freezes on Mac users 
* the constantly active tutorial camera was affecting performance as well

Using a Mac, you can test that rotating the camera at this place doesn't freeze the explorer anymore:
https://explorer.decentraland.zone/branch/fix/onboarding-performance/index.html?ENV=zone&position=64,-64