### PR TITLE
hotfix: fix type errors in generated ECS definitions

### DIFF
--- a/kernel/scripts/buildEcsTypes.ts
+++ b/kernel/scripts/buildEcsTypes.ts
@@ -13,9 +13,17 @@ copyFile(original, root + '/types/dcl/index.d.ts')
 
 const dtsFile = ensureFileExists(root, '/types/dcl/index.d.ts')
 {
-  const content = readFileSync(dtsFile).toString()
+  let content = readFileSync(dtsFile).toString()
 
-  writeFileSync(dtsFile, content.replace(/^export /gm, ''))
+  content = content.replace(/^export declare/gm, 'declare')
+
+  content = content.replace(/^export \{([\s\n\r]*)\}/gm, '')
+
+  writeFileSync(dtsFile, content)
+
+  if (content.match(/\bexport\b/)) {
+    throw new Error(`The file ${dtsFile} contains exports:\n${content}`)
+  }
 
   if (content.match(/\bimport\b/)) {
     throw new Error(`The file ${dtsFile} contains imports:\n${content}`)


### PR DESCRIPTION
# What? <!-- what is this PR? -->
Removes tailing `{}` from generated ECS types.

# Why? <!-- Explain the reason -->
Now that we report the errors properly, we realized the index.d.ts had an extra "object" at the end of the file.

https://github.com/decentraland/smart-items/runs/1220928750#step:5:40

```
  node_modules/decentraland-ecs/types/dcl/index.d.ts:6480:1 - error TS1036: Statements are not allowed in ambient contexts.
  
  6480 {
       ~
  
  
  Found 1 error.
  ```
