### PR TITLE
Player info card moved

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/Resources/PlayerInfoCardHUD.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/Resources/PlayerInfoCardHUD.prefab
@@ -477,8 +477,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -2, y: 10.54}
-  m_SizeDelta: {x: -3.999939, y: 41.957825}
+  m_AnchoredPosition: {x: 0, y: 10.539993}
+  m_SizeDelta: {x: -8.650482, y: 41.957825}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &7649770749279864204
 CanvasRenderer:
@@ -533,7 +533,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1193018594340784404}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
@@ -1111,7 +1111,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -0.000030517578, y: 0}
+  m_AnchoredPosition: {x: -0.000030517578, y: 1.0000134}
   m_SizeDelta: {x: 0, y: 16}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &3925265991705710024
@@ -1143,8 +1143,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: Passport
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
-  m_sharedMaterial: {fileID: 2100000, guid: cbef7abfd5b4443bf9d5c298a464b5a6, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: c0f2e4affe3f2438d9042ca1db45764f, type: 2}
+  m_sharedMaterial: {fileID: 2100000, guid: 70f3d6b07a517476dbd2b89cf148f858, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -1169,13 +1169,13 @@ MonoBehaviour:
   m_outlineColor:
     serializedVersion: 2
     rgba: 4278190080
-  m_fontSize: 9.8
-  m_fontSizeBase: 9.8
+  m_fontSize: 12
+  m_fontSizeBase: 12
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 7
   m_fontSizeMax: 9
-  m_fontStyle: 16
+  m_fontStyle: 1
   m_textAlignment: 514
   m_characterSpacing: 0
   m_wordSpacing: 0
@@ -2089,10 +2089,10 @@ RectTransform:
   m_Father: {fileID: 848251776757922260}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 112.1001, y: 13}
-  m_SizeDelta: {x: 224.11597, y: 327.4}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: -124.57, y: 0}
+  m_SizeDelta: {x: 240.04688, y: 327.4}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2054052090630472334
 CanvasRenderer:
@@ -2121,7 +2121,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 73eb02c3697d74008aff9a4139d43c55, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 7b4468575e3ab49e1aec3edd88298137, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -2697,7 +2697,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 1.0000134}
   m_SizeDelta: {x: 0, y: 16}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &3885152431390886536
@@ -2729,8 +2729,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: Collectibles
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
-  m_sharedMaterial: {fileID: 2100000, guid: cbef7abfd5b4443bf9d5c298a464b5a6, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: c0f2e4affe3f2438d9042ca1db45764f, type: 2}
+  m_sharedMaterial: {fileID: 2100000, guid: 70f3d6b07a517476dbd2b89cf148f858, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -2755,13 +2755,13 @@ MonoBehaviour:
   m_outlineColor:
     serializedVersion: 2
     rgba: 4278190080
-  m_fontSize: 9.8
-  m_fontSizeBase: 9.8
+  m_fontSize: 12
+  m_fontSizeBase: 12
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 7
   m_fontSizeMax: 9
-  m_fontStyle: 16
+  m_fontStyle: 1
   m_textAlignment: 514
   m_characterSpacing: 0
   m_wordSpacing: 0
@@ -3079,8 +3079,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0.059999466}
-  m_SizeDelta: {x: 0, y: -3.8847275}
+  m_AnchoredPosition: {x: 0.47999954, y: -0.20999908}
+  m_SizeDelta: {x: -16.257843, y: -3.3510437}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7069052607419588091
 CanvasRenderer:
@@ -3097,7 +3097,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2908032166496426148}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
@@ -3394,7 +3394,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 6c9da2cade77947d3bc10b1ad5c4f532, type: 3}
+  m_Sprite: {fileID: 21300000, guid: ad45379ab95744ed290d6c7808b89084, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -4673,7 +4673,6 @@ GameObject:
   - component: {fileID: 7940745148068168147}
   - component: {fileID: 485573182697832479}
   - component: {fileID: 3039249988673879662}
-  - component: {fileID: 871995468201220239}
   - component: {fileID: 6277624246107896268}
   - component: {fileID: 5331145053242549076}
   m_Layer: 20
@@ -4704,7 +4703,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 74, y: 46}
+  m_SizeDelta: {x: 78, y: 46}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7940745148068168147
 CanvasRenderer:
@@ -4775,22 +4774,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   targetText: {fileID: 8878329868580519372}
   onFont: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
-  offFont: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
---- !u!114 &871995468201220239
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5332427801049200702}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6cfb6394cc153446eacda7327b3db852, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  targetImage: {fileID: 3641331502537258890}
-  onColor: {r: 1, g: 1, b: 1, a: 1}
-  offColor: {r: 1, g: 1, b: 1, a: 0}
+  offFont: {fileID: 11400000, guid: c0f2e4affe3f2438d9042ca1db45764f, type: 2}
 --- !u!114 &6277624246107896268
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5086,8 +5070,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -5.6399994, y: 0.059999466}
-  m_SizeDelta: {x: -11.289841, y: -3.8847275}
+  m_AnchoredPosition: {x: 0.040000916, y: -0.20999908}
+  m_SizeDelta: {x: -5.8814697, y: -3.3510437}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6561712081220346313
 CanvasRenderer:
@@ -5104,7 +5088,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6045126105019552955}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
@@ -5503,8 +5487,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0.059999466}
-  m_SizeDelta: {x: 0, y: -3.8847275}
+  m_AnchoredPosition: {x: 0, y: -0.20999908}
+  m_SizeDelta: {x: 0, y: -3.3510437}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5958609764621718848
 CanvasRenderer:
@@ -5521,7 +5505,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7111941581605762272}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
@@ -5697,7 +5681,6 @@ GameObject:
   - component: {fileID: 4092361005934169148}
   - component: {fileID: 7082974898656184366}
   - component: {fileID: 8629567676430278528}
-  - component: {fileID: 5752850524028901438}
   - component: {fileID: 3734414787116764773}
   - component: {fileID: 8087644179958541084}
   m_Layer: 20
@@ -5728,7 +5711,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 74, y: 46}
+  m_SizeDelta: {x: 78, y: 46}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4092361005934169148
 CanvasRenderer:
@@ -5799,22 +5782,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   targetText: {fileID: 1961411879515996598}
   onFont: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
-  offFont: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
---- !u!114 &5752850524028901438
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7387533419399660297}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6cfb6394cc153446eacda7327b3db852, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  targetImage: {fileID: 1629297535479234440}
-  onColor: {r: 1, g: 1, b: 1, a: 1}
-  offColor: {r: 1, g: 1, b: 1, a: 0}
+  offFont: {fileID: 11400000, guid: c0f2e4affe3f2438d9042ca1db45764f, type: 2}
 --- !u!114 &3734414787116764773
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6080,7 +6048,6 @@ GameObject:
   - component: {fileID: 493777728770620825}
   - component: {fileID: 7155771949739570535}
   - component: {fileID: 8264717095437058145}
-  - component: {fileID: 6994933318947758782}
   - component: {fileID: 9163344818240518326}
   - component: {fileID: 7342698125525593538}
   m_Layer: 20
@@ -6111,7 +6078,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 74, y: 46}
+  m_SizeDelta: {x: 78, y: 46}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &493777728770620825
 CanvasRenderer:
@@ -6182,22 +6149,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   targetText: {fileID: 492976362715935780}
   onFont: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
-  offFont: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
---- !u!114 &6994933318947758782
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8055774471703887743}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6cfb6394cc153446eacda7327b3db852, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  targetImage: {fileID: 1939323749587315695}
-  onColor: {r: 1, g: 1, b: 1, a: 1}
-  offColor: {r: 1, g: 1, b: 1, a: 0}
+  offFont: {fileID: 11400000, guid: c0f2e4affe3f2438d9042ca1db45764f, type: 2}
 --- !u!114 &9163344818240518326
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6263,7 +6215,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -0.000030517578, y: 0}
+  m_AnchoredPosition: {x: -0.000030517578, y: 1}
   m_SizeDelta: {x: 0, y: 16}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &864718366436580005
@@ -6295,8 +6247,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: Block
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
-  m_sharedMaterial: {fileID: 2100000, guid: cbef7abfd5b4443bf9d5c298a464b5a6, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: c0f2e4affe3f2438d9042ca1db45764f, type: 2}
+  m_sharedMaterial: {fileID: 2100000, guid: 70f3d6b07a517476dbd2b89cf148f858, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -6321,13 +6273,13 @@ MonoBehaviour:
   m_outlineColor:
     serializedVersion: 2
     rgba: 4278190080
-  m_fontSize: 9.8
-  m_fontSizeBase: 9.8
+  m_fontSize: 12
+  m_fontSizeBase: 12
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 7
   m_fontSizeMax: 9
-  m_fontStyle: 16
+  m_fontStyle: 1
   m_textAlignment: 514
   m_characterSpacing: 0
   m_wordSpacing: 0

--- a/unity-client/Assets/Textures/UI/CardPassportIcon.png
+++ b/unity-client/Assets/Textures/UI/CardPassportIcon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8d2ad993f50a2175597dec159ae7bc24df133dfe9b9bd9bb9e022fb6d6d90df
+size 3020

--- a/unity-client/Assets/Textures/UI/CardPassportIcon.png.meta
+++ b/unity-client/Assets/Textures/UI/CardPassportIcon.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 73eb02c3697d74008aff9a4139d43c55
+guid: ad45379ab95744ed290d6c7808b89084
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -46,7 +46,7 @@ TextureImporter:
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 100
-  spriteBorder: {x: 47, y: 45, z: 11, w: 32}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 0
   alphaUsage: 1
   alphaIsTransparency: 1
@@ -64,7 +64,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 0
+    textureCompression: 1
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
@@ -76,7 +76,7 @@ TextureImporter:
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
-    textureCompression: 0
+    textureCompression: 1
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0

--- a/unity-client/Assets/Textures/UI/ContainerPassport.png
+++ b/unity-client/Assets/Textures/UI/ContainerPassport.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:349ef30dbb41d4a881a946250cdff740daf3ff48044b28b1e5d6af1c07a873fc
-size 875
+oid sha256:7cdf25c36da361e75ecc17e8b2fca3991c6904497f6489a91b25ed03650d19e0
+size 2578

--- a/unity-client/Assets/Textures/UI/TexturesUI.spriteatlas
+++ b/unity-client/Assets/Textures/UI/TexturesUI.spriteatlas
@@ -55,7 +55,7 @@ SpriteAtlas:
     variantMultiplier: 1
     packables:
     - {fileID: 102900000, guid: 1eee3b038d846456b84c415627892c52, type: 3}
-    totalSpriteSurfaceArea: 2835153
+    totalSpriteSurfaceArea: 2837463
     bindAsDefault: 1
   m_MasterAtlas: {fileID: 0}
   m_PackedSprites:
@@ -165,6 +165,7 @@ SpriteAtlas:
   - {fileID: 21300000, guid: df21406aac3b94b18b9edcf3e6ae36c4, type: 3}
   - {fileID: 21300000, guid: 593f8d6a3ab9548768fe19dc0eaaad16, type: 3}
   - {fileID: 21300000, guid: cda51e8a359aa4105bbb5f2b2e27dd10, type: 3}
+  - {fileID: 21300000, guid: ad45379ab95744ed290d6c7808b89084, type: 3}
   - {fileID: 21300000, guid: 96af52ba6c86845beb91f068f1cabe94, type: 3}
   - {fileID: 21300000, guid: 6c9da2cade77947d3bc10b1ad5c4f532, type: 3}
   - {fileID: 21300000, guid: 0b8573ead118a4e798b4fa5d8c93fe8c, type: 3}
@@ -322,6 +323,7 @@ SpriteAtlas:
   - CardCollectiblesIcon
   - NowTag
   - RectRadius16
+  - CardPassportIcon
   - MarketplaceEditorIcon
   - PassportIcon
   - ContainerRadius6Shadow


### PR DESCRIPTION
Player info card was moved to the right in order to avoid overlapping with the rest of the UI.
Passport icon in the tab fixed.

![image (2)](https://user-images.githubusercontent.com/51088292/98129257-af9b0800-1e97-11eb-9eb0-726d277afe4e.png)
<img width="395" alt="Screen Shot 2020-11-04 at 12 18 46" src="https://user-images.githubusercontent.com/51088292/98129468-e8d37800-1e97-11eb-8a2a-f8ba5a8c3517.png">
