### PR TITLE
fix: set texture compression to HighQuality

### DIFF
--- a/unity-client/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/unity-client/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -750,7 +750,7 @@ namespace UnityGLTF
 
 #if !UNITY_EDITOR
             //NOTE(Brian): This breaks importing in editor mode
-            texture.Compress(false);
+            texture.Compress(true);
 #endif
             _assetCache.ImageCache[imageCacheIndex] = texture;
 

--- a/unity-client/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/unity-client/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -750,7 +750,7 @@ namespace UnityGLTF
 
 #if !UNITY_EDITOR
             //NOTE(Brian): This breaks importing in editor mode
-            //texture.Compress(true);
+            texture.Compress(true);
 #endif
             _assetCache.ImageCache[imageCacheIndex] = texture;
 

--- a/unity-client/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/unity-client/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -750,7 +750,7 @@ namespace UnityGLTF
 
 #if !UNITY_EDITOR
             //NOTE(Brian): This breaks importing in editor mode
-            texture.Compress(true);
+            //texture.Compress(true);
 #endif
             _assetCache.ImageCache[imageCacheIndex] = texture;
 


### PR DESCRIPTION
#742 

This issue is likely caused by our new compression in textures. If that's the case we will have to decide whether or not the quality improvement worth the extra memory.