### PR TITLE
fix: AvatarShape calling OnPoolGet at start + update event + builder handling update event

### DIFF
--- a/unity-client/Assets/Builder/Scripts/Builder.asmdef
+++ b/unity-client/Assets/Builder/Scripts/Builder.asmdef
@@ -17,7 +17,8 @@
         "GUID:a3ceb534947fac14da25035bc5c24788",
         "GUID:a881b57670b1d2747a6d7f9e32b63230",
         "GUID:3bdb7fe910cce8d4888137cded3ba4a2",
-        "GUID:555c1f3c6d18648df910b7a1de75b424"
+        "GUID:555c1f3c6d18648df910b7a1de75b424",
+        "GUID:9fad297e585ef204c9c2c497d77099f0"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-client/Assets/Builder/Scripts/DCLBuilderEntity.cs
+++ b/unity-client/Assets/Builder/Scripts/DCLBuilderEntity.cs
@@ -3,6 +3,7 @@ using DCL.Helpers;
 using DCL.Models;
 using System;
 using System.Collections;
+using DCL;
 using UnityEngine;
 
 namespace Builder
@@ -66,6 +67,9 @@ namespace Builder
 
             entity.OnRemoved -= OnEntityRemoved;
             entity.OnRemoved += OnEntityRemoved;
+
+            AvatarShape.OnAvatarShapeUpdated -= OnAvatarShapeUpdated;
+            AvatarShape.OnAvatarShapeUpdated += OnAvatarShapeUpdated;
 
             DCLBuilderBridge.OnPreviewModeChanged -= OnPreviewModeChanged;
             DCLBuilderBridge.OnPreviewModeChanged += OnPreviewModeChanged;
@@ -164,6 +168,7 @@ namespace Builder
             rootEntity.OnShapeUpdated -= OnShapeUpdated;
             rootEntity.OnTransformChange -= OnTransformUpdated;
             DCLBuilderBridge.OnPreviewModeChanged -= OnPreviewModeChanged;
+            AvatarShape.OnAvatarShapeUpdated -= OnAvatarShapeUpdated;
             DestroyColliders();
         }
 
@@ -227,6 +232,16 @@ namespace Builder
             {
                 OnEntityTransformUpdated?.Invoke(this);
             }
+        }
+
+        private void OnAvatarShapeUpdated(DecentralandEntity entity, AvatarShape avatarShape)
+        {
+            if (rootEntity != entity)
+            {
+                return;
+            }
+
+            OnShapeUpdated(rootEntity);
         }
 
         private void OnPreviewModeChanged(bool isPreview)

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -4,6 +4,7 @@ using DCL.Interface;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using DCL.Models;
 using UnityEngine;
 
 namespace DCL
@@ -11,6 +12,8 @@ namespace DCL
     public class AvatarShape : BaseComponent
     {
         private const string CURRENT_PLAYER_ID = "CurrentPlayerInfoCardId";
+
+        public static event Action<DecentralandEntity, AvatarShape> OnAvatarShapeUpdated;
 
         public AvatarName avatarName;
         public AvatarRenderer avatarRenderer;
@@ -27,9 +30,9 @@ namespace DCL
         private MinimapMetadata.MinimapUserInfo avatarUserInfo = new MinimapMetadata.MinimapUserInfo();
         bool initializedPosition = false;
 
-        private void Start()
+        private void Awake()
         {
-            OnPoolGet();
+            currentPlayerInfoCardId = Resources.Load<StringVariable>(CURRENT_PLAYER_ID);
         }
 
         private void PlayerClicked()
@@ -105,6 +108,7 @@ namespace DCL
             avatarName.SetTalking(model.talking);
 
             everythingIsLoaded = true;
+            OnAvatarShapeUpdated?.Invoke(entity, this);
 
             onPointerDown.collider.enabled = true;
         }
@@ -140,14 +144,11 @@ namespace DCL
         {
             base.OnPoolGet();
 
-            currentPlayerInfoCardId = Resources.Load<StringVariable>(CURRENT_PLAYER_ID);
-
             everythingIsLoaded = false;
             initializedPosition = false;
             currentSerialization = "";
             model = new AvatarModel();
             lastAvatarPosition = null;
-            avatarUserInfo = new MinimapMetadata.MinimapUserInfo();
             avatarName.SetName(String.Empty);
         }
 


### PR DESCRIPTION
# What? <!-- what is this PR? -->
AvatarShape: Removed call for `OnPoolGet` from `Start` function.
AvatarShape: Added event triggered when AvatarShape is updated.
Builder: Handle AvatarShape's update.

# Why? <!-- Explain the reason -->
Calling `OnPoolGet` on `Start` was causing an issue where AvatarShape's model was being overwritten by a new instance before being send to AvatarRenderer, resulting in an invisible Avatar.
