### PR TITLE
chore: engine getcomponent optimization

### DIFF
--- a/kernel/packages/decentraland-ecs/src/ecs/Engine.ts
+++ b/kernel/packages/decentraland-ecs/src/ecs/Engine.ts
@@ -264,7 +264,34 @@ export class Engine implements IEngine {
   }
 
   getComponentGroup(...requires: ComponentConstructor<any>[]) {
-    // TODO: memoize?
+
+    // Return an already created component-group if it already exists
+    if (requires.length > 0) {
+      // 1. get component groups for first require
+      let componentGroups = this._componentGroups[getComponentName(requires[0])]
+
+      if (componentGroups) {
+        const components = requires.slice()
+
+        // 2. search for a component group that has all the same requirements
+        componentGroups.forEach(componentGroup => {
+          if (components.length === componentGroup.requiresNames.length) {
+            for (let index = 0; index < components.length; index++) {
+              const componentName = getComponentName(components[index])
+
+              if (componentGroup.requiresNames.indexOf(componentName) === -1) break
+
+              if (index === (components.length - 1)) {
+                // 3. Found an existent component group with the exact same requirements
+                return componentGroup
+              }
+            }
+          }
+        })
+      }
+    }
+
+    // Otherwise create and store it
     const componentGroup = new ComponentGroup(...requires)
 
     componentGroup.active = true

--- a/kernel/packages/decentraland-ecs/src/ecs/Engine.ts
+++ b/kernel/packages/decentraland-ecs/src/ecs/Engine.ts
@@ -278,12 +278,9 @@ export class Engine implements IEngine {
         componentGroups.forEach(traversedComponentGroup => {
           if (components.length === traversedComponentGroup.requires.length) {
             for (let i = 0; i < components.length; i++) {
-              console.log("looking for " + getComponentName(components[i]) + " in " + traversedComponentGroup.requiresNames)
-
               if (traversedComponentGroup.requires.indexOf(components[i]) === -1) break
 
               if (i === (components.length - 1)) {
-                // 3. Found an existent component group with the exact same requirements
                 componentGroup = traversedComponentGroup
               }
             }
@@ -292,11 +289,10 @@ export class Engine implements IEngine {
       }
     }
 
-    if(componentGroup) {
-      console.log("returning EXISTENT component group")
+    if (componentGroup) {
+      // 3. Found an existent component group with the exact same requirements
       return componentGroup
     }
-    console.log("returning new component group")
 
     // Otherwise create and store it
     componentGroup = new ComponentGroup(...requires)

--- a/kernel/packages/decentraland-ecs/src/ecs/Engine.ts
+++ b/kernel/packages/decentraland-ecs/src/ecs/Engine.ts
@@ -275,17 +275,21 @@ export class Engine implements IEngine {
         const components = requires.slice()
 
         // 2. search for a component group that has all the same requirements
-        componentGroups.forEach(traversedComponentGroup => {
-          if (components.length === traversedComponentGroup.requires.length) {
-            for (let i = 0; i < components.length; i++) {
-              if (traversedComponentGroup.requires.indexOf(components[i]) === -1) break
+        for (let i = 0; i < componentGroups.length; i++) {
+          const traversedComponentGroup = componentGroups[i]
 
-              if (i === (components.length - 1)) {
+          if (components.length === traversedComponentGroup.requires.length) {
+            for (let j = 0; j < components.length; j++) {
+              if (traversedComponentGroup.requires.indexOf(components[j]) === -1) break
+
+              if (j === (components.length - 1)) {
                 componentGroup = traversedComponentGroup
               }
             }
+
+            if (componentGroup) break
           }
-        })
+        }
       }
     }
 

--- a/kernel/packages/decentraland-ecs/src/ecs/Engine.ts
+++ b/kernel/packages/decentraland-ecs/src/ecs/Engine.ts
@@ -264,6 +264,7 @@ export class Engine implements IEngine {
   }
 
   getComponentGroup(...requires: ComponentConstructor<any>[]) {
+    let componentGroup = undefined
 
     // Return an already created component-group if it already exists
     if (requires.length > 0) {
@@ -274,16 +275,16 @@ export class Engine implements IEngine {
         const components = requires.slice()
 
         // 2. search for a component group that has all the same requirements
-        componentGroups.forEach(componentGroup => {
-          if (components.length === componentGroup.requiresNames.length) {
-            for (let index = 0; index < components.length; index++) {
-              const componentName = getComponentName(components[index])
+        componentGroups.forEach(traversedComponentGroup => {
+          if (components.length === traversedComponentGroup.requires.length) {
+            for (let i = 0; i < components.length; i++) {
+              console.log("looking for " + getComponentName(components[i]) + " in " + traversedComponentGroup.requiresNames)
 
-              if (componentGroup.requiresNames.indexOf(componentName) === -1) break
+              if (traversedComponentGroup.requires.indexOf(components[i]) === -1) break
 
-              if (index === (components.length - 1)) {
+              if (i === (components.length - 1)) {
                 // 3. Found an existent component group with the exact same requirements
-                return componentGroup
+                componentGroup = traversedComponentGroup
               }
             }
           }
@@ -291,8 +292,14 @@ export class Engine implements IEngine {
       }
     }
 
+    if(componentGroup) {
+      console.log("returning EXISTENT component group")
+      return componentGroup
+    }
+    console.log("returning new component group")
+
     // Otherwise create and store it
-    const componentGroup = new ComponentGroup(...requires)
+    componentGroup = new ComponentGroup(...requires)
 
     componentGroup.active = true
 

--- a/kernel/test/index.ts
+++ b/kernel/test/index.ts
@@ -20,6 +20,7 @@ import './unit/profiles.saga.test'
 import './unit/BrowserInterface.test'
 import './unit/positionThings.test'
 import './unit/RestrictedActions.test'
+import './unit/engine.test'
 import './unityIntegration/ecs/math/quaternion.test'
 import './unityIntegration/ecs/math/vector3.test'
 

--- a/kernel/test/unit/engine.test.tsx
+++ b/kernel/test/unit/engine.test.tsx
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { Entity, BoxShape, Transform, Vector3, engine } from 'decentraland-ecs/src';
 
-describe.skip('Engine tests', () => {
+describe('Engine tests', () => {
   it('getComponentGroupReturnsCachedGroup', () => {
 
     let box = new Entity()

--- a/kernel/test/unit/engine.test.tsx
+++ b/kernel/test/unit/engine.test.tsx
@@ -1,0 +1,28 @@
+import { expect } from 'chai'
+import { Entity, BoxShape, Transform, Vector3, engine } from 'decentraland-ecs/src';
+
+describe.skip('Engine tests', () => {
+  it('getComponentGroupReturnsCachedGroup', () => {
+
+    let box = new Entity()
+    box.addComponent(new BoxShape())
+    box.addComponent(
+      new Transform({
+        position: new Vector3(8, 0, 8),
+      })
+    )
+    const firstComponentGroup = engine.getComponentGroup(BoxShape, Transform)
+    const secondComponentGroup = engine.getComponentGroup(BoxShape, Transform)
+    const thirdComponentGroup = engine.getComponentGroup(BoxShape, Transform)
+
+    expect(firstComponentGroup).to.same(
+      secondComponentGroup,
+      'returnCachedComponentGroup01'
+    )
+
+    expect(secondComponentGroup).to.same(
+      thirdComponentGroup,
+      'returnCachedComponentGroup02'
+    )
+  })
+})

--- a/kernel/test/unit/engine.test.tsx
+++ b/kernel/test/unit/engine.test.tsx
@@ -2,7 +2,7 @@ import { expect } from 'chai'
 import { Entity, BoxShape, Transform, Vector3, engine } from 'decentraland-ecs/src';
 
 describe('Engine tests', () => {
-  it('getComponentGroupReturnsCachedGroup', () => {
+  it('getComponentGroup returns cached group', () => {
 
     let box = new Entity()
     box.addComponent(new BoxShape())
@@ -11,18 +11,25 @@ describe('Engine tests', () => {
         position: new Vector3(8, 0, 8),
       })
     )
+
     const firstComponentGroup = engine.getComponentGroup(BoxShape, Transform)
     const secondComponentGroup = engine.getComponentGroup(BoxShape, Transform)
     const thirdComponentGroup = engine.getComponentGroup(BoxShape, Transform)
 
-    expect(firstComponentGroup).to.same(
+    expect(firstComponentGroup).to.equal(
       secondComponentGroup,
       'returnCachedComponentGroup01'
     )
 
-    expect(secondComponentGroup).to.same(
+    expect(secondComponentGroup).to.equal(
       thirdComponentGroup,
       'returnCachedComponentGroup02'
+    )
+
+    const fourthComponentGroup = engine.getComponentGroup(BoxShape)
+    expect(thirdComponentGroup).to.not.equal(
+      fourthComponentGroup,
+      'returnCachedComponentGroup03'
     )
   })
 })


### PR DESCRIPTION
**WHY?**
Currently, every time an `engine.getComponentGroup()` is called, a new component group is always created, leading to memory leaks when used aggresively (e.g. in a system update()) like the one reported at #1340 

**WHAT?**
Added a bit of code to traverse the already existent (we were aleady caching them) component groups and return the one with exactly the same requirements. Otherwise, we follow the normal flow and create and store it.
