### PR TITLE
fix: pbrmaterial missing null check

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Materials/PBRMaterial.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Materials/PBRMaterial.cs
@@ -273,8 +273,11 @@ namespace DCL.Components
                     CoroutineStarter.Start(DCLTexture.FetchTextureComponent(scene, textureComponentId,
                         (fetchedDCLTexture) =>
                         {
-                            material.SetTexture(materialPropertyId, fetchedDCLTexture.texture);
-                            SwitchTextureComponent(cachedDCLTexture, fetchedDCLTexture);
+                            if(material != null)
+                            {
+                                material.SetTexture(materialPropertyId, fetchedDCLTexture.texture);
+                                SwitchTextureComponent(cachedDCLTexture, fetchedDCLTexture);
+                            }
                         }));
                 }
             }


### PR DESCRIPTION
Added missing nullcheck, as the material can be destroyed while the texture is being downloaded
