### PR TITLE
test: selective UI enable + verbose asset bundle loading

### DIFF
--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -96,6 +96,7 @@ export const GIF_WORKERS = location.search.indexOf('GIF_WORKERS') !== -1
 
 const qs = queryString.parse(location.search)
 
+export const ENABLE_UI = qs.enable_ui
 // Comms
 export const USE_LOCAL_COMMS = location.search.indexOf('LOCAL_COMMS') !== -1 || PREVIEW
 export const COMMS = USE_LOCAL_COMMS ? 'v1-local' : qs.COMMS ? qs.COMMS : 'v2-p2p' // by default

--- a/kernel/packages/entryPoints/unity.ts
+++ b/kernel/packages/entryPoints/unity.ts
@@ -11,9 +11,7 @@ import { worldToGrid } from '../atomicHelpers/parcelScenePositions'
 import {
   NO_MOTD,
   DEBUG_PM,
-  OPEN_AVATAR_EDITOR,
   HAS_INITIAL_POSITION_MARK,
-  VOICE_CHAT_ENABLED
 } from '../config/index'
 import { signalRendererInitialized, signalParcelLoadingStarted } from 'shared/renderer/actions'
 import { lastPlayerPosition, teleportObservable } from 'shared/world/positionThings'

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/AssetBundlesLoader.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/AssetBundlesLoader.cs
@@ -132,12 +132,15 @@ namespace DCL
                 yield break;
             }
 
+            Debug.Log("AssetBundleLoader >>> LOADING START ... " + assetBundleInfo.asset.id);
             AssetBundleRequest abRequest = assetBundleInfo.assetBundle.LoadAllAssetsAsync();
 
             while (!abRequest.isDone)
             {
                 yield return null;
             }
+
+            Debug.Log("AssetBundleLoader >>> LOADING END ... " + assetBundleInfo.asset.id);
 
             loadedAssetsByName = abRequest.allAssets.ToList();
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/AssetBundlesLoader.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/AssetBundles/AB/AssetBundlesLoader.cs
@@ -126,6 +126,12 @@ namespace DCL
 
         private IEnumerator LoadAssetBundle(AssetBundleInfo assetBundleInfo)
         {
+            if ((string) assetBundleInfo.asset.id == "QmXrJp5ZKB1GeWjJvg4tArAcvwyqyBmydLbN7L6VT5gnf7")
+            {
+                assetBundleInfo.onFail?.Invoke();
+                yield break;
+            }
+
             if (assetBundleInfo.assetBundle == null)
             {
                 assetBundleInfo.onFail?.Invoke();

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/NotificationsController/NotificationsController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/NotificationsController/NotificationsController.cs
@@ -68,6 +68,7 @@ public class NotificationsController : MonoBehaviour
             timer = NOTIFICATION_DURATION
         };
 
-        controller.ShowNotification(model);
+        if (controller != null)
+            controller.ShowNotification(model);
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
@@ -49,7 +49,7 @@ namespace DCL
 
 #if !UNITY_EDITOR
             Debug.Log("DCL Unity Build Version: " + DCL.Configuration.ApplicationSettings.version);
-            Debug.unityLogger.logEnabled = false;
+            Debug.unityLogger.logEnabled = true;
 #endif
 
             InitializeSceneBoundariesChecker();
@@ -64,8 +64,8 @@ namespace DCL
 
             ParcelScene.parcelScenesCleaner.Start();
 
-            if (deferredMessagesDecoding)             // We should be able to delete this code
-                StartCoroutine(DeferredDecoding());   //
+            if (deferredMessagesDecoding) // We should be able to delete this code
+                StartCoroutine(DeferredDecoding()); //
 
             DCLCharacterController.OnCharacterMoved += SetPositionDirty;
 
@@ -223,99 +223,99 @@ namespace DCL
                 switch (method)
                 {
                     case MessagingTypes.ENTITY_CREATE:
-                        {
-                            if (msgObject.payload is Protocol.CreateEntity payload)
-                                scene.CreateEntity(payload.entityId);
+                    {
+                        if (msgObject.payload is Protocol.CreateEntity payload)
+                            scene.CreateEntity(payload.entityId);
 
-                            break;
-                        }
+                        break;
+                    }
                     case MessagingTypes.ENTITY_REPARENT:
-                        {
-                            if (msgObject.payload is Protocol.SetEntityParent payload)
-                                scene.SetEntityParent(payload.entityId, payload.parentId);
+                    {
+                        if (msgObject.payload is Protocol.SetEntityParent payload)
+                            scene.SetEntityParent(payload.entityId, payload.parentId);
 
-                            break;
-                        }
+                        break;
+                    }
 
                     case MessagingTypes.ENTITY_COMPONENT_CREATE_OR_UPDATE:
-                        {
-                            if (msgObject.payload is Protocol.EntityComponentCreateOrUpdate payload)
-                                scene.EntityComponentCreateOrUpdate(payload.entityId, (CLASS_ID_COMPONENT)payload.classId, payload.json, out yieldInstruction);
+                    {
+                        if (msgObject.payload is Protocol.EntityComponentCreateOrUpdate payload)
+                            scene.EntityComponentCreateOrUpdate(payload.entityId, (CLASS_ID_COMPONENT) payload.classId, payload.json, out yieldInstruction);
 
-                            break;
-                        }
+                        break;
+                    }
 
                     case MessagingTypes.ENTITY_COMPONENT_DESTROY:
-                        {
-                            if (msgObject.payload is Protocol.EntityComponentDestroy payload)
-                                scene.EntityComponentRemove(payload.entityId, payload.name);
+                    {
+                        if (msgObject.payload is Protocol.EntityComponentDestroy payload)
+                            scene.EntityComponentRemove(payload.entityId, payload.name);
 
-                            break;
-                        }
+                        break;
+                    }
 
                     case MessagingTypes.SHARED_COMPONENT_ATTACH:
-                        {
-                            if (msgObject.payload is Protocol.SharedComponentAttach payload)
-                                scene.SharedComponentAttach(payload.entityId, payload.id);
+                    {
+                        if (msgObject.payload is Protocol.SharedComponentAttach payload)
+                            scene.SharedComponentAttach(payload.entityId, payload.id);
 
-                            break;
-                        }
+                        break;
+                    }
 
                     case MessagingTypes.SHARED_COMPONENT_CREATE:
-                        {
-                            if (msgObject.payload is Protocol.SharedComponentCreate payload)
-                                scene.SharedComponentCreate(payload.id, payload.classId);
+                    {
+                        if (msgObject.payload is Protocol.SharedComponentCreate payload)
+                            scene.SharedComponentCreate(payload.id, payload.classId);
 
-                            break;
-                        }
+                        break;
+                    }
 
                     case MessagingTypes.SHARED_COMPONENT_DISPOSE:
-                        {
-                            if (msgObject.payload is Protocol.SharedComponentDispose payload)
-                                scene.SharedComponentDispose(payload.id);
-                            break;
-                        }
+                    {
+                        if (msgObject.payload is Protocol.SharedComponentDispose payload)
+                            scene.SharedComponentDispose(payload.id);
+                        break;
+                    }
 
                     case MessagingTypes.SHARED_COMPONENT_UPDATE:
-                        {
-                            if (msgObject.payload is Protocol.SharedComponentUpdate payload)
-                                scene.SharedComponentUpdate(payload.componentId, payload.json, out yieldInstruction);
-                            break;
-                        }
+                    {
+                        if (msgObject.payload is Protocol.SharedComponentUpdate payload)
+                            scene.SharedComponentUpdate(payload.componentId, payload.json, out yieldInstruction);
+                        break;
+                    }
 
                     case MessagingTypes.ENTITY_DESTROY:
-                        {
-                            if (msgObject.payload is Protocol.RemoveEntity payload)
-                                scene.RemoveEntity(payload.entityId);
-                            break;
-                        }
+                    {
+                        if (msgObject.payload is Protocol.RemoveEntity payload)
+                            scene.RemoveEntity(payload.entityId);
+                        break;
+                    }
 
                     case MessagingTypes.INIT_DONE:
-                        {
-                            scene.SetInitMessagesDone();
-                            break;
-                        }
+                    {
+                        scene.SetInitMessagesDone();
+                        break;
+                    }
 
                     case MessagingTypes.QUERY:
-                        {
-                            if (msgObject.payload is QueryMessage queryMessage)
-                                ParseQuery(queryMessage.payload, scene.sceneData.id);
-                            break;
-                        }
+                    {
+                        if (msgObject.payload is QueryMessage queryMessage)
+                            ParseQuery(queryMessage.payload, scene.sceneData.id);
+                        break;
+                    }
 
                     case MessagingTypes.OPEN_EXTERNAL_URL:
-                        {
-                            if (msgObject.payload is Protocol.OpenExternalUrl payload)
-                                OnOpenExternalUrlRequest?.Invoke(scene, payload.url);
-                            break;
-                        }
+                    {
+                        if (msgObject.payload is Protocol.OpenExternalUrl payload)
+                            OnOpenExternalUrlRequest?.Invoke(scene, payload.url);
+                        break;
+                    }
 
                     case MessagingTypes.OPEN_NFT_DIALOG:
-                        {
-                            if (msgObject.payload is Protocol.OpenNftDialog payload)
-                                OnOpenNFTDialogRequest?.Invoke(payload.contactAddress, payload.tokenId, payload.comment);
-                            break;
-                        }
+                    {
+                        if (msgObject.payload is Protocol.OpenNftDialog payload)
+                            OnOpenNFTDialogRequest?.Invoke(payload.contactAddress, payload.tokenId, payload.comment);
+                        break;
+                    }
 
                     default:
                         Debug.LogError($"Unknown method {method}");
@@ -362,7 +362,7 @@ namespace DCL
 
         private string SendSceneMessage(string payload, bool enqueue)
         {
-            string[] chunks = payload.Split(new char[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            string[] chunks = payload.Split(new char[] {'\n'}, StringSplitOptions.RemoveEmptyEntries);
             int count = chunks.Length;
             string lastBusId = null;
 
@@ -470,7 +470,7 @@ namespace DCL
 
             if (data.parcels == null)
             {
-                data.parcels = new Vector2Int[] { data.basePosition };
+                data.parcels = new Vector2Int[] {data.basePosition};
             }
 
             if (string.IsNullOrEmpty(data.id))
@@ -570,14 +570,14 @@ namespace DCL
 
         void InitializeWorldBlockersController()
         {
-            if(worldBlockersController == null)
+            if (worldBlockersController == null)
                 worldBlockersController = new WorldBlockersController(this, new BlockerHandler(DCLCharacterController.i.characterPosition), DCLCharacterController.i.characterPosition);
         }
 
         private void SetPositionDirty(DCLCharacterPosition character)
         {
-            var currentX = (int)Math.Floor(character.worldPosition.x / ParcelSettings.PARCEL_SIZE);
-            var currentY = (int)Math.Floor(character.worldPosition.z / ParcelSettings.PARCEL_SIZE);
+            var currentX = (int) Math.Floor(character.worldPosition.x / ParcelSettings.PARCEL_SIZE);
+            var currentY = (int) Math.Floor(character.worldPosition.z / ParcelSettings.PARCEL_SIZE);
 
             positionDirty = currentX != currentGridSceneCoordinate.x || currentY != currentGridSceneCoordinate.y;
 
@@ -648,10 +648,7 @@ namespace DCL
             {
                 CommonScriptableObjects.rendererState.AddLock(newCurrentScene);
 
-                newCurrentScene.OnSceneReady += (readyScene) =>
-                {
-                    CommonScriptableObjects.rendererState.RemoveLock(readyScene);
-                };
+                newCurrentScene.OnSceneReady += (readyScene) => { CommonScriptableObjects.rendererState.RemoveLock(readyScene); };
             }
         }
 
@@ -732,7 +729,7 @@ namespace DCL
         public void UnloadScene(string sceneKey)
         {
             var queuedMessage = new MessagingBus.QueuedSceneMessage()
-            { type = MessagingBus.QueuedSceneMessage.Type.UNLOAD_PARCEL, message = sceneKey };
+                {type = MessagingBus.QueuedSceneMessage.Type.UNLOAD_PARCEL, message = sceneKey};
 
             OnMessageWillQueue?.Invoke(MessagingTypes.SCENE_DESTROY);
 
@@ -801,7 +798,7 @@ namespace DCL
         public void UpdateParcelScenes(string decentralandSceneJSON)
         {
             var queuedMessage = new MessagingBus.QueuedSceneMessage()
-            { type = MessagingBus.QueuedSceneMessage.Type.UPDATE_PARCEL, message = decentralandSceneJSON };
+                {type = MessagingBus.QueuedSceneMessage.Type.UPDATE_PARCEL, message = decentralandSceneJSON};
 
             OnMessageWillQueue?.Invoke(MessagingTypes.SCENE_UPDATE);
 
@@ -810,7 +807,7 @@ namespace DCL
 
         public void UnloadAllScenesQueued()
         {
-            var queuedMessage = new MessagingBus.QueuedSceneMessage() { type = MessagingBus.QueuedSceneMessage.Type.UNLOAD_SCENES };
+            var queuedMessage = new MessagingBus.QueuedSceneMessage() {type = MessagingBus.QueuedSceneMessage.Type.UNLOAD_SCENES};
 
             OnMessageWillQueue?.Invoke(MessagingTypes.SCENE_DESTROY);
 
@@ -974,7 +971,6 @@ namespace DCL
 
         private Vector2Int currentGridSceneCoordinate = new Vector2Int(EnvironmentSettings.MORDOR_SCALAR, EnvironmentSettings.MORDOR_SCALAR);
         private Vector2Int sortAuxiliaryVector = new Vector2Int(EnvironmentSettings.MORDOR_SCALAR, EnvironmentSettings.MORDOR_SCALAR);
-
 
 
         public const string EMPTY_GO_POOL_NAME = "Empty";


### PR DESCRIPTION
This PR produces a build with ALL UI disabled by default. A few URL params were added to enable the UI elements selectively.

URL params:

`enable_ui=<id>`

Enables UI by `id`. This abides our enum:

```
  MINIMAP = 1,
  PROFILE_HUD = 2,
  NOTIFICATION = 3,
  AVATAR_EDITOR = 4,
  SETTINGS = 5,
  EXPRESSIONS = 6,
  PLAYER_INFO_CARD = 7,
  AIRDROPPING = 8,
  TERMS_OF_SERVICE = 9,
  WORLD_CHAT_WINDOW = 10,
  TASKBAR = 11,
  MESSAGE_OF_THE_DAY = 12,
  FRIENDS = 13, // Not supported
  OPEN_EXTERNAL_URL_PROMPT = 14,
  NFT_INFO_DIALOG = 16,
  TELEPORT_DIALOG = 17,
  CONTROLS_HUD = 18,
  EXPLORE_HUD = 19,
  MANA_HUD = 20, // Not supported
  HELP_AND_SUPPORT_HUD = 21,
  GO_TO_GENESIS_PLAZA_HUD = 22,
  EMAIL_PROMPT = 23 // Not supported
```

`enable_tutorial_ui`

Enables `TUTORIAL` ui

`enable_web3_ui`

Enables `FRIENDS` and `MANA_HUD` uis.

Test link:
https://play.decentraland.zone/branch/test/enable-ui-param/index.html?ENV=org