### PR TITLE
fix: use correct version before publish

### DIFF
--- a/kernel/static/package.json
+++ b/kernel/static/package.json
@@ -4,6 +4,6 @@
   "license": "Apache-2.0",
   "bundleDependencies": ["decentraland-renderer"],
   "devDependencies": {
-    "decentraland-renderer": "{TEMPLATE}"
+    "decentraland-renderer": "1.0.0"
   }
 }


### PR DESCRIPTION
# What? <!-- what is this PR? -->
Even though the version is **always** overwritten. For some reason it has to be a valid semver.


