### PR TITLE
fix: nullcheck in avatar

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/BodyShapeController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/BodyShapeController.cs
@@ -102,7 +102,7 @@ public class BodyShapeController : WearableController, IBodyShapeController
     {
         if (assetContainer?.transform == null)
         {
-            Debug.LogWarning("Tried to setup eyes when the asset not ready");
+            Debug.LogWarning("Tried to setup mouth when the asset not ready");
             return;
         }
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/BodyShapeController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/BodyShapeController.cs
@@ -53,6 +53,12 @@ public class BodyShapeController : WearableController, IBodyShapeController
 
     public void SetupEyes(Material material, Texture texture, Texture mask, Color color)
     {
+        if (assetContainer?.transform == null)
+        {
+            Debug.LogWarning("Tried to setup eyes when the asset not ready");
+            return;
+        }
+
         AvatarUtils.MapSharedMaterialsRecursively(assetContainer.transform,
             (mat) =>
             {
@@ -66,6 +72,12 @@ public class BodyShapeController : WearableController, IBodyShapeController
 
     public void SetupEyebrows(Material material, Texture texture, Color color)
     {
+        if (assetContainer?.transform == null)
+        {
+            Debug.LogWarning("Tried to setup eyes when the asset not ready");
+            return;
+        }
+
         AvatarUtils.MapSharedMaterialsRecursively(assetContainer.transform,
             (mat) =>
             {
@@ -88,6 +100,12 @@ public class BodyShapeController : WearableController, IBodyShapeController
 
     public void SetupMouth(Material material, Texture texture, Color color)
     {
+        if (assetContainer?.transform == null)
+        {
+            Debug.LogWarning("Tried to setup eyes when the asset not ready");
+            return;
+        }
+
         AvatarUtils.MapSharedMaterialsRecursively(assetContainer.transform,
             (mat) =>
             {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/BodyShapeController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/BodyShapeController.cs
@@ -74,7 +74,7 @@ public class BodyShapeController : WearableController, IBodyShapeController
     {
         if (assetContainer?.transform == null)
         {
-            Debug.LogWarning("Tried to setup eyes when the asset not ready");
+            Debug.LogWarning("Tried to setup eyebrows when the asset not ready");
             return;
         }
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/WearableController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/WearableController.cs
@@ -64,7 +64,10 @@ public class WearableController
 
         void OnSuccessWrapper(GameObject gameObject)
         {
-            loader.OnSuccessEvent -= OnSuccessWrapper;
+            if (loader != null)
+            {
+                loader.OnSuccessEvent -= OnSuccessWrapper;
+            }
             assetRenderers = gameObject.GetComponentsInChildren<Renderer>();
             PrepareWearable(gameObject);
             onSuccess?.Invoke(this);
@@ -73,8 +76,12 @@ public class WearableController
 
         void OnFailEventWrapper()
         {
-            loader.OnFailEvent -= OnFailEventWrapper;
-            loader = null;
+            if (loader != null)
+            {
+                loader.OnFailEvent -= OnFailEventWrapper;
+                loader.ClearEvents();
+                loader = null;
+            }
             onFail?.Invoke(this);
         }
         loader.OnFailEvent += OnFailEventWrapper;


### PR DESCRIPTION
#1440 
AvatarRenderer system is throwing some uncatched null references. Let's avoid them until we discover the underlying cause.