### PR TITLE
fix: Don't send all avatar events

### DIFF
--- a/kernel/packages/shared/analytics.ts
+++ b/kernel/packages/shared/analytics.ts
@@ -104,9 +104,21 @@ function track({ name, data }: SegmentEvent) {
   })
 }
 
+const TRACEABLE_AVATAR_EVENTS = [
+  AvatarMessageType.ADD_FRIEND,
+  AvatarMessageType.USER_DATA,
+  AvatarMessageType.USER_EXPRESSION,
+  AvatarMessageType.USER_REMOVED,
+  AvatarMessageType.SET_LOCAL_UUID,
+  AvatarMessageType.USER_MUTED,
+  AvatarMessageType.USER_UNMUTED,
+  AvatarMessageType.USER_BLOCKED,
+  AvatarMessageType.USER_UNBLOCKED
+]
+
 function hookObservables() {
   avatarMessageObservable.add(({ type, ...data }) => {
-    if (type === AvatarMessageType.USER_VISIBLE || type === AvatarMessageType.USER_POSE) {
+    if (!TRACEABLE_AVATAR_EVENTS.includes(type)) {
       return
     }
 

--- a/kernel/packages/shared/comms/interface/types.ts
+++ b/kernel/packages/shared/comms/interface/types.ts
@@ -17,8 +17,7 @@ export enum AvatarMessageType {
   USER_BLOCKED = 'USER_BLOCKED',
   USER_UNBLOCKED = 'USER_UNBLOCKED',
 
-  ADD_FRIEND = 'ADD_FRIEND',
-  SHOW_WINDOW = 'SHOW_WINDOW'
+  ADD_FRIEND = 'ADD_FRIEND'
 }
 
 export type ReceiveUserExpressionMessage = {
@@ -64,7 +63,6 @@ export type UserMessage = {
     | AvatarMessageType.USER_UNBLOCKED
     | AvatarMessageType.USER_MUTED
     | AvatarMessageType.USER_UNMUTED
-    | AvatarMessageType.SHOW_WINDOW
     | AvatarMessageType.USER_TALKING
   uuid: string
 }

--- a/kernel/packages/ui/avatar/avatarSystem.ts
+++ b/kernel/packages/ui/avatar/avatarSystem.ts
@@ -10,7 +10,6 @@ import {
   ReceiveUserTalkingMessage,
   ReceiveUserVisibleMessage,
   UserInformation,
-  UserMessage,
   UserRemovedMessage,
   UUID
 } from 'shared/comms/interface/types'
@@ -195,10 +194,6 @@ function handleUserRemoved({ uuid }: UserRemovedMessage): void {
   }
 }
 
-function handleShowWindow({ uuid }: UserMessage): void {
-  // noop
-}
-
 avatarMessageObservable.add((evt) => {
   if (evt.type === AvatarMessageType.USER_DATA) {
     handleUserData(evt)
@@ -212,7 +207,5 @@ avatarMessageObservable.add((evt) => {
     handleUserRemoved(evt)
   } else if (evt.type === AvatarMessageType.USER_TALKING) {
     handleUserTalkingUpdate(evt as ReceiveUserTalkingMessage)
-  } else if (evt.type === AvatarMessageType.SHOW_WINDOW) {
-    handleShowWindow(evt)
   }
 })


### PR DESCRIPTION
Changed Avatar Events tracking so it only tracks the specified events and not every new event added