### PR TITLE
hotfix: deployment script is now aware of symbolic links

### DIFF
--- a/kernel/scripts/_utils.ts
+++ b/kernel/scripts/_utils.ts
@@ -22,6 +22,14 @@ export function copyFile(from: string, to: string) {
     throw new Error(`${from} does not exist`)
   }
 
+  // if it is not a file, remove it to avoid conflict with symbolic links
+  if (fs.existsSync(to)) {
+    const type = fs.lstatSync(to)
+    if (!type.isFile()) {
+      fs.removeSync(to)
+    }
+  }
+
   fs.copySync(from, to)
 
   if (!fs.existsSync(to)) {


### PR DESCRIPTION
NPM ignores symlinks when publishing. Yet we identify the file as existing. Therefore, it doesn't fail and the file is not published.