### PR TITLE
fix: Adding soft timeout to profile promises to ensure they are resolved

### DIFF
--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -99,6 +99,7 @@ const qs = queryString.parse(location.search)
 // Comms
 export const USE_LOCAL_COMMS = location.search.indexOf('LOCAL_COMMS') !== -1 || PREVIEW
 export const COMMS = USE_LOCAL_COMMS ? 'v1-local' : qs.COMMS ? qs.COMMS : 'v2-p2p' // by default
+export const COMMS_PROFILE_TIMEOUT = 10000
 
 export const FETCH_PROFILE_SERVICE = qs.FETCH_PROFILE_SERVICE
 export const UPDATE_CONTENT_SERVICE = qs.UPDATE_CONTENT_SERVICE

--- a/kernel/packages/shared/comms/index.ts
+++ b/kernel/packages/shared/comms/index.ts
@@ -1,4 +1,4 @@
-import { commConfigurations, parcelLimits, COMMS, AUTO_CHANGE_REALM, genericAvatarSnapshots } from 'config'
+import { commConfigurations, parcelLimits, COMMS, AUTO_CHANGE_REALM, genericAvatarSnapshots, COMMS_PROFILE_TIMEOUT } from 'config'
 import { CommunicationsController } from 'shared/apis/CommunicationsController'
 import { defaultLogger } from 'shared/logger'
 import { ChatMessage as InternalChatMessage, ChatMessageType } from 'shared/types'
@@ -352,7 +352,7 @@ export async function requestLocalProfileToPeers(userId: string, version?: numbe
           pendingRequests.splice(pendingRequests.indexOf(thisFuture), 1)
         }
       }
-    }, 10000)
+    }, COMMS_PROFILE_TIMEOUT)
 
     return thisFuture
   } else {


### PR DESCRIPTION
# What? <!-- what is this PR? -->
When refactoring profiles one if the issues that arised was that `ProfileAsPromise` didn't check the version of the profile when awaiting. It only checked it before executing the request. This was because `getProfile` would return null in case a profile was in "loading" state. This lead to some problems so that behaviour was changed.

But it made the `ProfileAsPromise` stricter, which lead to it not being resolved sometimes.

In order to ensure the promise gets resolved, we added a soft timeout, after which the promise will get resolved even if the version of the profile is old. This should solve some issues with invisible avatars that showed up as regressions as a consequence of the refactor.
