### PR TITLE
fix: show logs by default on preview mode

### DIFF
--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -124,7 +124,7 @@ export const DEBUG_WS_MESSAGES = location.search.indexOf('DEBUG_WS_MESSAGES') !=
 export const DEBUG_REDUX = location.search.indexOf('DEBUG_REDUX') !== -1
 export const DEBUG_LOGIN = location.search.indexOf('DEBUG_LOGIN') !== -1
 export const DEBUG_PM = location.search.indexOf('DEBUG_PM') !== -1
-export const DEBUG_SCENE_LOG = location.search.indexOf('DEBUG_SCENE_LOG') !== -1
+export const DEBUG_SCENE_LOG = DEBUG || location.search.indexOf('DEBUG_SCENE_LOG') !== -1
 
 export const INIT_PRE_LOAD = location.search.indexOf('INIT_PRE_LOAD') !== -1
 


### PR DESCRIPTION
In https://github.com/decentraland/explorer/pull/1326, we started using the query parameter `DEBUG_SCENE_LOG` so that logs could be activated in production.

However, by doing so, we disabled logs in preview mode, that were activated by default. It could still be turned on with the `DEBUG_SCENE_LOG` flag, but it caused confusion on users using the `@next` version of the SDK.

In this PR, we are activating the flag `DEBUG_SCENE_LOG` when `DEBUG` is also activated. Therefore, logs will be shown by default on preview and editor mode.