### PR TITLE
fix: Added nullsafe check in TaskbarHUD -> ShowTutorialOption()

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/TaskbarHUDController.cs
@@ -560,6 +560,7 @@ public class TaskbarHUDController : IHUD
 
     public void ShowTutorialOption(bool isActive)
     {
-        view.moreMenu.ShowTutorialButton(isActive);
+        if (view != null && view.moreMenu != null)
+            view.moreMenu.ShowTutorialButton(isActive);
     }
 }


### PR DESCRIPTION
Avoid a null reference error that we were receiving sometimes on the app shutdown.