### PR TITLE
chore: Meta config URL change

### DIFF
--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -149,6 +149,8 @@ export const HALLOWEEN = location.search.indexOf('HALLOWEEN') !== -1
 
 export const TEST_WEARABLES_OVERRIDE = location.search.indexOf('TEST_WEARABLES') !== -1
 
+const META_CONFIG_URL = qs.META_CONFIG_URL
+
 export namespace commConfigurations {
   export const debug = true
   export const commRadius = 4
@@ -266,10 +268,12 @@ export function getServerConfigurations() {
 
   const synapseUrl = TLDDefault === 'zone' ? `https://matrix.decentraland.zone` : `https://decentraland.modular.im`
 
+  const metaConfigBaseUrl = META_CONFIG_URL || `https://explorer-config.decentraland.${notToday}/configuration.json`
+
   return {
     contentAsBundle: `https://content-assets-as-bundle.decentraland.org`,
     wearablesApi: `https://wearable-api.decentraland.org/v2`,
-    explorerConfiguration: `https://explorer-config.decentraland.${notToday}/configuration.json?t=${new Date().getTime()}`,
+    explorerConfiguration: `${metaConfigBaseUrl}?t=${new Date().getTime()}`,
     synapseUrl,
     fallbackResizeServiceUrl: `${PIN_CATALYST ?? 'https://peer.decentraland.' + notToday}/lambdas/images`,
     avatar: {

--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -268,7 +268,7 @@ export function getServerConfigurations() {
 
   const synapseUrl = TLDDefault === 'zone' ? `https://matrix.decentraland.zone` : `https://decentraland.modular.im`
 
-  const metaConfigBaseUrl = META_CONFIG_URL || `https://explorer-config.decentraland.${notToday}/configuration.json`
+  const metaConfigBaseUrl = META_CONFIG_URL || `https://config.decentraland.${notToday}/explorer.json`
 
   return {
     contentAsBundle: `https://content-assets-as-bundle.decentraland.org`,


### PR DESCRIPTION
Changed meta configuration url to config.decentraland.<env>.

Also, made it configurable using URL, so we can test against custom configurations before releasing them.