### PR TITLE
chore: replace Sprite with Texture2D in avatar snapshot

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
@@ -469,7 +469,7 @@ public class AvatarEditorHUDController : IHUD
         SetVisibility(configuration.active);
     }
 
-    public void SaveAvatar(Sprite faceSnapshot, Sprite face128Snapshot, Sprite face256Snapshot, Sprite bodySnapshot)
+    public void SaveAvatar(Texture2D faceSnapshot, Texture2D face128Snapshot, Texture2D face256Snapshot, Texture2D bodySnapshot)
     {
         var avatarModel = model.ToAvatarModel();
         WebInterface.SendSaveAvatar(avatarModel, faceSnapshot, face128Snapshot, face256Snapshot, bodySnapshot);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDView.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDView.cs
@@ -327,7 +327,7 @@ public class AvatarEditorHUDView : MonoBehaviour
         controller.DiscardAndClose();
     }
 
-    private void OnSnapshotsReady(Sprite face, Sprite face128, Sprite face256, Sprite body)
+    private void OnSnapshotsReady(Texture2D face, Texture2D face128, Texture2D face256, Texture2D body)
     {
         doneButton.interactable = true;
         controller.SaveAvatar(face, face128, face256, body);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/CharacterPreviewController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/CharacterPreviewController.cs
@@ -22,7 +22,7 @@ public class CharacterPreviewController : MonoBehaviour
     private static int CHARACTER_PREVIEW_LAYER => LayerMask.NameToLayer("CharacterPreview");
     private static int CHARACTER_DEFAULT_LAYER => LayerMask.NameToLayer("Default");
 
-    public delegate void OnSnapshotsReady(Sprite face, Sprite face128, Sprite face256, Sprite body);
+    public delegate void OnSnapshotsReady(Texture2D face, Texture2D face128, Texture2D face256, Texture2D body);
 
     public enum CameraFocus
     {
@@ -113,14 +113,14 @@ public class CharacterPreviewController : MonoBehaviour
         SetFocus(CameraFocus.FaceSnapshot, false);
         avatarAnimator.Reset();
         yield return null;
-        Sprite face = Snapshot(SNAPSHOT_FACE_WIDTH_RES, SNAPSHOT_FACE_HEIGHT_RES);
-        Sprite face128 = Snapshot(SNAPSHOT_FACE_128_WIDTH_RES, SNAPSHOT_FACE_128_HEIGHT_RES);
-        Sprite face256 = Snapshot(SNAPSHOT_FACE_256_WIDTH_RES, SNAPSHOT_FACE_256_HEIGHT_RES);
+        Texture2D face = Snapshot(SNAPSHOT_FACE_WIDTH_RES, SNAPSHOT_FACE_HEIGHT_RES);
+        Texture2D face128 = Snapshot(SNAPSHOT_FACE_128_WIDTH_RES, SNAPSHOT_FACE_128_HEIGHT_RES);
+        Texture2D face256 = Snapshot(SNAPSHOT_FACE_256_WIDTH_RES, SNAPSHOT_FACE_256_HEIGHT_RES);
 
         SetFocus(CameraFocus.BodySnapshot, false);
         avatarAnimator.Reset();
         yield return null;
-        Sprite body = Snapshot(SNAPSHOT_BODY_WIDTH_RES, SNAPSHOT_BODY_HEIGHT_RES);
+        Texture2D body = Snapshot(SNAPSHOT_BODY_WIDTH_RES, SNAPSHOT_BODY_HEIGHT_RES);
 
         SetFocus(CameraFocus.DefaultEditing, false);
 
@@ -128,7 +128,7 @@ public class CharacterPreviewController : MonoBehaviour
         callback?.Invoke(face, face128, face256, body);
     }
 
-    private Sprite Snapshot(int width, int height)
+    private Texture2D Snapshot(int width, int height)
     {
         RenderTexture rt = new RenderTexture(width * SUPERSAMPLING, height * SUPERSAMPLING, 32);
         camera.targetTexture = rt;
@@ -138,7 +138,7 @@ public class CharacterPreviewController : MonoBehaviour
         screenShot.ReadPixels(new Rect(0, 0, rt.width, rt.height), 0, 0);
         screenShot.Apply();
 
-        return Sprite.Create(screenShot, new Rect(0, 0, screenShot.width, screenShot.height), Vector2.zero);
+        return screenShot;
     }
 
     private Coroutine cameraTransitionCoroutine;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Tests/AvatarEditorHUDControllerShould.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Tests/AvatarEditorHUDControllerShould.cs
@@ -279,8 +279,7 @@ namespace AvatarEditorHUD_Tests
             controller.WearableClicked("dcl://base-avatars/blue_bandana");
             controller.WearableClicked("dcl://base-avatars/black_jacket");
 
-            Sprite whiteSprite = Sprite.Create(Texture2D.whiteTexture, new Rect(0, 0, Texture2D.whiteTexture.width, Texture2D.whiteTexture.height), Vector2.zero);
-            controller.SaveAvatar(whiteSprite, whiteSprite, whiteSprite, whiteSprite);
+            controller.SaveAvatar(Texture2D.whiteTexture, Texture2D.whiteTexture, Texture2D.whiteTexture, Texture2D.whiteTexture);
 
             AssertAvatarModelAgainstAvatarEditorHUDModel(userProfile.avatar, controller.myModel);
         }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ExploreHUD/Prefabs/ExploreFriendHead.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ExploreHUD/Prefabs/ExploreFriendHead.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8812185763995546245}
   - component: {fileID: 2665974591458742826}
-  - component: {fileID: 6906638308821999687}
+  - component: {fileID: 1607387837154484392}
   m_Layer: 5
   m_Name: Picture
   m_TagString: Untagged
@@ -45,7 +45,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 973927327678031341}
   m_CullTransparentMesh: 0
---- !u!114 &6906638308821999687
+--- !u!114 &1607387837154484392
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -54,7 +54,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 973927327678031341}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -64,16 +64,13 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 1
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
 --- !u!1 &1996798981937576475
 GameObject:
   m_ObjectHideFlags: 0
@@ -201,7 +198,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 95e7f5cb407204bbf96c85dd98f1b328, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  friendPortrait: {fileID: 6906638308821999687}
+  friendPortrait: {fileID: 1607387837154484392}
   friendBackground: {fileID: 1498590082575333330}
   showHideAnimator: {fileID: 3332448338752215982}
   friendName: {fileID: 2777136830131887387}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ExploreHUD/Scripts/Friends/ExploreFriendsView.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ExploreHUD/Scripts/Friends/ExploreFriendsView.cs
@@ -4,7 +4,7 @@ using TMPro;
 
 internal class ExploreFriendsView : MonoBehaviour
 {
-    [SerializeField] Image friendPortrait;
+    [SerializeField] RawImage friendPortrait;
     [SerializeField] Image friendBackground;
     [SerializeField] ShowHideAnimator showHideAnimator;
     [SerializeField] TextMeshProUGUI friendName;
@@ -15,7 +15,7 @@ internal class ExploreFriendsView : MonoBehaviour
     public void SetUserProfile(UserProfile profile, Color backgroundColor)
     {
         userProfile = profile;
-        friendPortrait.sprite = profile.faceSnapshot;
+        friendPortrait.texture = profile.faceSnapshot;
         friendName.text = profile.userName;
         friendBackground.color = backgroundColor;
 
@@ -26,10 +26,10 @@ internal class ExploreFriendsView : MonoBehaviour
         gameObject.SetActive(true);
     }
 
-    void OnFaceSnapshotReadyEvent(Sprite sprite)
+    void OnFaceSnapshotReadyEvent(Texture2D texture)
     {
         userProfile.OnFaceSnapshotReadyEvent -= OnFaceSnapshotReadyEvent;
-        friendPortrait.sprite = userProfile.faceSnapshot;
+        friendPortrait.texture = userProfile.faceSnapshot;
     }
 
     void OnHeadHoverEnter()

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ExpressionsHUD/ExpressionsHUDView.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ExpressionsHUD/ExpressionsHUDView.cs
@@ -20,7 +20,7 @@ public class ExpressionsHUDView : MonoBehaviour
     [SerializeField] internal Button_OnPointerDown[] hideContentButtons;
     [SerializeField] internal RectTransform content;
     [SerializeField] internal InputAction_Trigger openExpressionsAction;
-    [SerializeField] internal Image avatarPic;
+    [SerializeField] internal RawImage avatarPic;
 
     public static ExpressionsHUDView Create()
     {
@@ -59,11 +59,11 @@ public class ExpressionsHUDView : MonoBehaviour
         }
     }
 
-    public void UpdateAvatarSprite(Sprite avatarSprite)
+    public void UpdateAvatarSprite(Texture2D avatarTexture)
     {
-        if (avatarSprite == null) return;
+        if (avatarTexture == null) return;
 
-        avatarPic.sprite = avatarSprite;
+        avatarPic.texture = avatarTexture;
     }
 
     internal void ToggleContent()

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ExpressionsHUD/Resources/ExpressionsHUD.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ExpressionsHUD/Resources/ExpressionsHUD.prefab
@@ -1393,8 +1393,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4bfd0d144b6d3dd438b84fa14a062c4f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  extraClickSound: 0
-  playHoverSound: 1
+  playHover: 1
+  playClick: 1
+  playRelease: 1
+  extraClickEvent: {fileID: 0}
 --- !u!1 &2513147558662610264
 GameObject:
   m_ObjectHideFlags: 0
@@ -1681,7 +1683,7 @@ MonoBehaviour:
   content: {fileID: 3368308072246989936}
   openExpressionsAction: {fileID: 11400000, guid: a9a8e6cad9d1cc54db4c26cfb7e91f4c,
     type: 2}
-  avatarPic: {fileID: 8506282310728033477}
+  avatarPic: {fileID: 1026993927641938499}
 --- !u!222 &5211374839953244563
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1839,8 +1841,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4bfd0d144b6d3dd438b84fa14a062c4f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  extraClickSound: 0
-  playHoverSound: 1
+  playHover: 1
+  playClick: 1
+  playRelease: 1
+  extraClickEvent: {fileID: 0}
 --- !u!1 &3439737265274002378
 GameObject:
   m_ObjectHideFlags: 0
@@ -2485,8 +2489,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4bfd0d144b6d3dd438b84fa14a062c4f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  extraClickSound: 0
-  playHoverSound: 1
+  playHover: 1
+  playClick: 1
+  playRelease: 1
+  extraClickEvent: {fileID: 0}
 --- !u!1 &4305308132892508061
 GameObject:
   m_ObjectHideFlags: 0
@@ -2612,8 +2618,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4bfd0d144b6d3dd438b84fa14a062c4f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  extraClickSound: 0
-  playHoverSound: 1
+  playHover: 1
+  playClick: 1
+  playRelease: 1
+  extraClickEvent: {fileID: 0}
 --- !u!1 &4450369698054836543
 GameObject:
   m_ObjectHideFlags: 0
@@ -2813,8 +2821,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4bfd0d144b6d3dd438b84fa14a062c4f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  extraClickSound: 0
-  playHoverSound: 1
+  playHover: 1
+  playClick: 1
+  playRelease: 1
+  extraClickEvent: {fileID: 0}
 --- !u!1 &4517195494760827405
 GameObject:
   m_ObjectHideFlags: 0
@@ -3943,8 +3953,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4bfd0d144b6d3dd438b84fa14a062c4f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  extraClickSound: 0
-  playHoverSound: 1
+  playHover: 1
+  playClick: 1
+  playRelease: 1
+  extraClickEvent: {fileID: 0}
 --- !u!1 &6444154813287309588
 GameObject:
   m_ObjectHideFlags: 0
@@ -4660,8 +4672,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4bfd0d144b6d3dd438b84fa14a062c4f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  extraClickSound: 0
-  playHoverSound: 1
+  playHover: 1
+  playClick: 1
+  playRelease: 1
+  extraClickEvent: {fileID: 0}
 --- !u!1 &7275356608294338032
 GameObject:
   m_ObjectHideFlags: 0
@@ -4828,7 +4842,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8600354861481294617}
   - component: {fileID: 1017138830526259340}
-  - component: {fileID: 8506282310728033477}
+  - component: {fileID: 1026993927641938499}
   m_Layer: 5
   m_Name: AvatarPicture
   m_TagString: Untagged
@@ -4863,7 +4877,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7921236905796779737}
   m_CullTransparentMesh: 0
---- !u!114 &8506282310728033477
+--- !u!114 &1026993927641938499
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4872,7 +4886,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 7921236905796779737}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -4882,16 +4896,13 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
 --- !u!1 &8173705416063924011
 GameObject:
   m_ObjectHideFlags: 0
@@ -5123,8 +5134,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4bfd0d144b6d3dd438b84fa14a062c4f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  extraClickSound: 0
-  playHoverSound: 1
+  playHover: 1
+  playClick: 1
+  playRelease: 1
+  extraClickEvent: {fileID: 0}
 --- !u!1 &8195206557192345169
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Resources/FriendEntry.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Resources/FriendEntry.prefab
@@ -68,7 +68,7 @@ MonoBehaviour:
   playerBlockedImage: {fileID: 3044162380546479886}
   menuPositionReference: {fileID: 2396126356780351439}
   playerNameText: {fileID: 5460751659792233842}
-  playerImage: {fileID: 4777978208689502769}
+  playerImage: {fileID: 338001275658977575}
   menuButton: {fileID: 1575258791199021983}
   backgroundImage: {fileID: 712334457687682705}
   hoveredBackgroundSprite: {fileID: 21300000, guid: f48850fa5be164fc68819a7c8586432c,
@@ -223,7 +223,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1771904896382653596}
   - component: {fileID: 4884886738440766159}
-  - component: {fileID: 4777978208689502769}
+  - component: {fileID: 338001275658977575}
   m_Layer: 5
   m_Name: Pic
   m_TagString: Untagged
@@ -258,7 +258,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 831569218822348366}
   m_CullTransparentMesh: 0
---- !u!114 &4777978208689502769
+--- !u!114 &338001275658977575
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -267,26 +267,23 @@ MonoBehaviour:
   m_GameObject: {fileID: 831569218822348366}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 207af87588aa2421385119eee73c020d, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
 --- !u!1 &1110130480339001881
 GameObject:
   m_ObjectHideFlags: 0
@@ -1731,6 +1728,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 368e32a4fe02c184c853ee674afdc420, type: 3}
+--- !u!224 &491712260472388346 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5312804592723535042, guid: 368e32a4fe02c184c853ee674afdc420,
+    type: 3}
+  m_PrefabInstance: {fileID: 5721882781662879288}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &5034795002882272148 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 772113846466065836, guid: 368e32a4fe02c184c853ee674afdc420,
@@ -1743,12 +1746,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f066f155dead9bf48a736a7cdce0c3b6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &491712260472388346 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5312804592723535042, guid: 368e32a4fe02c184c853ee674afdc420,
-    type: 3}
-  m_PrefabInstance: {fileID: 5721882781662879288}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8602356751915698198
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1943,6 +1940,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0a008e464c70e3744b62a048a23c72f5, type: 3}
+--- !u!224 &5339480615015758430 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4429308612254855752, guid: 0a008e464c70e3744b62a048a23c72f5,
+    type: 3}
+  m_PrefabInstance: {fileID: 8602356751915698198}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &6141585309611989806 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2475570976191959864, guid: 0a008e464c70e3744b62a048a23c72f5,
@@ -1955,9 +1958,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 63cc3165dc2ab80458cb65b4ac41fdbd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &5339480615015758430 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4429308612254855752, guid: 0a008e464c70e3744b62a048a23c72f5,
-    type: 3}
-  m_PrefabInstance: {fileID: 8602356751915698198}
-  m_PrefabAsset: {fileID: 0}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Resources/FriendRequestEntry.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Resources/FriendRequestEntry.prefab
@@ -451,7 +451,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3361234363818194385}
   - component: {fileID: 5526326532968950548}
-  - component: {fileID: 3805504581241070516}
+  - component: {fileID: 3438028264569775926}
   m_Layer: 5
   m_Name: Pic
   m_TagString: Untagged
@@ -486,7 +486,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2815231675343004482}
   m_CullTransparentMesh: 0
---- !u!114 &3805504581241070516
+--- !u!114 &3438028264569775926
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -495,26 +495,23 @@ MonoBehaviour:
   m_GameObject: {fileID: 2815231675343004482}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 207af87588aa2421385119eee73c020d, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
 --- !u!1 &3159585121060257330
 GameObject:
   m_ObjectHideFlags: 0
@@ -793,7 +790,7 @@ MonoBehaviour:
   playerBlockedImage: {fileID: 7231910938041917282}
   menuPositionReference: {fileID: 4882786013316759375}
   playerNameText: {fileID: 9059110502284925088}
-  playerImage: {fileID: 3805504581241070516}
+  playerImage: {fileID: 3438028264569775926}
   menuButton: {fileID: 1278527795422366261}
   backgroundImage: {fileID: 8006369808805477131}
   hoveredBackgroundSprite: {fileID: 21300000, guid: f48850fa5be164fc68819a7c8586432c,

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/Entries/FriendEntryBase.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Scripts/Entries/FriendEntryBase.cs
@@ -13,13 +13,13 @@ public class FriendEntryBase : MonoBehaviour, IPointerEnterHandler, IPointerExit
         public string realm;
         public string realmServerName;
         public string realmLayerName;
-        public Sprite avatarImage;
+        public Texture2D avatarImage;
         public bool blocked;
 
-        public event System.Action<Sprite> OnSpriteUpdateEvent;
-        public void OnSpriteUpdate(Sprite sprite)
+        public event System.Action<Texture2D> OnTextureUpdateEvent;
+        public void OnSpriteUpdate(Texture2D texture)
         {
-            OnSpriteUpdateEvent?.Invoke(sprite);
+            OnTextureUpdateEvent?.Invoke(texture);
         }
     }
 
@@ -30,7 +30,7 @@ public class FriendEntryBase : MonoBehaviour, IPointerEnterHandler, IPointerExit
     public Transform menuPositionReference;
 
     [SerializeField] protected internal TextMeshProUGUI playerNameText;
-    [SerializeField] protected internal Image playerImage;
+    [SerializeField] protected internal RawImage playerImage;
     [SerializeField] protected internal Button menuButton;
     [SerializeField] protected internal Image backgroundImage;
     [SerializeField] protected internal Sprite hoveredBackgroundSprite;
@@ -65,7 +65,7 @@ public class FriendEntryBase : MonoBehaviour, IPointerEnterHandler, IPointerExit
     {
         OnPointerExit(null);
 
-        model.OnSpriteUpdateEvent -= OnAvatarImageChange;
+        model.OnTextureUpdateEvent -= OnAvatarImageChange;
     }
 
     public virtual void Populate(Model model)
@@ -77,19 +77,19 @@ public class FriendEntryBase : MonoBehaviour, IPointerEnterHandler, IPointerExit
 
         if (model.avatarImage == null)
         {
-            model.OnSpriteUpdateEvent -= OnAvatarImageChange;
-            model.OnSpriteUpdateEvent += OnAvatarImageChange;
+            model.OnTextureUpdateEvent -= OnAvatarImageChange;
+            model.OnTextureUpdateEvent += OnAvatarImageChange;
         }
 
-        if (model.avatarImage != playerImage.sprite)
-            playerImage.sprite = model.avatarImage;
+        if (model.avatarImage != playerImage.texture)
+            playerImage.texture = model.avatarImage;
 
         playerBlockedImage.enabled = model.blocked;
     }
 
-    private void OnAvatarImageChange(Sprite sprite)
+    private void OnAvatarImageChange(Texture2D texture)
     {
-        playerImage.sprite = sprite;
-        model.avatarImage = sprite;
+        playerImage.texture = texture;
+        model.avatarImage = texture;
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Tests/FriendEntryShould.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Tests/FriendEntryShould.cs
@@ -26,12 +26,11 @@ public class FriendEntryShould : TestsBase
     [Test]
     public void BePopulatedCorrectly()
     {
-        Sprite testSprite = Sprite.Create(Texture2D.whiteTexture, Rect.zero, Vector2.zero);
 
         FriendEntry.Model model = new FriendEntry.Model()
         {
             coords = Vector2.one,
-            avatarImage = testSprite,
+            avatarImage = Texture2D.whiteTexture,
             realm = "realm-test",
             realmServerName = "realm-test",
             realmLayerName = "realm-layer-test",
@@ -43,9 +42,7 @@ public class FriendEntryShould : TestsBase
         entry.Populate(model);
 
         Assert.AreEqual(model.userName, entry.playerNameText.text);
-        Assert.AreEqual(entry.playerImage.sprite, testSprite);
-
-        Object.Destroy(testSprite);
+        Assert.AreEqual(entry.playerImage.texture, Texture2D.whiteTexture);
     }
 
     [Test]

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Tests/FriendRequestEntryShould.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/FriendsHUD/Tests/FriendRequestEntryShould.cs
@@ -26,17 +26,15 @@ public class FriendRequestEntryShould : TestsBase
     [Test]
     public void BePopulatedCorrectly()
     {
-        Sprite testSprite1 = Sprite.Create(Texture2D.whiteTexture, Rect.zero, Vector2.zero);
-        Sprite testSprite2 = Sprite.Create(Texture2D.blackTexture, Rect.zero, Vector2.zero);
-        var model1 = new FriendEntry.Model() { userName = "test1", avatarImage = testSprite1 };
-        var model2 = new FriendEntry.Model() { userName = "test2", avatarImage = testSprite2 };
+        var model1 = new FriendEntry.Model() { userName = "test1", avatarImage = Texture2D.whiteTexture };
+        var model2 = new FriendEntry.Model() { userName = "test2", avatarImage = Texture2D.blackTexture };
 
         entry.userId = "userId1";
         entry.Populate(model1);
         entry.SetReceived(true);
 
         Assert.AreEqual(model1.userName, entry.playerNameText.text);
-        Assert.AreEqual(model1.avatarImage, entry.playerImage.sprite);
+        Assert.AreEqual(model1.avatarImage, entry.playerImage.texture);
 
         Assert.IsFalse(entry.cancelButton.gameObject.activeSelf);
         Assert.IsTrue(entry.acceptButton.gameObject.activeSelf);
@@ -47,14 +45,11 @@ public class FriendRequestEntryShould : TestsBase
         entry.SetReceived(false);
 
         Assert.AreEqual(model2.userName, entry.playerNameText.text);
-        Assert.AreEqual(model2.avatarImage, entry.playerImage.sprite);
+        Assert.AreEqual(model2.avatarImage, entry.playerImage.texture);
 
         Assert.IsTrue(entry.cancelButton.gameObject.activeSelf);
         Assert.IsFalse(entry.acceptButton.gameObject.activeSelf);
         Assert.IsFalse(entry.rejectButton.gameObject.activeSelf);
-
-        Object.Destroy(testSprite1);
-        Object.Destroy(testSprite2);
     }
 
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCardHUDView.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCardHUDView.cs
@@ -34,7 +34,7 @@ public class PlayerInfoCardHUDView : MonoBehaviour
     [SerializeField] internal TabsMapping[] tabsMapping;
     [SerializeField] internal Button hideCardButton;
 
-    [Space] [SerializeField] internal Image avatarPicture;
+    [Space] [SerializeField] internal RawImage avatarPicture;
     [SerializeField] internal Image blockedAvatarOverlay;
     [SerializeField] internal TextMeshProUGUI name;
 
@@ -164,7 +164,7 @@ public class PlayerInfoCardHUDView : MonoBehaviour
         currentUserProfile = userProfile;
         name.text = currentUserProfile.userName;
         description.text = currentUserProfile.description;
-        avatarPicture.sprite = currentUserProfile.faceSnapshot;
+        avatarPicture.texture = currentUserProfile.faceSnapshot;
 
         ClearCollectibles();
         var collectiblesIds = currentUserProfile.GetInventoryItemsIds();

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/Resources/PlayerInfoCardHUD.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/Resources/PlayerInfoCardHUD.prefab
@@ -166,7 +166,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1838900411901135327}
   - component: {fileID: 5994996717070433311}
-  - component: {fileID: 741949897801864843}
+  - component: {fileID: 516924546677337523}
   m_Layer: 20
   m_Name: AvatarPicture
   m_TagString: Untagged
@@ -201,7 +201,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 563613965645386547}
   m_CullTransparentMesh: 0
---- !u!114 &741949897801864843
+--- !u!114 &516924546677337523
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -210,7 +210,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 563613965645386547}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -220,16 +220,13 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
 --- !u!1 &711253438143063192
 GameObject:
   m_ObjectHideFlags: 0
@@ -5672,7 +5669,7 @@ MonoBehaviour:
     toggle: {fileID: 7155771949739570535}
     tab: 2
   hideCardButton: {fileID: 2054052090560482885}
-  avatarPicture: {fileID: 741949897801864843}
+  avatarPicture: {fileID: 516924546677337523}
   blockedAvatarOverlay: {fileID: 4774460956804247699}
   name: {fileID: 2054052089419740692}
   friendStatusContainer: {fileID: 7024342098701633596}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/PrivateChatWindowHUDView.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/PrivateChatWindowHUDView.cs
@@ -15,7 +15,7 @@ public class PrivateChatWindowHUDView : MonoBehaviour
     public ChatHUDView chatHudView;
     public PrivateChatWindowHUDController controller;
     public TMP_Text windowTitleText;
-    public Image profilePictureImage;
+    public RawImage profilePictureImage;
 
     public event System.Action OnPressBack;
     public event System.Action OnMinimize;
@@ -76,9 +76,9 @@ public class PrivateChatWindowHUDView : MonoBehaviour
         windowTitleText.text = targetUserName;
     }
 
-    public void ConfigureProfilePicture(Sprite sprite)
+    public void ConfigureProfilePicture(Texture2D texture)
     {
-        profilePictureImage.sprite = sprite;
+        profilePictureImage.texture = texture;
     }
 
     public void ConfigureUserId(string userId)

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/Resources/PrivateChatWindow.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PrivateChatWindow/Resources/PrivateChatWindow.prefab
@@ -56,7 +56,7 @@ MonoBehaviour:
   jumpInButton: {fileID: 7140426738380900122}
   chatHudView: {fileID: 7972521532659008595}
   windowTitleText: {fileID: 863219034852782852}
-  profilePictureImage: {fileID: 1242771785934811426}
+  profilePictureImage: {fileID: 1978456525324233398}
 --- !u!225 &2700259136045117502
 CanvasGroup:
   m_ObjectHideFlags: 0
@@ -326,9 +326,9 @@ RectTransform:
   m_Father: {fileID: 8687307330290101208}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -12.363083}
   m_SizeDelta: {x: 197.155, y: 19.1156}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &5615328774893752156
@@ -1611,7 +1611,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3276702657697536932}
   - component: {fileID: 2541700090131620826}
-  - component: {fileID: 1242771785934811426}
+  - component: {fileID: 1978456525324233398}
   m_Layer: 5
   m_Name: Pic
   m_TagString: Untagged
@@ -1646,7 +1646,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7247313806351906276}
   m_CullTransparentMesh: 0
---- !u!114 &1242771785934811426
+--- !u!114 &1978456525324233398
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1655,26 +1655,23 @@ MonoBehaviour:
   m_GameObject: {fileID: 7247313806351906276}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
 --- !u!114 &3417501252279225775
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2841,30 +2838,6 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 5396236211427936840}
   m_PrefabAsset: {fileID: 0}
---- !u!224 &5372630980460220423 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 30438154621426255, guid: 486cb7198dd7515498189de8c605a1a3,
-    type: 3}
-  m_PrefabInstance: {fileID: 5396236211427936840}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &5302075511252737345 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 249819674404411145, guid: 486cb7198dd7515498189de8c605a1a3,
-    type: 3}
-  m_PrefabInstance: {fileID: 5396236211427936840}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1aa08ab6e0800fa44ae55d278d1423e3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &6452473416983833199 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1398511019163901991, guid: 486cb7198dd7515498189de8c605a1a3,
-    type: 3}
-  m_PrefabInstance: {fileID: 5396236211427936840}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &272799298560250154 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5272138164132895586, guid: 486cb7198dd7515498189de8c605a1a3,
@@ -2913,15 +2886,39 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 5396236211427936840}
   m_PrefabAsset: {fileID: 0}
+--- !u!224 &5372630980460220423 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 30438154621426255, guid: 486cb7198dd7515498189de8c605a1a3,
+    type: 3}
+  m_PrefabInstance: {fileID: 5396236211427936840}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &7266075628342862806 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 3329569110261295518, guid: 486cb7198dd7515498189de8c605a1a3,
     type: 3}
   m_PrefabInstance: {fileID: 5396236211427936840}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &5302075511252737345 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 249819674404411145, guid: 486cb7198dd7515498189de8c605a1a3,
+    type: 3}
+  m_PrefabInstance: {fileID: 5396236211427936840}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1aa08ab6e0800fa44ae55d278d1423e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1233597897555265721 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6628690613324759793, guid: 486cb7198dd7515498189de8c605a1a3,
+    type: 3}
+  m_PrefabInstance: {fileID: 5396236211427936840}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &6452473416983833199 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1398511019163901991, guid: 486cb7198dd7515498189de8c605a1a3,
     type: 3}
   m_PrefabInstance: {fileID: 5396236211427936840}
   m_PrefabAsset: {fileID: 0}
@@ -3101,7 +3098,7 @@ PrefabInstance:
     - target: {fileID: 5312804592723535042, guid: 368e32a4fe02c184c853ee674afdc420,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -29.920883
       objectReference: {fileID: 0}
     - target: {fileID: 5312804592723535042, guid: 368e32a4fe02c184c853ee674afdc420,
         type: 3}
@@ -3121,7 +3118,7 @@ PrefabInstance:
     - target: {fileID: 5312804592723535042, guid: 368e32a4fe02c184c853ee674afdc420,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5312804592723535042, guid: 368e32a4fe02c184c853ee674afdc420,
         type: 3}
@@ -3131,7 +3128,7 @@ PrefabInstance:
     - target: {fileID: 5312804592723535042, guid: 368e32a4fe02c184c853ee674afdc420,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5312804592723535042, guid: 368e32a4fe02c184c853ee674afdc420,
         type: 3}
@@ -3170,6 +3167,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 368e32a4fe02c184c853ee674afdc420, type: 3}
+--- !u!224 &2313199404560520820 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5312804592723535042, guid: 368e32a4fe02c184c853ee674afdc420,
+    type: 3}
+  m_PrefabInstance: {fileID: 7611361798710637238}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &7140426738380900122 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 772113846466065836, guid: 368e32a4fe02c184c853ee674afdc420,
@@ -3182,9 +3185,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f066f155dead9bf48a736a7cdce0c3b6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &2313199404560520820 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5312804592723535042, guid: 368e32a4fe02c184c853ee674afdc420,
-    type: 3}
-  m_PrefabInstance: {fileID: 7611361798710637238}
-  m_PrefabAsset: {fileID: 0}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUDView.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUDView.cs
@@ -22,7 +22,7 @@ internal class ProfileHUDView : MonoBehaviour
     [SerializeField] internal GameObject[] hideOnNameClaimed;
 
     [Header("Thumbnail")]
-    [SerializeField] internal Image imageAvatarThumbnail;
+    [SerializeField] internal RawImage imageAvatarThumbnail;
     [SerializeField] internal Button buttonToggleMenu;
 
     [Header("Texts")]
@@ -143,10 +143,10 @@ internal class ProfileHUDView : MonoBehaviour
         textAddress.text = $"{start}...{end}";
     }
 
-    private void SetProfileImage(Sprite snapshot)
+    private void SetProfileImage(Texture2D texture)
     {
         profile.OnFaceSnapshotReadyEvent -= SetProfileImage;
-        imageAvatarThumbnail.sprite = snapshot;
+        imageAvatarThumbnail.texture = texture;
         loadingSpinner.SetActive(false);
     }
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/Resources/ProfileHUD.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/Resources/ProfileHUD.prefab
@@ -340,7 +340,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4847931510308338644}
   - component: {fileID: 2172089639314302377}
-  - component: {fileID: 830612372752845904}
+  - component: {fileID: 3515761081290592970}
   m_Layer: 5
   m_Name: Picture
   m_TagString: Untagged
@@ -375,7 +375,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1196886584062727644}
   m_CullTransparentMesh: 0
---- !u!114 &830612372752845904
+--- !u!114 &3515761081290592970
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -384,26 +384,23 @@ MonoBehaviour:
   m_GameObject: {fileID: 1196886584062727644}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
 --- !u!1 &1229710911140771352
 GameObject:
   m_ObjectHideFlags: 0
@@ -2455,7 +2452,7 @@ MonoBehaviour:
   hideOnNameClaimed:
   - {fileID: 7298648520246830518}
   - {fileID: 7575626182848155686}
-  imageAvatarThumbnail: {fileID: 830612372752845904}
+  imageAvatarThumbnail: {fileID: 3515761081290592970}
   buttonToggleMenu: {fileID: 5249297500395189288}
   textName: {fileID: 470573529617210512}
   textPostfix: {fileID: 4239755973591999985}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/ChatHeadButton.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/ChatHeadButton.cs
@@ -6,7 +6,7 @@ public class ChatHeadButton : TaskbarButton, IPointerEnterHandler, IPointerExitH
 {
     [SerializeField] internal ShowHideAnimator labelContainer;
     [SerializeField] internal TMPro.TextMeshProUGUI label;
-    [SerializeField] internal Image portrait;
+    [SerializeField] internal RawImage portrait;
     [SerializeField] internal UnreadNotificationBadge unreadNotificationBadge;
     [SerializeField] internal Image onlineStatusIndicator;
     [SerializeField] internal Color onlineColor = Color.green;
@@ -27,19 +27,19 @@ public class ChatHeadButton : TaskbarButton, IPointerEnterHandler, IPointerExitH
             label.text = profile.userName;
 
         if (profile.faceSnapshot != null)
-            portrait.sprite = profile.faceSnapshot;
+            portrait.texture = profile.faceSnapshot;
         else
             profile.OnFaceSnapshotReadyEvent += Profile_OnFaceSnapshotReadyEvent;
 
         SetOnlineStatus(false);
     }
 
-    private void Profile_OnFaceSnapshotReadyEvent(Sprite portraitSprite)
+    private void Profile_OnFaceSnapshotReadyEvent(Texture2D portraitTexture)
     {
         profile.OnFaceSnapshotReadyEvent -= Profile_OnFaceSnapshotReadyEvent;
 
-        if (portraitSprite != null && this.portrait.sprite != portraitSprite)
-            this.portrait.sprite = portraitSprite;
+        if (portraitTexture != null && this.portrait.texture != portraitTexture)
+            this.portrait.texture = portraitTexture;
     }
 
     private void OnDestroy()

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/Resources/ChatHead.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/TaskbarHUD/Resources/ChatHead.prefab
@@ -389,7 +389,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6619110094856779557}
   - component: {fileID: 2516109673077233140}
-  - component: {fileID: 3063364984001725074}
+  - component: {fileID: 7317044328055230854}
   m_Layer: 5
   m_Name: Picture
   m_TagString: Untagged
@@ -424,7 +424,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1787644444473133633}
   m_CullTransparentMesh: 0
---- !u!114 &3063364984001725074
+--- !u!114 &7317044328055230854
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -433,7 +433,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1787644444473133633}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -443,16 +443,13 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: e36f3569fbdef4c609c33f7a1cebace5, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 1
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
 --- !u!1 &1888759018527753620
 GameObject:
   m_ObjectHideFlags: 0
@@ -825,7 +822,7 @@ MonoBehaviour:
   lineOnIndicator: {fileID: 1917861761070693475}
   labelContainer: {fileID: 308250565065904326}
   label: {fileID: 4219386172326663630}
-  portrait: {fileID: 3063364984001725074}
+  portrait: {fileID: 7317044328055230854}
   unreadNotificationBadge: {fileID: 2870536401237111500}
   onlineStatusIndicator: {fileID: 4641590141182693941}
   onlineColor: {r: 0.31764707, g: 0.8980392, b: 0.34117648, a: 1}
@@ -1753,12 +1750,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 66a8a6e3725e6c04fa70579a8e343b89, type: 3}
---- !u!224 &4104151163294176188 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 3287869685075875600, guid: 66a8a6e3725e6c04fa70579a8e343b89,
-    type: 3}
-  m_PrefabInstance: {fileID: 1536857435981923500}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &2870536401237111500 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3639526527136052832, guid: 66a8a6e3725e6c04fa70579a8e343b89,
@@ -1771,3 +1762,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 63cc3165dc2ab80458cb65b4ac41fdbd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &4104151163294176188 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3287869685075875600, guid: 66a8a6e3725e6c04fa70579a8e343b89,
+    type: 3}
+  m_PrefabInstance: {fileID: 1536857435981923500}
+  m_PrefabAsset: {fileID: 0}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/UserProfile/UserProfile.cs
@@ -10,7 +10,7 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
 {
     static DateTime epochStart = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
     public event Action<UserProfile> OnUpdate;
-    public event Action<Sprite> OnFaceSnapshotReadyEvent;
+    public event Action<Texture2D> OnFaceSnapshotReadyEvent;
     public event Action<string, long> OnAvatarExpressionSet;
 
     public string userId => model.userId;
@@ -24,7 +24,7 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
     public int tutorialStep => model.tutorialStep;
     internal Dictionary<string, int> inventory = new Dictionary<string, int>();
 
-    public Sprite faceSnapshot { get; private set; }
+    public Texture2D faceSnapshot { get; private set; }
     private AssetPromise_Texture thumbnailPromise;
 
     internal UserProfileModel model = new UserProfileModel() //Empty initialization to avoid nullchecks
@@ -90,13 +90,13 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
             Destroy(faceSnapshot);
 
         if (texture != null)
-            faceSnapshot = ThumbnailsManager.CreateSpriteFromTexture(texture.texture);
+            faceSnapshot = texture.texture;
 
         OnUpdate?.Invoke(this);
         OnFaceSnapshotReadyEvent?.Invoke(faceSnapshot);
     }
 
-    public void OverrideAvatar(AvatarModel newModel, Sprite faceSnapshot)
+    public void OverrideAvatar(AvatarModel newModel, Texture2D newFaceSnapshot)
     {
         if (model?.snapshots != null)
         {
@@ -110,7 +110,7 @@ public class UserProfile : ScriptableObject //TODO Move to base variable
         }
 
         model.avatar.CopyFrom(newModel);
-        this.faceSnapshot = faceSnapshot;
+        this.faceSnapshot = newFaceSnapshot;
         OnUpdate?.Invoke(this);
     }
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -805,15 +805,15 @@ namespace DCL.Interface
             public AvatarModel avatar;
         }
 
-        public static void SendSaveAvatar(AvatarModel avatar, Sprite faceSnapshot, Sprite face128Snapshot, Sprite face256Snapshot, Sprite bodySnapshot)
+        public static void SendSaveAvatar(AvatarModel avatar, Texture2D faceSnapshot, Texture2D face128Snapshot, Texture2D face256Snapshot, Texture2D bodySnapshot)
         {
             var payload = new SaveAvatarPayload()
             {
                 avatar = avatar,
-                face = System.Convert.ToBase64String(faceSnapshot.texture.EncodeToPNG()),
-                face128 = System.Convert.ToBase64String(face128Snapshot.texture.EncodeToPNG()),
-                face256 = System.Convert.ToBase64String(face256Snapshot.texture.EncodeToPNG()),
-                body = System.Convert.ToBase64String(bodySnapshot.texture.EncodeToPNG())
+                face = System.Convert.ToBase64String(faceSnapshot.EncodeToPNG()),
+                face128 = System.Convert.ToBase64String(face128Snapshot.EncodeToPNG()),
+                face256 = System.Convert.ToBase64String(face256Snapshot.EncodeToPNG()),
+                body = System.Convert.ToBase64String(bodySnapshot.EncodeToPNG())
             };
             SendMessage("SaveUserAvatar", payload);
         }


### PR DESCRIPTION
Creating a runtime `Sprite` from a texture is slow and expensive and there are not advantages of using them unless you can pack them together in an atlas (which we cannot do) to reduce drawcalls.

Therefore all the use of `Sprite` has been replaced by `Texture2D`  and the prefabs readjusted to use `RawImage` instead of `Image`.