### PR TITLE
chore: move ABConverter to a namespace

### DIFF
--- a/unity-client/Assets/ABConverter/AssetPath.cs
+++ b/unity-client/Assets/ABConverter/AssetPath.cs
@@ -6,7 +6,7 @@ using UnityEngine.Networking;
 using MappingPair = DCL.ContentServerUtils.MappingPair;
 
 
-namespace DCL
+namespace DCL.ABConverter
 {
     public class AssetPath
     {

--- a/unity-client/Assets/ABConverter/Client.cs
+++ b/unity-client/Assets/ABConverter/Client.cs
@@ -6,252 +6,249 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 
-namespace DCL
+namespace DCL.ABConverter
 {
-    public abstract partial class ABConverter
+    public static class Client
     {
-        public static class Client
+        public class Settings
         {
-            public class Settings
-            {
-                /// <summary>
-                /// if set to true, when conversion finishes, the working folder containing all downloaded assets will be deleted
-                /// </summary>
-                public bool deleteDownloadPathAfterFinished = false;
-
-                /// <summary>
-                /// If set to true, Asset Bundles will not be built at all, and only the asset dump will be performed. 
-                /// </summary>
-                public bool dumpOnly = false;
-
-                /// <summary>
-                /// If set to true, Asset Bundle output folder will be checked, and existing bundles in that folder will be excluded from
-                /// the conversion process.
-                /// </summary>
-                public bool skipAlreadyBuiltBundles = false;
-
-                /// <summary>
-                /// Log verbosity.
-                /// </summary>
-                public bool verbose = false;
-
-                /// <summary>
-                /// Output folder for asset bundles, by default, they will be stored in Assets/../AssetBundles. 
-                /// </summary>
-                public string finalAssetBundlePath = Config.ASSET_BUNDLES_PATH_ROOT + Path.DirectorySeparatorChar;
-
-                /// <summary>
-                /// Target top level domain. This will define the content server url used for the conversion (org, zone, etc).
-                /// </summary>
-                public ContentServerUtils.ApiTLD tld = ContentServerUtils.ApiTLD.ORG;
-
-                /// <summary>
-                /// Raw baseUrl using for asset dumping.
-                /// </summary>
-                public string baseUrl;
-
-                public Settings Clone()
-                {
-                    return this.MemberwiseClone() as Settings;
-                }
-
-                public Settings(ContentServerUtils.ApiTLD tld = ContentServerUtils.ApiTLD.ORG)
-                {
-                    this.tld = tld;
-                    this.baseUrl = ContentServerUtils.GetContentAPIUrlBase(tld);
-                }
-            }
-
-            private static Logger log = new Logger("ABConverter.Client");
-
-            public static Environment env;
-
-            public static Environment EnsureEnvironment()
-            {
-                if (env == null)
-                    env = Environment.CreateWithDefaultImplementations();
-
-                return env;
-            }
+            /// <summary>
+            /// if set to true, when conversion finishes, the working folder containing all downloaded assets will be deleted
+            /// </summary>
+            public bool deleteDownloadPathAfterFinished = false;
 
             /// <summary>
-            /// Batch-mode entry point
+            /// If set to true, Asset Bundles will not be built at all, and only the asset dump will be performed. 
             /// </summary>
-            public static void ExportSceneToAssetBundles()
-            {
-                //NOTE(Brian): This should make the logs cleaner
-                Application.SetStackTraceLogType(LogType.Log, StackTraceLogType.None);
-                Application.SetStackTraceLogType(LogType.Warning, StackTraceLogType.None);
-                Application.SetStackTraceLogType(LogType.Error, StackTraceLogType.Full);
-                Application.SetStackTraceLogType(LogType.Exception, StackTraceLogType.Full);
-                Application.SetStackTraceLogType(LogType.Assert, StackTraceLogType.Full);
-
-                EnsureEnvironment();
-                ExportSceneToAssetBundles(System.Environment.GetCommandLineArgs());
-            }
+            public bool dumpOnly = false;
 
             /// <summary>
-            /// Start the conversion process with the given commandLineArgs. 
+            /// If set to true, Asset Bundle output folder will be checked, and existing bundles in that folder will be excluded from
+            /// the conversion process.
             /// </summary>
-            /// <param name="commandLineArgs">An array with the command line arguments.</param>
-            /// <exception cref="ArgumentException">When an invalid argument is passed</exception>
-            public static void ExportSceneToAssetBundles(string[] commandLineArgs)
+            public bool skipAlreadyBuiltBundles = false;
+
+            /// <summary>
+            /// Log verbosity.
+            /// </summary>
+            public bool verbose = false;
+
+            /// <summary>
+            /// Output folder for asset bundles, by default, they will be stored in Assets/../AssetBundles. 
+            /// </summary>
+            public string finalAssetBundlePath = Config.ASSET_BUNDLES_PATH_ROOT + Path.DirectorySeparatorChar;
+
+            /// <summary>
+            /// Target top level domain. This will define the content server url used for the conversion (org, zone, etc).
+            /// </summary>
+            public ContentServerUtils.ApiTLD tld = ContentServerUtils.ApiTLD.ORG;
+
+            /// <summary>
+            /// Raw baseUrl using for asset dumping.
+            /// </summary>
+            public string baseUrl;
+
+            public Settings Clone()
             {
-                Settings settings = new Settings();
-                try
+                return this.MemberwiseClone() as Settings;
+            }
+
+            public Settings(ContentServerUtils.ApiTLD tld = ContentServerUtils.ApiTLD.ORG)
+            {
+                this.tld = tld;
+                this.baseUrl = ContentServerUtils.GetContentAPIUrlBase(tld);
+            }
+        }
+
+        private static Logger log = new Logger("ABConverter.Client");
+
+        public static Environment env;
+
+        public static Environment EnsureEnvironment()
+        {
+            if (env == null)
+                env = Environment.CreateWithDefaultImplementations();
+
+            return env;
+        }
+
+        /// <summary>
+        /// Batch-mode entry point
+        /// </summary>
+        public static void ExportSceneToAssetBundles()
+        {
+            //NOTE(Brian): This should make the logs cleaner
+            Application.SetStackTraceLogType(LogType.Log, StackTraceLogType.None);
+            Application.SetStackTraceLogType(LogType.Warning, StackTraceLogType.None);
+            Application.SetStackTraceLogType(LogType.Error, StackTraceLogType.Full);
+            Application.SetStackTraceLogType(LogType.Exception, StackTraceLogType.Full);
+            Application.SetStackTraceLogType(LogType.Assert, StackTraceLogType.Full);
+
+            EnsureEnvironment();
+            ExportSceneToAssetBundles(System.Environment.GetCommandLineArgs());
+        }
+
+        /// <summary>
+        /// Start the conversion process with the given commandLineArgs. 
+        /// </summary>
+        /// <param name="commandLineArgs">An array with the command line arguments.</param>
+        /// <exception cref="ArgumentException">When an invalid argument is passed</exception>
+        public static void ExportSceneToAssetBundles(string[] commandLineArgs)
+        {
+            Settings settings = new Settings();
+            try
+            {
+                if (Utils.ParseOption(commandLineArgs, Config.CLI_SET_CUSTOM_OUTPUT_ROOT_PATH, 1, out string[] outputPath))
                 {
-                    if (Utils.ParseOption(commandLineArgs, Config.CLI_SET_CUSTOM_OUTPUT_ROOT_PATH, 1, out string[] outputPath))
+                    settings.finalAssetBundlePath = outputPath[0] + "/";
+                }
+
+                if (Utils.ParseOption(commandLineArgs, Config.CLI_SET_CUSTOM_BASE_URL, 1, out string[] customBaseUrl))
+                    settings.baseUrl = customBaseUrl[0];
+
+                if (Utils.ParseOption(commandLineArgs, Config.CLI_VERBOSE, 0, out _))
+                    settings.verbose = true;
+
+                if (Utils.ParseOption(commandLineArgs, Config.CLI_ALWAYS_BUILD_SYNTAX, 0, out _))
+                    settings.skipAlreadyBuiltBundles = false;
+
+                if (Utils.ParseOption(commandLineArgs, Config.CLI_KEEP_BUNDLES_SYNTAX, 0, out _))
+                    settings.deleteDownloadPathAfterFinished = false;
+
+                if (Utils.ParseOption(commandLineArgs, Config.CLI_BUILD_SCENE_SYNTAX, 1, out string[] sceneCid))
+                {
+                    if (sceneCid == null || string.IsNullOrEmpty(sceneCid[0]))
                     {
-                        settings.finalAssetBundlePath = outputPath[0] + "/";
+                        throw new ArgumentException("Invalid sceneCid argument! Please use -sceneCid <id> to establish the desired id to process.");
                     }
 
-                    if (Utils.ParseOption(commandLineArgs, Config.CLI_SET_CUSTOM_BASE_URL, 1, out string[] customBaseUrl))
-                        settings.baseUrl = customBaseUrl[0];
+                    DumpScene(sceneCid[0], settings);
+                    return;
+                }
 
-                    if (Utils.ParseOption(commandLineArgs, Config.CLI_VERBOSE, 0, out _))
-                        settings.verbose = true;
-
-                    if (Utils.ParseOption(commandLineArgs, Config.CLI_ALWAYS_BUILD_SYNTAX, 0, out _))
-                        settings.skipAlreadyBuiltBundles = false;
-
-                    if (Utils.ParseOption(commandLineArgs, Config.CLI_KEEP_BUNDLES_SYNTAX, 0, out _))
-                        settings.deleteDownloadPathAfterFinished = false;
-
-                    if (Utils.ParseOption(commandLineArgs, Config.CLI_BUILD_SCENE_SYNTAX, 1, out string[] sceneCid))
+                if (Utils.ParseOption(commandLineArgs, Config.CLI_BUILD_PARCELS_RANGE_SYNTAX, 4, out string[] xywh))
+                {
+                    if (xywh == null)
                     {
-                        if (sceneCid == null || string.IsNullOrEmpty(sceneCid[0]))
-                        {
-                            throw new ArgumentException("Invalid sceneCid argument! Please use -sceneCid <id> to establish the desired id to process.");
-                        }
-
-                        DumpScene(sceneCid[0], settings);
-                        return;
+                        throw new ArgumentException("Invalid parcelsXYWH argument! Please use -parcelsXYWH x y w h to establish the desired parcels range to process.");
                     }
 
-                    if (Utils.ParseOption(commandLineArgs, Config.CLI_BUILD_PARCELS_RANGE_SYNTAX, 4, out string[] xywh))
+                    int x, y, w, h;
+                    bool parseSuccess = false;
+
+                    parseSuccess |= int.TryParse(xywh[0], out x);
+                    parseSuccess |= int.TryParse(xywh[1], out y);
+                    parseSuccess |= int.TryParse(xywh[2], out w);
+                    parseSuccess |= int.TryParse(xywh[3], out h);
+
+                    if (!parseSuccess)
                     {
-                        if (xywh == null)
-                        {
-                            throw new ArgumentException("Invalid parcelsXYWH argument! Please use -parcelsXYWH x y w h to establish the desired parcels range to process.");
-                        }
-
-                        int x, y, w, h;
-                        bool parseSuccess = false;
-
-                        parseSuccess |= int.TryParse(xywh[0], out x);
-                        parseSuccess |= int.TryParse(xywh[1], out y);
-                        parseSuccess |= int.TryParse(xywh[2], out w);
-                        parseSuccess |= int.TryParse(xywh[3], out h);
-
-                        if (!parseSuccess)
-                        {
-                            throw new ArgumentException("Invalid parcelsXYWH argument! Please use -parcelsXYWH x y w h to establish the desired parcels range to process.");
-                        }
-
-                        if (w > 10 || h > 10 || w < 0 || h < 0)
-                        {
-                            throw new ArgumentException("Invalid parcelsXYWH argument! Please don't use negative width/height values, and ensure any given width/height doesn't exceed 10.");
-                        }
-
-                        DumpArea(new Vector2Int(x, y), new Vector2Int(w, h), settings);
-                        return;
+                        throw new ArgumentException("Invalid parcelsXYWH argument! Please use -parcelsXYWH x y w h to establish the desired parcels range to process.");
                     }
 
-                    throw new ArgumentException("Invalid arguments! You must pass -parcelsXYWH or -sceneCid for dump to work!");
-                }
-                catch (Exception e)
-                {
-                    log.Error(e.Message);
-                }
-            }
+                    if (w > 10 || h > 10 || w < 0 || h < 0)
+                    {
+                        throw new ArgumentException("Invalid parcelsXYWH argument! Please don't use negative width/height values, and ensure any given width/height doesn't exceed 10.");
+                    }
 
-            /// <summary>
-            /// This will start the asset bundle conversion for a given scene list, given a scene cids list.
-            /// </summary>
-            /// <param name="sceneCidsList">The cid list for the scenes to gather from the catalyst's content server</param>
-            /// <param name="settings">Any conversion settings object, if its null, a new one will be created</param>
-            /// <returns>A state context object useful for tracking the conversion progress</returns>
-            public static Core.State ConvertScenesToAssetBundles(List<string> sceneCidsList, Settings settings = null)
-            {
-                if (sceneCidsList == null || sceneCidsList.Count == 0)
-                {
-                    log.Error("Scene list is null or count == 0! Maybe this sector lacks scenes or content requests failed?");
-                    return new Core.State() {lastErrorCode = Core.ErrorCodes.SCENE_LIST_NULL};
+                    DumpArea(new Vector2Int(x, y), new Vector2Int(w, h), settings);
+                    return;
                 }
 
-                log.Info($"Building {sceneCidsList.Count} scenes...");
-
-                List<ContentServerUtils.MappingPair> rawContents = new List<ContentServerUtils.MappingPair>();
-
-                EnsureEnvironment();
-
-                if (settings == null)
-                    settings = new Settings();
-
-                foreach (var sceneCid in sceneCidsList)
-                {
-                    ContentServerUtils.MappingsAPIData parcelInfoApiData = ABConverter.Utils.GetSceneMappingsData(env.webRequest, settings.tld, sceneCid);
-                    rawContents.AddRange(parcelInfoApiData.data[0].content.contents);
-                }
-
-                var core = new ABConverter.Core(env, settings);
-                core.Convert(rawContents.ToArray());
-                return core.state;
+                throw new ArgumentException("Invalid arguments! You must pass -parcelsXYWH or -sceneCid for dump to work!");
             }
-
-            /// <summary>
-            /// Dump a world area given coords and size. The zone is a rectangle with a center pivot.
-            /// </summary>
-            /// <param name="coords">Coords as parcel coordinates</param>
-            /// <param name="size">Size as radius</param>
-            /// <param name="settings">Conversion settings</param>
-            /// <returns>A state context object useful for tracking the conversion progress</returns>
-            public static Core.State DumpArea(Vector2Int coords, Vector2Int size, Settings settings = null)
+            catch (Exception e)
             {
-                EnsureEnvironment();
-
-                if (settings == null)
-                    settings = new Settings();
-
-                HashSet<string> sceneCids = ABConverter.Utils.GetSceneCids(env.webRequest, settings.tld, coords, size);
-                List<string> sceneCidsList = sceneCids.ToList();
-                return ConvertScenesToAssetBundles(sceneCidsList, settings);
+                log.Error(e.Message);
             }
+        }
 
-            /// <summary>
-            /// Dump a world area given a parcel coords array.
-            /// </summary>
-            /// <param name="coords">A list with the parcels coordinates wanted to be converted</param>
-            /// <param name="settings">Conversion settings</param>
-            /// <returns>A state context object useful for tracking the conversion progress</returns>
-            public static Core.State DumpArea(List<Vector2Int> coords, Settings settings = null)
+        /// <summary>
+        /// This will start the asset bundle conversion for a given scene list, given a scene cids list.
+        /// </summary>
+        /// <param name="sceneCidsList">The cid list for the scenes to gather from the catalyst's content server</param>
+        /// <param name="settings">Any conversion settings object, if its null, a new one will be created</param>
+        /// <returns>A state context object useful for tracking the conversion progress</returns>
+        public static Core.State ConvertScenesToAssetBundles(List<string> sceneCidsList, Settings settings = null)
+        {
+            if (sceneCidsList == null || sceneCidsList.Count == 0)
             {
-                EnsureEnvironment();
-
-                if (settings == null)
-                    settings = new Settings();
-
-                HashSet<string> sceneCids = Utils.GetScenesCids(env.webRequest, settings.tld, coords);
-
-                List<string> sceneCidsList = sceneCids.ToList();
-                return ConvertScenesToAssetBundles(sceneCidsList, settings);
+                log.Error("Scene list is null or count == 0! Maybe this sector lacks scenes or content requests failed?");
+                return new Core.State() {lastErrorCode = Core.ErrorCodes.SCENE_LIST_NULL};
             }
 
-            /// <summary>
-            /// Dump a single world scene given a scene cid.
-            /// </summary>
-            /// <param name="cid">The scene cid in the multi-hash format (i.e. Qm...etc)</param>
-            /// <param name="settings">Conversion settings</param>
-            /// <returns>A state context object useful for tracking the conversion progress</returns>
-            public static Core.State DumpScene(string cid, Settings settings = null)
+            log.Info($"Building {sceneCidsList.Count} scenes...");
+
+            List<ContentServerUtils.MappingPair> rawContents = new List<ContentServerUtils.MappingPair>();
+
+            EnsureEnvironment();
+
+            if (settings == null)
+                settings = new Settings();
+
+            foreach (var sceneCid in sceneCidsList)
             {
-                EnsureEnvironment();
-
-                if (settings == null)
-                    settings = new Settings();
-
-                return ConvertScenesToAssetBundles(new List<string> {cid}, settings);
+                ContentServerUtils.MappingsAPIData parcelInfoApiData = ABConverter.Utils.GetSceneMappingsData(env.webRequest, settings.tld, sceneCid);
+                rawContents.AddRange(parcelInfoApiData.data[0].content.contents);
             }
+
+            var core = new ABConverter.Core(env, settings);
+            core.Convert(rawContents.ToArray());
+            return core.state;
+        }
+
+        /// <summary>
+        /// Dump a world area given coords and size. The zone is a rectangle with a center pivot.
+        /// </summary>
+        /// <param name="coords">Coords as parcel coordinates</param>
+        /// <param name="size">Size as radius</param>
+        /// <param name="settings">Conversion settings</param>
+        /// <returns>A state context object useful for tracking the conversion progress</returns>
+        public static Core.State DumpArea(Vector2Int coords, Vector2Int size, Settings settings = null)
+        {
+            EnsureEnvironment();
+
+            if (settings == null)
+                settings = new Settings();
+
+            HashSet<string> sceneCids = ABConverter.Utils.GetSceneCids(env.webRequest, settings.tld, coords, size);
+            List<string> sceneCidsList = sceneCids.ToList();
+            return ConvertScenesToAssetBundles(sceneCidsList, settings);
+        }
+
+        /// <summary>
+        /// Dump a world area given a parcel coords array.
+        /// </summary>
+        /// <param name="coords">A list with the parcels coordinates wanted to be converted</param>
+        /// <param name="settings">Conversion settings</param>
+        /// <returns>A state context object useful for tracking the conversion progress</returns>
+        public static Core.State DumpArea(List<Vector2Int> coords, Settings settings = null)
+        {
+            EnsureEnvironment();
+
+            if (settings == null)
+                settings = new Settings();
+
+            HashSet<string> sceneCids = Utils.GetScenesCids(env.webRequest, settings.tld, coords);
+
+            List<string> sceneCidsList = sceneCids.ToList();
+            return ConvertScenesToAssetBundles(sceneCidsList, settings);
+        }
+
+        /// <summary>
+        /// Dump a single world scene given a scene cid.
+        /// </summary>
+        /// <param name="cid">The scene cid in the multi-hash format (i.e. Qm...etc)</param>
+        /// <param name="settings">Conversion settings</param>
+        /// <returns>A state context object useful for tracking the conversion progress</returns>
+        public static Core.State DumpScene(string cid, Settings settings = null)
+        {
+            EnsureEnvironment();
+
+            if (settings == null)
+                settings = new Settings();
+
+            return ConvertScenesToAssetBundles(new List<string> {cid}, settings);
         }
     }
 }

--- a/unity-client/Assets/ABConverter/Config.cs
+++ b/unity-client/Assets/ABConverter/Config.cs
@@ -1,10 +1,8 @@
 ﻿using System.IO;
 using UnityEngine;
 
-namespace DCL
+namespace DCL.ABConverter
 {
-    public abstract partial class ABConverter
-    {
         public static class Config
         {
             internal const string CLI_VERBOSE = "verbose";
@@ -28,5 +26,4 @@ namespace DCL
             internal static string[] gltfExtensions = {".glb", ".gltf"};
             internal static string[] textureExtensions = {".jpg", ".png", ".jpeg", ".tga", ".gif", ".bmp", ".psd", ".tiff", ".iff"};
         }
-    }
 }

--- a/unity-client/Assets/ABConverter/Core.cs
+++ b/unity-client/Assets/ABConverter/Core.cs
@@ -11,10 +11,8 @@ using UnityEngine.Networking;
 using UnityGLTF;
 using UnityGLTF.Cache;
 
-namespace DCL
+namespace DCL.ABConverter
 {
-    public abstract partial class ABConverter
-    {
         public class Core
         {
             public enum ErrorCodes
@@ -646,4 +644,3 @@ namespace DCL
             }
         }
     }
-}

--- a/unity-client/Assets/ABConverter/DependencyMapBuilder.cs
+++ b/unity-client/Assets/ABConverter/DependencyMapBuilder.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 [assembly: InternalsVisibleTo("AssetBundleBuilderEditorTests")]
 
-namespace DCL
+namespace DCL.ABConverter
 {
     public static class DependencyMapBuilder
     {

--- a/unity-client/Assets/ABConverter/Environment.cs
+++ b/unity-client/Assets/ABConverter/Environment.cs
@@ -1,51 +1,48 @@
 ﻿using System.Collections.Generic;
 
-namespace DCL
+namespace DCL.ABConverter
 {
-    public abstract partial class ABConverter
+    public class Environment
     {
-        public class Environment
+        public readonly IDirectory directory;
+        public readonly IFile file;
+        public readonly IAssetDatabase assetDatabase;
+        public readonly IWebRequest webRequest;
+        public readonly IBuildPipeline buildPipeline;
+
+        public Environment(IDirectory directory, IFile file, IAssetDatabase assetDatabase, IWebRequest webRequest, IBuildPipeline buildPipeline)
         {
-            public readonly IDirectory directory;
-            public readonly IFile file;
-            public readonly IAssetDatabase assetDatabase;
-            public readonly IWebRequest webRequest;
-            public readonly IBuildPipeline buildPipeline;
+            this.directory = directory;
+            this.file = file;
+            this.assetDatabase = assetDatabase;
+            this.webRequest = webRequest;
+            this.buildPipeline = buildPipeline;
+        }
 
-            public Environment(IDirectory directory, IFile file, IAssetDatabase assetDatabase, IWebRequest webRequest, IBuildPipeline buildPipeline)
-            {
-                this.directory = directory;
-                this.file = file;
-                this.assetDatabase = assetDatabase;
-                this.webRequest = webRequest;
-                this.buildPipeline = buildPipeline;
-            }
+        public static Environment CreateWithDefaultImplementations()
+        {
+            return new Environment
+            (
+                directory: new SystemWrappers.Directory(),
+                file: new SystemWrappers.File(),
+                assetDatabase: new UnityEditorWrappers.AssetDatabase(),
+                webRequest: new UnityEditorWrappers.WebRequest(),
+                buildPipeline: new UnityEditorWrappers.BuildPipeline()
+            );
+        }
 
-            public static Environment CreateWithDefaultImplementations()
-            {
-                return new Environment
-                (
-                    directory: new SystemWrappers.Directory(),
-                    file: new SystemWrappers.File(),
-                    assetDatabase: new UnityEditorWrappers.AssetDatabase(),
-                    webRequest: new UnityEditorWrappers.WebRequest(),
-                    buildPipeline: new UnityEditorWrappers.BuildPipeline()
-                );
-            }
+        public static Environment CreateWithMockImplementations()
+        {
+            var file = new Mocked.File();
 
-            public static Environment CreateWithMockImplementations()
-            {
-                var file = new Mocked.File();
-
-                return new Environment
-                (
-                    directory: new Mocked.Directory(),
-                    file: file,
-                    assetDatabase: new Mocked.AssetDatabase(file),
-                    webRequest: new Mocked.WebRequest(),
-                    buildPipeline: new UnityEditorWrappers.BuildPipeline()
-                );
-            }
+            return new Environment
+            (
+                directory: new Mocked.Directory(),
+                file: file,
+                assetDatabase: new Mocked.AssetDatabase(file),
+                webRequest: new Mocked.WebRequest(),
+                buildPipeline: new UnityEditorWrappers.BuildPipeline()
+            );
         }
     }
 }

--- a/unity-client/Assets/ABConverter/Tests/ABConverterCoreShould.cs
+++ b/unity-client/Assets/ABConverter/Tests/ABConverterCoreShould.cs
@@ -13,7 +13,7 @@ using UnityEngine.TestTools;
 using UnityEngine.UI;
 using UnityGLTF.Cache;
 
-namespace ABConverterTests
+namespace DCL.ABConverter.Tests
 {
     public class ABConverterShould
     {
@@ -331,7 +331,7 @@ namespace ABConverterTests
                 new ContentServerUtils.MappingPair {file = "Textures/Test.png", hash = "Test.png"}
             };
 
-            core.settings.baseUrl = Utils.GetTestsAssetsPath() + "/GLTF/SimpleCube/";
+            core.settings.baseUrl = DCL.Helpers.Utils.GetTestsAssetsPath() + "/GLTF/SimpleCube/";
 
             env = ABConverter.Environment.CreateWithDefaultImplementations();
             core = new ABConverter.Core(env, core.settings);
@@ -371,7 +371,7 @@ namespace ABConverterTests
                 new ContentServerUtils.MappingPair {file = "Textures/Test.png", hash = "Test.png"}
             };
 
-            core.settings.baseUrl = Utils.GetTestsAssetsPath() + "/GLTF/SimpleCube/";
+            core.settings.baseUrl = DCL.Helpers.Utils.GetTestsAssetsPath() + "/GLTF/SimpleCube/";
             core.settings.verbose = true;
             core.settings.dumpOnly = true;
             core.settings.deleteDownloadPathAfterFinished = false;
@@ -401,7 +401,7 @@ namespace ABConverterTests
                 new ContentServerUtils.MappingPair {file = "SimpleCubeWithSharedNormal.bin", hash = "SimpleCubeWithSharedNormal.bin"},
             };
 
-            core.settings.baseUrl = Utils.GetTestsAssetsPath() + "/GLTF/SimpleCube/";
+            core.settings.baseUrl = DCL.Helpers.Utils.GetTestsAssetsPath() + "/GLTF/SimpleCube/";
 
             env = ABConverter.Environment.CreateWithDefaultImplementations();
             core = new ABConverter.Core(env, core.settings);

--- a/unity-client/Assets/ABConverter/Tests/ParseOptionShould.cs
+++ b/unity-client/Assets/ABConverter/Tests/ParseOptionShould.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 
+namespace DCL.ABConverter {
 public class ParseOptionShould
 {
     readonly static string[] args = new string[] {"-unityRandomOption", "-testOption", "arg1", "arg2", "-garbage", "-garbage2"};
@@ -56,4 +57,5 @@ public class ParseOptionShould
             Assert.IsTrue(test2[1] == "arg2");
         }
     }
+}
 }

--- a/unity-client/Assets/ABConverter/Tests/UtilsTests.cs
+++ b/unity-client/Assets/ABConverter/Tests/UtilsTests.cs
@@ -3,49 +3,52 @@ using NUnit.Framework;
 using System.IO;
 using UnityEngine;
 
-public class UtilsTests
+namespace DCL.ABConverter
 {
-    [Test]
-    public void CIDtoGuidTest()
+    public class UtilsTests
     {
-        Assert.AreEqual("d3b55cc7e3367537c1670ecebb1ccb05", DCL.ABConverter.Utils.CidToGuid("QmWVcyTEzSEBKC7hzq6doiTWnopZ6DdqJMqufx6gXwFnTS"));
-    }
+        [Test]
+        public void CIDtoGuidTest()
+        {
+            Assert.AreEqual("d3b55cc7e3367537c1670ecebb1ccb05", DCL.ABConverter.Utils.CidToGuid("QmWVcyTEzSEBKC7hzq6doiTWnopZ6DdqJMqufx6gXwFnTS"));
+        }
 
-    [Test]
-    [TestCase("..|FenceStoneLarge_01|file1.png", "models/Fountain_01/Fountain_01.glb", "models/FenceStoneLarge_01/file1.png")]
-    [TestCase("file1.png", "models/Fountain_01/Fountain_01.glb", "models/Fountain_01/file1.png")]
-    [TestCase("..|LampPost_01|file1.png", "models/Fountain_01/Fountain_01.glb", "models/LampPost_01/file1.png")]
-    [TestCase("..|FenceStonePillarTall_01|file1.png", "models/Fountain_01/Fountain_01.glb", "models/FenceStonePillarTall_01/file1.png")]
-    [TestCase("..|Grass_02|file1.png", "models/Fountain_01/Fountain_01.glb", "models/Grass_02/file1.png")]
-    [TestCase("..|FloorBaseGrass_01|Floor_Grass01.png.png", "models/Fountain_01/Fountain_01.glb", "models/FloorBaseGrass_01/Floor_Grass01.png.png")]
-    [TestCase("..|FenceStonePillar_01|file1.png", "models/Fountain_01/Fountain_01.glb", "models/FenceStonePillar_01/file1.png")]
-    public void GetRelativePathToTest(string expected, string from, string to)
-    {
-        expected = expected.Replace('|', Path.DirectorySeparatorChar);
-        Assert.AreEqual(expected, ABConverter.PathUtils.GetRelativePathTo(from, to));
-    }
+        [Test]
+        [TestCase("..|FenceStoneLarge_01|file1.png", "models/Fountain_01/Fountain_01.glb", "models/FenceStoneLarge_01/file1.png")]
+        [TestCase("file1.png", "models/Fountain_01/Fountain_01.glb", "models/Fountain_01/file1.png")]
+        [TestCase("..|LampPost_01|file1.png", "models/Fountain_01/Fountain_01.glb", "models/LampPost_01/file1.png")]
+        [TestCase("..|FenceStonePillarTall_01|file1.png", "models/Fountain_01/Fountain_01.glb", "models/FenceStonePillarTall_01/file1.png")]
+        [TestCase("..|Grass_02|file1.png", "models/Fountain_01/Fountain_01.glb", "models/Grass_02/file1.png")]
+        [TestCase("..|FloorBaseGrass_01|Floor_Grass01.png.png", "models/Fountain_01/Fountain_01.glb", "models/FloorBaseGrass_01/Floor_Grass01.png.png")]
+        [TestCase("..|FenceStonePillar_01|file1.png", "models/Fountain_01/Fountain_01.glb", "models/FenceStonePillar_01/file1.png")]
+        public void GetRelativePathToTest(string expected, string from, string to)
+        {
+            expected = expected.Replace('|', Path.DirectorySeparatorChar);
+            Assert.AreEqual(expected, ABConverter.PathUtils.GetRelativePathTo(from, to));
+        }
 
-    [Test]
-    [TestCase("C:/MyProject/Assets/MyAsset.png", "/Assets/MyAsset.png")]
-    [TestCase("C:/MyProject/Assets/Blah/MyAsset.glb", "/Assets/Blah/MyAsset.glb")]
-    [TestCase("C:/MyProject/Assets/Blah/My Asset With Spaces.long", "/Assets/Blah/My Asset With Spaces.long")]
-    [TestCase("C:/MyProject", "")]
-    public void AssetPathToFullPathTest(string expected, string input)
-    {
-        expected = ABConverter.PathUtils.FixDirectorySeparator(expected);
-        string result = ABConverter.PathUtils.AssetPathToFullPath(input, $"C:/MyProject/Assets");
-        UnityEngine.Assertions.Assert.AreEqual(expected, result);
-    }
+        [Test]
+        [TestCase("C:/MyProject/Assets/MyAsset.png", "/Assets/MyAsset.png")]
+        [TestCase("C:/MyProject/Assets/Blah/MyAsset.glb", "/Assets/Blah/MyAsset.glb")]
+        [TestCase("C:/MyProject/Assets/Blah/My Asset With Spaces.long", "/Assets/Blah/My Asset With Spaces.long")]
+        [TestCase("C:/MyProject", "")]
+        public void AssetPathToFullPathTest(string expected, string input)
+        {
+            expected = ABConverter.PathUtils.FixDirectorySeparator(expected);
+            string result = ABConverter.PathUtils.AssetPathToFullPath(input, $"C:/MyProject/Assets");
+            UnityEngine.Assertions.Assert.AreEqual(expected, result);
+        }
 
-    [Test]
-    [TestCase("C:/MyProjects/Assets/MyAsset.png", "/Assets/MyAsset.png")]
-    [TestCase("C:/MyProjects/Assets/Blah/MyAsset.glb", "/Assets/Blah/MyAsset.glb")]
-    [TestCase("C:/MyProjects/Assets/Blah/My Asset With Spaces.long", "/Assets/Blah/My Asset With Spaces.long")]
-    [TestCase("", "")]
-    public void FullPathToAssetPath(string input, string expected)
-    {
-        expected = ABConverter.PathUtils.FixDirectorySeparator(expected);
-        string result = ABConverter.PathUtils.FullPathToAssetPath(input);
-        UnityEngine.Assertions.Assert.AreEqual(expected, result);
+        [Test]
+        [TestCase("C:/MyProjects/Assets/MyAsset.png", "/Assets/MyAsset.png")]
+        [TestCase("C:/MyProjects/Assets/Blah/MyAsset.glb", "/Assets/Blah/MyAsset.glb")]
+        [TestCase("C:/MyProjects/Assets/Blah/My Asset With Spaces.long", "/Assets/Blah/My Asset With Spaces.long")]
+        [TestCase("", "")]
+        public void FullPathToAssetPath(string input, string expected)
+        {
+            expected = ABConverter.PathUtils.FixDirectorySeparator(expected);
+            string result = ABConverter.PathUtils.FullPathToAssetPath(input);
+            UnityEngine.Assertions.Assert.AreEqual(expected, result);
+        }
     }
 }

--- a/unity-client/Assets/ABConverter/Utils.cs
+++ b/unity-client/Assets/ABConverter/Utils.cs
@@ -14,9 +14,7 @@ using UnityEngine.Assertions;
 using UnityEngine.Networking;
 using static DCL.ContentServerUtils;
 
-namespace DCL
-{
-    public abstract partial class ABConverter
+namespace DCL.ABConverter
     {
         public static class PathUtils
         {
@@ -379,4 +377,3 @@ namespace DCL
             }
         }
     }
-}


### PR DESCRIPTION
This PR changes ABConverter from a `partial abstract` class to a namespace.