### PR TITLE
feat: Voice chat now disabled by default. Added allowlist for voice chat

### DIFF
--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -111,6 +111,8 @@ export const REALM = qs.realm
 
 export const VOICE_CHAT_DISABLED_FLAG = location.search.indexOf('VOICE_CHAT_DISABLED') !== -1
 
+export const VOICE_CHAT_ENABLED_FLAG = location.search.indexOf('VOICE_CHAT_ENABLED') !== -1
+
 export const AUTO_CHANGE_REALM = location.search.indexOf('AUTO_CHANGE_REALM') !== -1
 
 export const LOS = qs.LOS

--- a/kernel/packages/entryPoints/unity.ts
+++ b/kernel/packages/entryPoints/unity.ts
@@ -22,7 +22,8 @@ import { realmInitialized } from 'shared/dao'
 import { EnsureProfile } from 'shared/profiles/ProfileAsPromise'
 import { ensureMetaConfigurationInitialized, waitForMessageOfTheDay } from 'shared/meta'
 import { WorldConfig } from 'shared/meta/types'
-import { isVoiceChatEnabled } from 'shared/meta/selectors'
+import {  isVoiceChatEnabledFor } from 'shared/meta/selectors'
+import { UnityInterface } from 'unity-interface/UnityInterface'
 
 const container = document.getElementById('gameContainer')
 
@@ -38,6 +39,16 @@ const observer = renderStateObservable.add((isRunning) => {
     DEBUG_PM && logger.info(`initial load: `, Date.now() - start)
   }
 })
+
+function configureTaskbar(i: UnityInterface, voiceChatEnabled: boolean) {
+  i.ConfigureHUDElement(HUDElementID.TASKBAR, { active: true, visible: true }, { enableVoiceChat: voiceChatEnabled })
+  i.ConfigureHUDElement(HUDElementID.WORLD_CHAT_WINDOW, { active: true, visible: true })
+
+  i.ConfigureHUDElement(HUDElementID.CONTROLS_HUD, { active: true, visible: false })
+  i.ConfigureHUDElement(HUDElementID.EXPLORE_HUD, { active: true, visible: false })
+  i.ConfigureHUDElement(HUDElementID.HELP_AND_SUPPORT_HUD, { active: true, visible: false })
+  i.ConfigureHUDElement(HUDElementID.USERS_AROUND_LIST_HUD, { active: voiceChatEnabled, visible: false })
+}
 
 initializeUnity(container)
   .then(async ({ instancedJS }) => {
@@ -58,26 +69,22 @@ initializeUnity(container)
     })
     i.ConfigureHUDElement(HUDElementID.AIRDROPPING, { active: true, visible: true })
     i.ConfigureHUDElement(HUDElementID.TERMS_OF_SERVICE, { active: true, visible: true })
+
+    i.ConfigureHUDElement(HUDElementID.OPEN_EXTERNAL_URL_PROMPT, { active: true, visible: false })
+    i.ConfigureHUDElement(HUDElementID.NFT_INFO_DIALOG, { active: true, visible: false })
+    i.ConfigureHUDElement(HUDElementID.TELEPORT_DIALOG, { active: true, visible: false })
+
     //NOTE(Brian): Scene download manager uses meta config to determine which empty parcels we want
     //             so ensuring meta configuration is initialized in this stage is a must
     //NOTE(Pablo): We also need meta configuration to know if we need to enable voice chat
     await ensureMetaConfigurationInitialized()
 
-    const voiceChatEnabled = isVoiceChatEnabled(globalThis.globalStore.getState())
-
-    i.ConfigureHUDElement(HUDElementID.TASKBAR, { active: true, visible: true }, { enableVoiceChat: voiceChatEnabled })
-    i.ConfigureHUDElement(HUDElementID.WORLD_CHAT_WINDOW, { active: true, visible: true })
-    i.ConfigureHUDElement(HUDElementID.OPEN_EXTERNAL_URL_PROMPT, { active: true, visible: false })
-    i.ConfigureHUDElement(HUDElementID.NFT_INFO_DIALOG, { active: true, visible: false })
-    i.ConfigureHUDElement(HUDElementID.TELEPORT_DIALOG, { active: true, visible: false })
-    i.ConfigureHUDElement(HUDElementID.CONTROLS_HUD, { active: true, visible: false })
-    i.ConfigureHUDElement(HUDElementID.EXPLORE_HUD, { active: true, visible: false })
-    i.ConfigureHUDElement(HUDElementID.HELP_AND_SUPPORT_HUD, { active: true, visible: false })
-    i.ConfigureHUDElement(HUDElementID.USERS_AROUND_LIST_HUD, { active: voiceChatEnabled, visible: false })
-
     try {
       await userAuthentified()
       const identity = getCurrentIdentity(globalThis.globalStore.getState())!
+
+      configureTaskbar(i, isVoiceChatEnabledFor(globalThis.globalStore.getState(), identity.address))
+
       i.ConfigureHUDElement(HUDElementID.FRIENDS, { active: identity.hasConnectedWeb3, visible: false })
       // NOTE (Santi): We have temporarily deactivated the MANA HUD until Product team designs a new place for it (probably inside the Profile HUD).
       i.ConfigureHUDElement(HUDElementID.MANA_HUD, { active: identity.hasConnectedWeb3 && false, visible: true })
@@ -89,7 +96,8 @@ initializeUnity(container)
         })
         .catch((e) => logger.error(`error getting profile ${e}`))
     } catch (e) {
-      logger.error('error on configuring friends hud / tutorial')
+      logger.error('error on configuring taskbar & friends hud / tutorial. Trying to default to simple taskbar', e)
+      configureTaskbar(i, false)
     }
 
     globalThis.globalStore.dispatch(signalRendererInitialized())

--- a/kernel/packages/shared/comms/index.ts
+++ b/kernel/packages/shared/comms/index.ts
@@ -1,4 +1,11 @@
-import { commConfigurations, parcelLimits, COMMS, AUTO_CHANGE_REALM, genericAvatarSnapshots, COMMS_PROFILE_TIMEOUT } from 'config'
+import {
+  commConfigurations,
+  parcelLimits,
+  COMMS,
+  AUTO_CHANGE_REALM,
+  genericAvatarSnapshots,
+  COMMS_PROFILE_TIMEOUT
+} from 'config'
 import { CommunicationsController } from 'shared/apis/CommunicationsController'
 import { defaultLogger } from 'shared/logger'
 import { ChatMessage as InternalChatMessage, ChatMessageType } from 'shared/types'
@@ -71,7 +78,7 @@ import { realmToString } from '../dao/utils/realmToString'
 import { queueTrackingEvent } from 'shared/analytics'
 import { messageReceived } from '../chat/actions'
 import { arrayEquals } from 'atomicHelpers/arrayEquals'
-import { getCommsConfig, isVoiceChatEnabled } from 'shared/meta/selectors'
+import { getCommsConfig, isVoiceChatEnabledFor } from 'shared/meta/selectors'
 import { ensureMetaConfigurationInitialized } from 'shared/meta/index'
 import { ReportFatalError } from 'shared/loading/ReportFatalError'
 import {
@@ -1138,7 +1145,7 @@ async function doStartCommunications(context: Context) {
       }
     }, 100)
 
-    if (!voiceCommunicator && isVoiceChatEnabled(store.getState())) {
+    if (!voiceCommunicator && isVoiceChatEnabledFor(store.getState(), context.userInfo.userId!)) {
       voiceCommunicator = new VoiceCommunicator(
         context.userInfo.userId!,
         {

--- a/kernel/packages/shared/comms/sagas.ts
+++ b/kernel/packages/shared/comms/sagas.ts
@@ -36,7 +36,8 @@ import {
 import { isVoiceChatRecording } from './selectors'
 import { unityInterface } from 'unity-interface/UnityInterface'
 import { ensureMetaConfigurationInitialized } from 'shared/meta'
-import { isVoiceChatEnabled } from 'shared/meta/selectors'
+import { isVoiceChatEnabledFor } from 'shared/meta/selectors'
+import { userAuthentified } from 'shared/session'
 
 const DEBUG = false
 const logger = createLogger('comms: ')
@@ -45,7 +46,11 @@ export function* commsSaga() {
   yield takeEvery(USER_AUTHENTIFIED, establishCommunications)
   yield takeLatest(CATALYST_REALMS_SCAN_SUCCESS, changeRealm)
   yield ensureMetaConfigurationInitialized()
-  if (yield select(isVoiceChatEnabled)) {
+  yield userAuthentified()
+
+  const identity = yield select(getCurrentIdentity)
+
+  if (yield select(isVoiceChatEnabledFor, identity.address)) {
     yield takeEvery(SET_VOICE_CHAT_RECORDING, updateVoiceChatRecordingStatus)
     yield takeEvery(TOGGLE_VOICE_CHAT_RECORDING, updateVoiceChatRecordingStatus)
     yield takeEvery(VOICE_PLAYING_UPDATE, updateUserVoicePlaying)

--- a/kernel/packages/shared/meta/selectors.ts
+++ b/kernel/packages/shared/meta/selectors.ts
@@ -36,7 +36,7 @@ export const getMessageOfTheDay = (store: RootMetaState): MessageOfTheDayConfig 
 export const isVoiceChatEnabled = (store: RootMetaState): boolean =>
   (!!getCommsConfig(store).voiceChatEnabled && !VOICE_CHAT_DISABLED_FLAG) || VOICE_CHAT_ENABLED_FLAG
 
-export const getVoiceChatWhitelist = (store: RootMetaState): string[] => getCommsConfig(store).voiceChatAllowlist ?? []
+export const getVoiceChatAllowlist = (store: RootMetaState): string[] => getCommsConfig(store).voiceChatAllowlist ?? []
 
 export const isVoiceChatEnabledFor = (store: RootMetaState, userId: string): boolean =>
-  isVoiceChatEnabled(store) || getVoiceChatWhitelist(store).includes(userId)
+  isVoiceChatEnabled(store) || (getVoiceChatAllowlist(store).includes(userId) && !VOICE_CHAT_DISABLED_FLAG)

--- a/kernel/packages/shared/meta/selectors.ts
+++ b/kernel/packages/shared/meta/selectors.ts
@@ -36,8 +36,7 @@ export const getMessageOfTheDay = (store: RootMetaState): MessageOfTheDayConfig 
 export const isVoiceChatEnabled = (store: RootMetaState): boolean =>
   (!!getCommsConfig(store).voiceChatEnabled && !VOICE_CHAT_DISABLED_FLAG) || VOICE_CHAT_ENABLED_FLAG
 
-export const getVoiceChatWhitelist = (store: RootMetaState): string[] =>
-  getCommsConfig(store).voiceChatAllowlist ?? ['0x8f75ac49512b65990537122edab456b81597ebfa']
+export const getVoiceChatWhitelist = (store: RootMetaState): string[] => getCommsConfig(store).voiceChatAllowlist ?? []
 
 export const isVoiceChatEnabledFor = (store: RootMetaState, userId: string): boolean =>
   isVoiceChatEnabled(store) || getVoiceChatWhitelist(store).includes(userId)

--- a/kernel/packages/shared/meta/selectors.ts
+++ b/kernel/packages/shared/meta/selectors.ts
@@ -1,6 +1,6 @@
 import { CommsConfig, MessageOfTheDayConfig, RootMetaState } from './types'
 import { Vector2Component } from 'atomicHelpers/landHelpers'
-import { VOICE_CHAT_DISABLED_FLAG } from 'config'
+import { VOICE_CHAT_DISABLED_FLAG, VOICE_CHAT_ENABLED_FLAG } from 'config'
 
 export const getAddedServers = (store: RootMetaState): string[] => {
   const { config } = store.meta
@@ -34,4 +34,10 @@ export const getMessageOfTheDay = (store: RootMetaState): MessageOfTheDayConfig 
   store.meta.config.world ? store.meta.config.world.messageOfTheDay || null : null
 
 export const isVoiceChatEnabled = (store: RootMetaState): boolean =>
-  !getCommsConfig(store).voiceChatDisabled && !VOICE_CHAT_DISABLED_FLAG
+  (!!getCommsConfig(store).voiceChatEnabled && !VOICE_CHAT_DISABLED_FLAG) || VOICE_CHAT_ENABLED_FLAG
+
+export const getVoiceChatWhitelist = (store: RootMetaState): string[] =>
+  getCommsConfig(store).voiceChatAllowlist ?? ['0x8f75ac49512b65990537122edab456b81597ebfa']
+
+export const isVoiceChatEnabledFor = (store: RootMetaState, userId: string): boolean =>
+  isVoiceChatEnabled(store) || getVoiceChatWhitelist(store).includes(userId)

--- a/kernel/packages/shared/meta/types.ts
+++ b/kernel/packages/shared/meta/types.ts
@@ -55,5 +55,6 @@ export type CommsConfig = {
   relaySuspensionDisabled?: boolean
   relaySuspensionInterval?: number
   relaySuspensionDuration?: number
-  voiceChatDisabled?: boolean
+  voiceChatEnabled?: boolean
+  voiceChatAllowlist?: string[]
 }


### PR DESCRIPTION
There are now four controls for enabling / disabling voice chat:
- `voiceChatEnabled` flag in meta configuration -> enables/disables voice chat globally
- `voiceChatAllowlist` list in meta configuration -> Enables voice chat for those included in the list by address (0xabcdef01234...)
- `VOICE_CHAT_ENABLED` in the URL overrides this and enables it for this session
- `VOICE_CHAT_DISABLED` in the URL overrides this and enables it for this session
