### PR TITLE
Temporarily turn off the MANA HUD

### DIFF
--- a/kernel/packages/entryPoints/unity.ts
+++ b/kernel/packages/entryPoints/unity.ts
@@ -68,7 +68,8 @@ initializeUnity(container)
       await userAuthentified()
       const identity = getCurrentIdentity(globalThis.globalStore.getState())!
       i.ConfigureHUDElement(HUDElementID.FRIENDS, { active: identity.hasConnectedWeb3, visible: false })
-      i.ConfigureHUDElement(HUDElementID.MANA_HUD, { active: identity.hasConnectedWeb3, visible: true })
+      // NOTE (Santi): We have temporarily deactivated the MANA HUD until Product team designs a new place for it (probably inside the Profile HUD).
+      i.ConfigureHUDElement(HUDElementID.MANA_HUD, { active: identity.hasConnectedWeb3 && false, visible: true })
 
       EnsureProfile(identity.address)
           .then((profile) => {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
@@ -336,10 +336,9 @@ public class HUDController : MonoBehaviour
                     taskbarHud?.AddExploreWindow(exploreHud);
                 }
                 break;
-            // NOTE (Santi): We have temporarily turned off the MANA HUD until Product team designs a new place for it (probably inside the Profile HUD).
-            //case HUDElementID.MANA_HUD:
-            //    CreateHudElement<ManaHUDController>(configuration, hudElementId);
-            //    break;
+            case HUDElementID.MANA_HUD:
+                CreateHudElement<ManaHUDController>(configuration, hudElementId);
+                break;
             case HUDElementID.HELP_AND_SUPPORT_HUD:
                 CreateHudElement<HelpAndSupportHUDController>(configuration, hudElementId);
                 taskbarHud?.AddHelpAndSupportWindow(helpAndSupportHud);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
@@ -336,9 +336,10 @@ public class HUDController : MonoBehaviour
                     taskbarHud?.AddExploreWindow(exploreHud);
                 }
                 break;
-            case HUDElementID.MANA_HUD:
-                CreateHudElement<ManaHUDController>(configuration, hudElementId);
-                break;
+            // NOTE (Santi): We have temporarily turned off the MANA HUD until Product team designs a new place for it (probably inside the Profile HUD).
+            //case HUDElementID.MANA_HUD:
+            //    CreateHudElement<ManaHUDController>(configuration, hudElementId);
+            //    break;
             case HUDElementID.HELP_AND_SUPPORT_HUD:
                 CreateHudElement<HelpAndSupportHUDController>(configuration, hudElementId);
                 taskbarHud?.AddHelpAndSupportWindow(helpAndSupportHud);


### PR DESCRIPTION
After some feedback from the team, we have decided temporarily turned off the `MANA HUD` until Product team designs a new place for it (probably inside the Profile HUD).