### PR TITLE
chore: wearables retry tests

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
@@ -291,7 +291,7 @@ namespace DCL
             OnFailEvent?.Invoke();
         }
 
-        void OnWearableLoadingFail(WearableController wearableController, int retriesCount = MAX_RETRIES)
+        protected virtual void OnWearableLoadingFail(WearableController wearableController, int retriesCount = MAX_RETRIES)
         {
             if (retriesCount <= 0)
             {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarRenderer.cs
@@ -9,7 +9,7 @@ namespace DCL
 {
     public class AvatarRenderer : MonoBehaviour
     {
-        private const int MAX_RETRIES = 5;
+        public  const int MAX_RETRIES = 5;
 
         public Material defaultMaterial;
         public Material eyeMaterial;
@@ -344,7 +344,7 @@ namespace DCL
                     break;
 
                 default:
-                    var wearableController = new WearableController(wearable, bodyShapeController.id);
+                    var wearableController = wearableFactory.Create(wearable, bodyShapeController.id);
                     wearableControllers.Add(wearable, wearableController);
                     break;
             }
@@ -400,5 +400,14 @@ namespace DCL
         {
             CleanupAvatar();
         }
+
+        public WearableFactory wearableFactory = new WearableFactory();
+
     }
+
+    public class WearableFactory
+    {
+        public virtual WearableController Create(WearableItem item, string bodyShapeId) => new WearableController(item, bodyShapeId);
+    }
+
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/Tests/AvatarShape_Helpers.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/Tests/AvatarShape_Helpers.cs
@@ -156,7 +156,7 @@ namespace AvatarShape_Tests
 
         public Renderer[] myAssetRenderers => assetRenderers;
         public GameObject myAssetContainer => assetContainer;
-        public RendereableAssetLoadHelper myLoader => loader;
+        public IRendereableAssetLoadHelper myLoader => loader;
     }
 
     class BodyShapeController_Mock : BodyShapeController

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/WearableController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/WearableController.cs
@@ -43,7 +43,7 @@ public class WearableController
         assetRenderers = original.assetRenderers;
     }
 
-    protected virtual IRendereableAssetLoadHelper CreateRendereableAssetLoaderHelper()
+    public virtual IRendereableAssetLoadHelper CreateRendereableAssetLoaderHelper()
     {
         return new RendereableAssetLoadHelper();
     }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/LoadWrapper_GLTF.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/LoadWrapper_GLTF.cs
@@ -22,7 +22,7 @@ namespace DCL.Components
 
             alreadyLoaded = false;
             Assert.IsFalse(string.IsNullOrEmpty(targetUrl), "url is null!!");
-            loadHelper = new RendereableAssetLoadHelper(this.entity.scene.contentProvider, entity.scene.sceneData.baseUrlBundles);
+            loadHelper = new RendereableAssetLoadHelper();
 
             loadHelper.settings.parent = entity.meshRootGameObject.transform;
 
@@ -40,7 +40,7 @@ namespace DCL.Components
 
             loadHelper.OnSuccessEvent += (x) => OnSuccessWrapper(OnSuccess);
             loadHelper.OnFailEvent += () => OnFailWrapper(OnSuccess);
-            loadHelper.Load(targetUrl);
+            loadHelper.Load(this.entity.scene.contentProvider, entity.scene.sceneData.baseUrlBundles, targetUrl);
         }
 
         private void OnFailWrapper(Action<LoadWrapper> OnFail)

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/RendereableAssetLoadHelper.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/RendereableAssetLoadHelper.cs
@@ -27,8 +27,8 @@ namespace DCL.Components
 
         private static bool VERBOSE = false;
 
-        public event Action<GameObject> OnSuccessEvent;
-        public event Action OnFailEvent;
+        public virtual event Action<GameObject> OnSuccessEvent;
+        public virtual event Action OnFailEvent;
 
         //TODO These statics are coupling this script to WSSController and SceneController.
         //     We can break it with ScriptableObjects.
@@ -56,7 +56,7 @@ namespace DCL.Components
             }
         }
 
-        public void Load(ContentProvider contentProvider, string bundlesContentUrl, string targetUrl)
+        public virtual void Load(ContentProvider contentProvider, string bundlesContentUrl, string targetUrl)
         {
             Assert.IsFalse(string.IsNullOrEmpty(targetUrl), "url is null!!");
 #if UNITY_EDITOR


### PR DESCRIPTION
#1331 
This PR contains:
- A refactor in the `RendereableAssetLoadHelper` to make it mockable. I'm happy with the result, it looks cleaner and I dont see any downside.

- A refactor of the `AvatarRenderer` to be able to create the wearable controllers through a mockable factory. I cannot think of a better approach but I still dont like this one. Without a deep refactor of how the `AvatarRenderer` works to be able to have real DI is gonna be tricky.

- A test for the wearables retry. I personally find this test a bit hard to follow, but without the deep refactor previously mentioned we cannot test this in a better way.