### PR TITLE
fix: "View Profile" text on invisible avatars

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -57,6 +57,8 @@ namespace DCL
             if (currentSerialization == newJson)
                 yield break;
 
+            DisablePassport();
+
             model = SceneController.i.SafeFromJson<AvatarModel>(newJson);
 
             everythingIsLoaded = false;
@@ -110,7 +112,7 @@ namespace DCL
             everythingIsLoaded = true;
             OnAvatarShapeUpdated?.Invoke(entity, this);
 
-            onPointerDown.collider.enabled = true;
+            EnablePassport();
         }
 
         public void DisablePassport()


### PR DESCRIPTION
Sometimes you can not see an avatar, but you can see the "View Profile" legend, and clicking on it you can see her passport.