### PR TITLE
Fix typo in Tutorial

### DIFF
--- a/unity-client/Assets/Tutorial/Prefabs/Steps/TutorialStep_TaskbarTooltip_ExploreButton.prefab
+++ b/unity-client/Assets/Tutorial/Prefabs/Steps/TutorialStep_TaskbarTooltip_ExploreButton.prefab
@@ -174,7 +174,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Use the Explore tool to quickly find crowded-hignlighted scenes
+  m_text: Use the Explore tool to quickly find crowded-highlighted scenes
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
   m_sharedMaterial: {fileID: -6892909264025736228, guid: 26b03903800224f718b64e9afbc91b61,


### PR DESCRIPTION
Fix the message showed in the tutorial tooltip related to the explore button in the taskbar.