### PR TITLE
fix: invalid fps stacking when out of focus

### DIFF
--- a/kernel/packages/entryPoints/unity.ts
+++ b/kernel/packages/entryPoints/unity.ts
@@ -15,7 +15,7 @@ import { StoreContainer } from 'shared/store/rootTypes'
 import { startUnitySceneWorkers } from '../unity-interface/dcl'
 import { initializeUnity } from '../unity-interface/initializer'
 import { HUDElementID, RenderProfile } from 'shared/types'
-import { renderStateObservable, onNextRendererEnabled } from 'shared/world/worldState'
+import { renderStateObservable, onNextRendererEnabled, foregroundObservable } from 'shared/world/worldState'
 import { getCurrentIdentity } from 'shared/session/selectors'
 import { userAuthentified } from 'shared/session'
 import { realmInitialized } from 'shared/dao'
@@ -84,7 +84,7 @@ initializeUnity(container)
 
       const voiceChatEnabled = isVoiceChatEnabledFor(globalThis.globalStore.getState(), identity.address)
       configureTaskbarDependentHUD(i, voiceChatEnabled)
-      
+
       i.ConfigureHUDElement(HUDElementID.USERS_AROUND_LIST_HUD, { active: voiceChatEnabled, visible: false })
 
       i.ConfigureHUDElement(HUDElementID.FRIENDS, { active: identity.hasConnectedWeb3, visible: false })
@@ -121,6 +121,14 @@ initializeUnity(container)
     } else {
       i.SetRenderProfile(RenderProfile.DEFAULT)
     }
+
+    foregroundObservable.add((isForeground) => {
+      if (isForeground) {
+        i.ReportFocusOn()
+      } else {
+        i.ReportFocusOff()
+      }
+    })
 
     if (!NO_MOTD) {
       waitForMessageOfTheDay().then((messageOfTheDay) => {

--- a/kernel/packages/entryPoints/unity.ts
+++ b/kernel/packages/entryPoints/unity.ts
@@ -122,7 +122,7 @@ initializeUnity(container)
       i.SetRenderProfile(RenderProfile.DEFAULT)
     }
 
-    if ( isForeground() ) {
+    if (isForeground()) {
       i.ReportFocusOn()
     } else {
       i.ReportFocusOff()

--- a/kernel/packages/entryPoints/unity.ts
+++ b/kernel/packages/entryPoints/unity.ts
@@ -15,7 +15,7 @@ import { StoreContainer } from 'shared/store/rootTypes'
 import { startUnitySceneWorkers } from '../unity-interface/dcl'
 import { initializeUnity } from '../unity-interface/initializer'
 import { HUDElementID, RenderProfile } from 'shared/types'
-import { renderStateObservable, onNextRendererEnabled, foregroundObservable } from 'shared/world/worldState'
+import { renderStateObservable, onNextRendererEnabled, foregroundObservable, isForeground } from 'shared/world/worldState'
 import { getCurrentIdentity } from 'shared/session/selectors'
 import { userAuthentified } from 'shared/session'
 import { realmInitialized } from 'shared/dao'
@@ -121,6 +121,12 @@ initializeUnity(container)
     } else {
       i.SetRenderProfile(RenderProfile.DEFAULT)
     }
+
+    if ( isForeground() ) {
+      i.ReportFocusOn()
+    } else {
+      i.ReportFocusOff()
+    } 
 
     foregroundObservable.add((isForeground) => {
       if (isForeground) {

--- a/kernel/packages/shared/world/worldState.ts
+++ b/kernel/packages/shared/world/worldState.ts
@@ -2,19 +2,32 @@ import { Observable } from '../../decentraland-ecs/src/ecs/Observable'
 import future, { IFuture } from 'fp-future'
 
 let hidden: 'hidden' | 'msHidden' | 'webkitHidden' = 'hidden'
+let visibilityChange: 'visibilitychange' | 'msvisibilitychange' | 'webkitvisibilitychange' = 'visibilitychange'
 
 if (typeof (document as any).hidden !== 'undefined') {
   // Opera 12.10 and Firefox 18 and later support
   hidden = 'hidden'
+  visibilityChange = 'visibilitychange'
 } else if (typeof (document as any).msHidden !== 'undefined') {
   hidden = 'msHidden'
+  visibilityChange = 'msvisibilitychange'
 } else if (typeof (document as any).webkitHidden !== 'undefined') {
   hidden = 'webkitHidden'
+  visibilityChange = 'webkitvisibilitychange'
+}
+
+if (hidden && visibilityChange) {
+  document.addEventListener(visibilityChange, handleVisibilityChange, false)
 }
 
 let rendererEnabled: boolean = false
 
 export const renderStateObservable = new Observable<Readonly<boolean>>()
+export const foregroundObservable = new Observable<Readonly<boolean>>()
+
+function handleVisibilityChange() {
+  foregroundObservable.notifyObservers(isForeground())
+}
 
 renderStateObservable.add((state) => {
   rendererEnabled = state

--- a/kernel/packages/unity-interface/BrowserInterface.ts
+++ b/kernel/packages/unity-interface/BrowserInterface.ts
@@ -23,7 +23,7 @@ import {
 } from 'shared/types'
 import { getSceneWorkerBySceneID } from 'shared/world/parcelSceneManager'
 import { positionObservable } from 'shared/world/positionThings'
-import { isForeground, isRendererEnabled, renderStateObservable } from 'shared/world/worldState'
+import { renderStateObservable } from 'shared/world/worldState'
 import { sendMessage } from 'shared/chat/actions'
 import { updateUserData, updateFriendship } from 'shared/friends/actions'
 import { changeRealm, catalystRealmConnected, candidatesFetched } from 'shared/dao'
@@ -116,10 +116,6 @@ export class BrowserInterface {
   }
 
   public PerformanceReport(samples: string) {
-    if (!isRendererEnabled() || !isForeground()) {
-      return
-    }
-
     const perfReport = getPerformanceInfo(samples)
     queueTrackingEvent('performance report', perfReport)
   }

--- a/kernel/packages/unity-interface/UnityInterface.ts
+++ b/kernel/packages/unity-interface/UnityInterface.ts
@@ -221,6 +221,14 @@ export class UnityInterface {
     this.gameInstance.SendMessage('SceneController', 'DeactivateRendering')
   }
 
+  public ReportFocusOn() {
+    this.gameInstance.SendMessage('Bridges', 'ReportFocusOn')
+  }
+
+  public ReportFocusOff() {
+    this.gameInstance.SendMessage('Bridges', 'ReportFocusOff')
+  }
+
   public UnlockCursor() {
     this.SetCursorState(false)
   }

--- a/unity-client/Assets/Resources/ScriptableObjects/FocusState.asset
+++ b/unity-client/Assets/Resources/ScriptableObjects/FocusState.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bdae4528345114a1fa069b0a59dc53c7, type: 3}
+  m_Name: FocusState
+  m_EditorClassIdentifier: 
+  value: 0

--- a/unity-client/Assets/Resources/ScriptableObjects/FocusState.asset.meta
+++ b/unity-client/Assets/Resources/ScriptableObjects/FocusState.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 458eb0dddfd977d42b38920c1e069e48
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Bridges/Bridges.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Bridges/Bridges.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7246472424111214353}
   - component: {fileID: 6223604258081777967}
+  - component: {fileID: 2356216790431665206}
   m_Layer: 0
   m_Name: Bridges
   m_TagString: Untagged
@@ -41,5 +42,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 897f38afff37940e7a3e3c93e6a8ce99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2356216790431665206
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6401575379531892522}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b69c9f90046aee74f8fa1938727ba6bb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Bridges/FocusStateBridge.meta
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Bridges/FocusStateBridge.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3472d1e5acaa75b48a49e75516dd918d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Bridges/FocusStateBridge/FocusStateBridge.asmdef
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Bridges/FocusStateBridge/FocusStateBridge.asmdef
@@ -1,0 +1,15 @@
+{
+    "name": "FocusStateBridge",
+    "references": [
+        "GUID:4720e174f2805c74bb7aa94cc8bb5bf8"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Bridges/FocusStateBridge/FocusStateBridge.asmdef.meta
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Bridges/FocusStateBridge/FocusStateBridge.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: eb6ad2f6796eb964284137d4b9ab36f2
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Bridges/FocusStateBridge/FocusStateBridge.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Bridges/FocusStateBridge/FocusStateBridge.cs
@@ -4,7 +4,11 @@ using UnityEngine;
 
 public class FocusStateBridge : MonoBehaviour
 {
-    
+    public void Awake()
+    {
+        CommonScriptableObjects.focusState.Set(true);
+    }
+
     public void ReportFocusOn()
     {
         CommonScriptableObjects.focusState.Set(true);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Bridges/FocusStateBridge/FocusStateBridge.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Bridges/FocusStateBridge/FocusStateBridge.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class FocusStateBridge : MonoBehaviour
+{
+    public void ReportFocusOn()
+    {
+        CommonScriptableObjects.focusState.Set(true);
+    }
+
+    public void ReportFocusOff()
+    {
+        CommonScriptableObjects.focusState.Set(false);
+    }
+}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Bridges/FocusStateBridge/FocusStateBridge.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Bridges/FocusStateBridge/FocusStateBridge.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public class FocusStateBridge : MonoBehaviour
 {
+    
     public void ReportFocusOn()
     {
         CommonScriptableObjects.focusState.Set(true);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Bridges/FocusStateBridge/FocusStateBridge.cs.meta
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Bridges/FocusStateBridge/FocusStateBridge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b69c9f90046aee74f8fa1938727ba6bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/ScriptableObject/CommonScriptableObjects.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/ScriptableObject/CommonScriptableObjects.cs
@@ -122,6 +122,10 @@ public static class CommonScriptableObjects
     public static RendererState rendererState => GetOrLoad(ref rendererStateValue, "ScriptableObjects/RendererState");
     private static RendererState rendererStateValue;
 
+    public static BooleanVariable focusState => GetOrLoad(ref focusStateValue, "ScriptableObjects/FocusState");
+    private static BooleanVariable focusStateValue;
+
+
     private static ReadMessagesDictionary lastReadChatMessagesDictionary;
     public static ReadMessagesDictionary lastReadChatMessages => GetOrLoad(ref lastReadChatMessagesDictionary, "ScriptableObjects/LastReadChatMessages");
 

--- a/unity-client/Assets/Scripts/MainScripts/Debugging/PerformanceMetricsController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/Debugging/PerformanceMetricsController.cs
@@ -1,4 +1,3 @@
-using System.Reflection.Emit;
 using System.Text;
 using DCL.Interface;
 using DCL.FPSDisplay;

--- a/unity-client/Assets/Scripts/MainScripts/Debugging/PerformanceMetricsController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/Debugging/PerformanceMetricsController.cs
@@ -1,3 +1,4 @@
+using System.Reflection.Emit;
 using System.Text;
 using DCL.Interface;
 using DCL.FPSDisplay;
@@ -14,6 +15,12 @@ namespace DCL
 
         public void Update()
         {
+            if (!CommonScriptableObjects.focusState.Get())
+                return;
+
+            if (!CommonScriptableObjects.rendererState.Get())
+                return;
+
             var deltaInMs = Time.deltaTime * 1000;
 
             tracker.AddDeltaTime(Time.deltaTime);

--- a/unity-client/Assets/Scripts/MainScripts/Debugging/WSS/WSSController.asmdef
+++ b/unity-client/Assets/Scripts/MainScripts/Debugging/WSS/WSSController.asmdef
@@ -16,7 +16,8 @@
         "GUID:ba9b721ce33233c4da7ff4ef30d25b59",
         "GUID:70aa308435753374584c7061e4b89ef2",
         "GUID:b8662e798190944f4b638fbeb48e84f0",
-        "GUID:086c21f5b0c2a6a488e34b5e5da4eb40"
+        "GUID:086c21f5b0c2a6a488e34b5e5da4eb40",
+        "GUID:4720e174f2805c74bb7aa94cc8bb5bf8"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-client/Assets/Scripts/MainScripts/Debugging/WSS/WSSController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/Debugging/WSS/WSSController.cs
@@ -309,10 +309,10 @@ namespace DCL
                                 renderingController.DeactivateRendering();
                                 break;
                             case "ReportFocusOn":
-                                //
+                                CommonScriptableObjects.focusState.Set(true);
                                 break;
                             case "ReportFocusOff":
-                                //
+                                CommonScriptableObjects.focusState.Set(false);
                                 break;
                             case "ShowNotificationFromJson":
                                 NotificationsController.i.ShowNotificationFromJson(msg.payload);

--- a/unity-client/Assets/Scripts/MainScripts/Debugging/WSS/WSSController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/Debugging/WSS/WSSController.cs
@@ -309,10 +309,10 @@ namespace DCL
                                 renderingController.DeactivateRendering();
                                 break;
                             case "ReportFocusOn":
-                                CommonScriptableObjects.focusState.Set(true);
+                                bridgesGameObject.SendMessage(msg.type, msg.payload);
                                 break;
                             case "ReportFocusOff":
-                                CommonScriptableObjects.focusState.Set(false);
+                                bridgesGameObject.SendMessage(msg.type, msg.payload);
                                 break;
                             case "ShowNotificationFromJson":
                                 NotificationsController.i.ShowNotificationFromJson(msg.payload);

--- a/unity-client/Assets/Scripts/MainScripts/Debugging/WSS/WSSController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/Debugging/WSS/WSSController.cs
@@ -302,11 +302,17 @@ namespace DCL
                             case "RemoveUserProfilesFromCatalog":
                                 UserProfileController.i.RemoveUserProfilesFromCatalog(msg.payload);
                                 break;
+                            case "ActivateRendering":
+                                renderingController.ActivateRendering();
+                                break;
                             case "DeactivateRendering":
                                 renderingController.DeactivateRendering();
                                 break;
-                            case "ActivateRendering":
-                                renderingController.ActivateRendering();
+                            case "ReportFocusOn":
+                                //
+                                break;
+                            case "ReportFocusOff":
+                                //
                                 break;
                             case "ShowNotificationFromJson":
                                 NotificationsController.i.ShowNotificationFromJson(msg.payload);


### PR DESCRIPTION
With the current approach there was the possibility to send invalid FPS metrics within a single batch. 

Any frame metric is invalid when is stacked on these cases:
* Tab out of focus
* Rendering deactivated