### PR TITLE
fix: TextShape now implements visible and opacity correctly

### DIFF
--- a/kernel/packages/decentraland-ecs/src/decentraland/Components.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Components.ts
@@ -640,7 +640,7 @@ export class TextShape extends ObservableComponent {
   billboard: boolean = false
 
   @ObservableComponent.field
-  visible: boolean = false
+  visible: boolean = true
 
   constructor(value?: string) {
     super()

--- a/kernel/packages/decentraland-ecs/src/decentraland/Components.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Components.ts
@@ -557,7 +557,7 @@ export enum Fonts {
  * @public
  */
 @Component('engine.text', CLASS_ID.TEXT_SHAPE)
-export class TextShape extends Shape {
+export class TextShape extends ObservableComponent {
   @ObservableComponent.field
   outlineWidth: number = 0
 
@@ -638,6 +638,9 @@ export class TextShape extends Shape {
 
   @ObservableComponent.field
   billboard: boolean = false
+
+  @ObservableComponent.field
+  visible: boolean = false
 
   constructor(value?: string) {
     super()

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/TextShape/Tests/TextShapeTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/TextShape/Tests/TextShapeTests.cs
@@ -11,14 +11,6 @@ namespace Tests
 {
     public class TextShapeTests : TestsBase
     {
-        [UnitySetUp]
-        protected override IEnumerator SetUp()
-        {
-            yield return SetUp_SceneController();
-            yield return null;
-            yield return SetUp_SceneIntegrityChecker();
-        }
-
         [UnityTest]
         public IEnumerator TestCreate()
         {
@@ -136,6 +128,56 @@ namespace Tests
             Assert.AreEqual(0, textShapeComponent.model.lineCount);
             Assert.IsFalse(textShapeComponent.model.fontAutoSize);
             Assert.AreEqual(new Color(1, 1, 1), textShapeComponent.model.shadowColor);
+        }
+
+        [UnityTest]
+        [TestCase(0, ExpectedResult = null)]
+        [TestCase(0.3f, ExpectedResult = null)]
+        [TestCase(1, ExpectedResult = null)]
+        public IEnumerator OpacityIsProcessedCorrectly(float opacity)
+        {
+            DecentralandEntity entity = TestHelpers.CreateSceneEntity(scene);
+            TextShape textShapeComponent = TestHelpers.EntityComponentCreate<TextShape, TextShape.Model>(scene, entity, new TextShape.Model { value = "Hello test", opacity = opacity});
+
+            yield return textShapeComponent.routine;
+
+            TextMeshPro tmpro = textShapeComponent.gameObject.GetComponentInChildren<TextMeshPro>();
+
+            Assert.NotNull(tmpro);
+            Assert.AreEqual(opacity, textShapeComponent.model.opacity);
+            Assert.AreEqual(tmpro.color.a, opacity);
+        }
+
+        [UnityTest]
+        public IEnumerator VisibleTrueIsProcessedCorrectly()
+        {
+            DecentralandEntity entity = TestHelpers.CreateSceneEntity(scene);
+            TextShape textShapeComponent = TestHelpers.EntityComponentCreate<TextShape, TextShape.Model>(scene, entity, new TextShape.Model { value = "Hello test", opacity = 0.3f, visible = true});
+
+            yield return textShapeComponent.routine;
+
+            TextMeshPro tmpro = textShapeComponent.gameObject.GetComponentInChildren<TextMeshPro>();
+
+            Assert.NotNull(tmpro);
+            Assert.AreEqual(0.3f, textShapeComponent.model.opacity);
+            Assert.IsTrue(textShapeComponent.model.visible);
+            Assert.AreEqual(tmpro.color.a, 0.3f);
+        }
+
+        [UnityTest]
+        public IEnumerator VisibleFalseIsProcessedCorrectly()
+        {
+            DecentralandEntity entity = TestHelpers.CreateSceneEntity(scene);
+            TextShape textShapeComponent = TestHelpers.EntityComponentCreate<TextShape, TextShape.Model>(scene, entity, new TextShape.Model { value = "Hello test", opacity = 0.3f, visible = false});
+
+            yield return textShapeComponent.routine;
+
+            TextMeshPro tmpro = textShapeComponent.gameObject.GetComponentInChildren<TextMeshPro>();
+
+            Assert.NotNull(tmpro);
+            Assert.AreEqual(0.3f, textShapeComponent.model.opacity);
+            Assert.IsFalse(textShapeComponent.model.visible);
+            Assert.AreEqual(tmpro.color.a, 0f);
         }
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/TextShape/TextShape.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/TextShape/TextShape.cs
@@ -15,6 +15,8 @@ namespace DCL.Components
             [Header("Font Properties")]
             public string value = "";
 
+            public bool visible = true;
+
             public Color color = Color.white;
             public float opacity = 1f;
             public float fontSize = 100f;
@@ -86,7 +88,7 @@ namespace DCL.Components
 
             text.text = model.value;
 
-            text.color = new Color(model.color.r, model.color.g, model.color.b, model.color.a);
+            text.color = new Color(model.color.r, model.color.g, model.color.b, model.visible ? model.opacity : 0);
             text.fontSize = (int)model.fontSize;
             text.richText = true;
             text.overflowMode = TextOverflowModes.Overflow;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIText/Tests/UITextTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIText/Tests/UITextTests.cs
@@ -83,7 +83,7 @@ namespace Tests
             Assert.AreEqual(50f, uiTextShape.childHookRectTransform.rect.height);
             Assert.AreEqual("hello world", uiTextShape.referencesContainer.text.text);
             Assert.IsTrue(uiTextShape.referencesContainer.text.enabled);
-            Assert.AreEqual(new Color(0f, 1f, 0f, 1f), uiTextShape.referencesContainer.text.color);
+            Assert.AreEqual(new Color(0f, 1f, 0f, 0.5f), uiTextShape.referencesContainer.text.color);
             Assert.AreEqual(35f, uiTextShape.referencesContainer.text.fontSize);
             Assert.AreEqual(3, uiTextShape.referencesContainer.text.maxVisibleLines);
             Assert.AreEqual(0.1f, uiTextShape.referencesContainer.text.lineSpacing);


### PR DESCRIPTION
#827

The problem is `TextShape` in Unity not extending `BaseShape` where this property exists. This is problematic for various reasons:
- `TextShape` currently is a `BaseComponent` in Unity, that means that changing the parent class to `BaseShape` (which is a Disposable component) can get really messy.
- Another side effect of making `TextShape` a `BaseShape` are the properties `withCollision` and `isPointerBlocker`. After discussing it with Nico, these two are enabled by default in kernel, which means that the current deployed scenes using `TextShape` has these properties already set by default to `true`. If we implement said properties in Unity we might be introducing a gamebreaking change.

On a side note, this ticket will also fix #1392