### PR TITLE
chore: update canvas mask bottom limit

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIContainer/UISizeFitter.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIContainer/UISizeFitter.cs
@@ -21,11 +21,10 @@ public class UISizeFitter : MonoBehaviour
     {
         if (canvasChildHookRT == null)
         {
-            RectMask2D constrainedPanelMask = GetComponentInParent<RectMask2D>();
-
-            if(constrainedPanelMask != null)
+            CanvasRenderer resizedCanvasPanel = GetComponentInParent<CanvasRenderer>();
+            if (resizedCanvasPanel != null)
             {
-                canvasChildHookRT = constrainedPanelMask.GetComponent<RectTransform>();
+                canvasChildHookRT = resizedCanvasPanel.GetComponent<RectTransform>();
                 return;
             }
 
@@ -36,9 +35,9 @@ public class UISizeFitter : MonoBehaviour
     public void FitSizeToChildren(bool adjustWidth = true, bool adjustHeight = true)
     {
         UIReferencesContainer[] containers = GetComponentsInChildren<UIReferencesContainer>();
-        
+
         EnsureCanvasChildHookRectTransform();
-        
+
         RectTransform rt = transform as RectTransform;
 
         if (rt == null || canvasChildHookRT == null || containers == null || containers.Length == 0)

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIScreenSpace/Tests/UIScreenSpaceTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIScreenSpace/Tests/UIScreenSpaceTests.cs
@@ -106,25 +106,6 @@ namespace Tests
         }
 
         [UnityTest]
-        public IEnumerator TestConstrainedPanelMaskAppliesToParcelsUI()
-        {
-            scene.isPersistent = false;
-            yield return null;
-
-            // Create UIScreenSpaceShape
-            UIScreenSpace screenSpaceShape =
-                TestHelpers.SharedComponentCreate<UIScreenSpace, UIScreenSpace.Model>(scene,
-                    CLASS_ID.UI_SCREEN_SPACE_SHAPE);
-
-            yield return screenSpaceShape.routine;
-
-            Assert.IsFalse(scene.isPersistent);
-            Assert.IsTrue(screenSpaceShape.childHookRectTransform.GetComponent<UnityEngine.UI.RectMask2D>() != null);
-
-            screenSpaceShape.Dispose();
-        }
-
-        [UnityTest]
         public IEnumerator TestConstrainedPanelMaskDoesntApplyToDecentralandUI()
         {
             scene.isPersistent = true;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIScreenSpace/UIScreenSpace.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIScreenSpace/UIScreenSpace.cs
@@ -148,11 +148,17 @@ namespace DCL.Components
                 childHookRectTransform.anchorMin = Vector2.zero;
                 childHookRectTransform.anchorMax = new Vector2(1, 0);
 
+                // We scale the panel downwards to subtract the viewport's top 10%
                 float canvasHeight = canvasScaler.referenceResolution.y;
+                childHookRectTransform.pivot = new Vector2(0.5f, 0f);
+                float canvasSubtraction = canvasHeight * UISettings.RESERVED_CANVAS_TOP_PERCENTAGE / 100;
+                childHookRectTransform.sizeDelta = new Vector2(0, canvasHeight - canvasSubtraction);
+
+                // We scale the panel upwards to subtract the viewport's bottom 5% for Decentraland's taskbar
+                canvasHeight = childHookRectTransform.sizeDelta.y;
                 childHookRectTransform.pivot = new Vector2(0.5f, 1f);
                 childHookRectTransform.anchoredPosition = new Vector3(0, canvasHeight, 0f);
-                float canvasSubtraction = canvasHeight * 0.05f;
-                childHookRectTransform.sizeDelta = new Vector2(0, canvasHeight - canvasSubtraction);
+                childHookRectTransform.sizeDelta = new Vector2(0, canvasHeight - canvasSubtraction / 2);
             }
 
             // Canvas group

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIScreenSpace/UIScreenSpace.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIScreenSpace/UIScreenSpace.cs
@@ -143,13 +143,20 @@ namespace DCL.Components
                 childHookRectTransform.SetParent(canvas.transform);
                 childHookRectTransform.ResetLocalTRS();
 
-                float canvasHeight = canvasScaler.referenceResolution.y;
-
                 childHookRectTransform.anchorMin = Vector2.zero;
                 childHookRectTransform.anchorMax = new Vector2(1, 0);
+
+                // We scale the panel downwards to subtract the viewport's top 10%
+                float canvasHeight = canvasScaler.referenceResolution.y;
                 childHookRectTransform.pivot = new Vector2(0.5f, 0f);
-                // We scale the panel downwards to release the viewport's top 10%
-                childHookRectTransform.sizeDelta = new Vector2(0, canvasHeight - (canvasHeight * UISettings.RESERVED_CANVAS_TOP_PERCENTAGE / 100));
+                float canvasSubtraction = canvasHeight * UISettings.RESERVED_CANVAS_TOP_PERCENTAGE / 100;
+                childHookRectTransform.sizeDelta = new Vector2(0, canvasHeight - canvasSubtraction);
+
+                // We scale the panel upwards to subtract the viewport's bottom 10% for Decentraland's taskbar
+                canvasHeight = childHookRectTransform.sizeDelta.y;
+                childHookRectTransform.pivot = new Vector2(0.5f, 1f);
+                childHookRectTransform.anchoredPosition = new Vector3(0, canvasHeight, 0f);
+                childHookRectTransform.sizeDelta = new Vector2(0, canvasHeight - canvasSubtraction / 2);
             }
 
             // Canvas group

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIScreenSpace/UIScreenSpace.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIScreenSpace/UIScreenSpace.cs
@@ -136,27 +136,23 @@ namespace DCL.Components
             {
                 canvas.sortingOrder = -1;
 
-                // "Constrained" panel mask (to avoid rendering parcels UI on the viewport's top 10%)
-                GameObject constrainedPanel = new GameObject("ConstrainedPanel");
-                constrainedPanel.AddComponent<RectMask2D>();
-                childHookRectTransform = constrainedPanel.GetComponent<RectTransform>();
+                GameObject resizedPanel = new GameObject("ResizeUIArea");
+
+                resizedPanel.AddComponent<RectMask2D>().enabled = false; // TODO: find a way of avoiding this RectMask (right now if we remove it that gameobject gets destroyed somehow...)
+
+                resizedPanel.AddComponent<CanvasRenderer>();
+                childHookRectTransform = resizedPanel.GetComponent<RectTransform>();
                 childHookRectTransform.SetParent(canvas.transform);
                 childHookRectTransform.ResetLocalTRS();
 
                 childHookRectTransform.anchorMin = Vector2.zero;
                 childHookRectTransform.anchorMax = new Vector2(1, 0);
 
-                // We scale the panel downwards to subtract the viewport's top 10%
                 float canvasHeight = canvasScaler.referenceResolution.y;
-                childHookRectTransform.pivot = new Vector2(0.5f, 0f);
-                float canvasSubtraction = canvasHeight * UISettings.RESERVED_CANVAS_TOP_PERCENTAGE / 100;
-                childHookRectTransform.sizeDelta = new Vector2(0, canvasHeight - canvasSubtraction);
-
-                // We scale the panel upwards to subtract the viewport's bottom 5% for Decentraland's taskbar
-                canvasHeight = childHookRectTransform.sizeDelta.y;
                 childHookRectTransform.pivot = new Vector2(0.5f, 1f);
                 childHookRectTransform.anchoredPosition = new Vector3(0, canvasHeight, 0f);
-                childHookRectTransform.sizeDelta = new Vector2(0, canvasHeight - canvasSubtraction / 2);
+                float canvasSubtraction = canvasHeight * 0.05f;
+                childHookRectTransform.sizeDelta = new Vector2(0, canvasHeight - canvasSubtraction);
             }
 
             // Canvas group

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIScreenSpace/UIScreenSpace.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIScreenSpace/UIScreenSpace.cs
@@ -138,10 +138,8 @@ namespace DCL.Components
 
                 GameObject resizedPanel = new GameObject("ResizeUIArea");
 
-                resizedPanel.AddComponent<RectMask2D>().enabled = false; // TODO: find a way of avoiding this RectMask (right now if we remove it that gameobject gets destroyed somehow...)
-
                 resizedPanel.AddComponent<CanvasRenderer>();
-                childHookRectTransform = resizedPanel.GetComponent<RectTransform>();
+                childHookRectTransform = resizedPanel.AddComponent<RectTransform>();
                 childHookRectTransform.SetParent(canvas.transform);
                 childHookRectTransform.ResetLocalTRS();
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIScreenSpace/UIScreenSpace.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIScreenSpace/UIScreenSpace.cs
@@ -152,7 +152,7 @@ namespace DCL.Components
                 float canvasSubtraction = canvasHeight * UISettings.RESERVED_CANVAS_TOP_PERCENTAGE / 100;
                 childHookRectTransform.sizeDelta = new Vector2(0, canvasHeight - canvasSubtraction);
 
-                // We scale the panel upwards to subtract the viewport's bottom 10% for Decentraland's taskbar
+                // We scale the panel upwards to subtract the viewport's bottom 5% for Decentraland's taskbar
                 canvasHeight = childHookRectTransform.sizeDelta.y;
                 childHookRectTransform.pivot = new Vector2(0.5f, 1f);
                 childHookRectTransform.anchoredPosition = new Vector3(0, canvasHeight, 0f);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
@@ -57,6 +57,11 @@ namespace DCL.Configuration
         public static float LOAD_PARCEL_SCENES_THROTTLING_TIME = SIXTY_FPS_TIME / 4.0f;
     }
 
+    public static class UISettings
+    {
+        public static float RESERVED_CANVAS_TOP_PERCENTAGE = 10f;
+    }
+
     public static class NFTDataFetchingSettings
     {
         public static UnityEngine.Vector2

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Configuration/Configuration.cs
@@ -57,11 +57,6 @@ namespace DCL.Configuration
         public static float LOAD_PARCEL_SCENES_THROTTLING_TIME = SIXTY_FPS_TIME / 4.0f;
     }
 
-    public static class UISettings
-    {
-        public static float RESERVED_CANVAS_TOP_PERCENTAGE = 10f;
-    }
-
     public static class NFTDataFetchingSettings
     {
         public static UnityEngine.Vector2

--- a/unity-client/TestResources/VisualTests/BaselineImages/UIContainerStackTest_0.png
+++ b/unity-client/TestResources/VisualTests/BaselineImages/UIContainerStackTest_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:00dbba613e0eb7a2d8ec3ff0253fff5ecd3f3b8baccf48d4b25921f9f1dd233c
-size 112087
+oid sha256:227d706519cbf197e260776d6a687723b43679ad819a9a41e47655978f48284d
+size 88031


### PR DESCRIPTION
Updated scenes ui canvas:
- Replaced mask-middle-gameobject with a new canvas renderer with no mask and the bottom limit lifted according to the new taskbar

### **BEFORE**
![Screen Shot 2020-10-19 at 13 47 57](https://user-images.githubusercontent.com/1031741/96481544-f0491f00-1211-11eb-961e-758ea5fc6952.png)
![Screen Shot 2020-10-19 at 13 49 21](https://user-images.githubusercontent.com/1031741/96481579-f212e280-1211-11eb-8515-1745c252e5a7.png)
![Screen Shot 2020-10-19 at 13 48 22](https://user-images.githubusercontent.com/1031741/96481603-f3dca600-1211-11eb-8cdd-0fe630c0320d.png)


### **AFTER**
![Screen Shot 2020-10-16 at 16 48 40](https://user-images.githubusercontent.com/1031741/96480864-2f2aa500-1211-11eb-899d-38fa2876900d.png)
![Screen Shot 2020-10-16 at 16 48 07](https://user-images.githubusercontent.com/1031741/96480884-318cff00-1211-11eb-9832-fee48a95827c.png)
![Screen Shot 2020-10-16 at 16 49 02](https://user-images.githubusercontent.com/1031741/96480905-33ef5900-1211-11eb-89c1-54fb68570788.png)
