### PR TITLE
[ProfileHUD] Fix LogOut flow

### DIFF
--- a/kernel/packages/shared/session/index.ts
+++ b/kernel/packages/shared/session/index.ts
@@ -92,10 +92,13 @@ export class Session {
     sendToMordor()
     disconnect()
     removeStoredSession(getIdentity()?.address)
+    removeUrlParam('position')
+    removeUrlParam('show_wallet')
     window.location.reload()
   }
 
   async redirectToSignUp() {
+    removeUrlParam('position')
     window.location.search += '&show_wallet=1'
   }
 
@@ -123,4 +126,19 @@ export async function userAuthentified(): Promise<void> {
       }
     })
   })
+}
+
+function removeUrlParam(paramToRemove: string) {
+  let url = window.location.href.split('?')[0] + '?'
+  let pageURL = decodeURIComponent(window.location.search.substring(1))
+  let urlVariables = pageURL.split('&')
+  let parameterName
+
+  for (let i = 0; i < urlVariables.length; i++) {
+    parameterName = urlVariables[i].split('=')
+    if (parameterName[0] !== paramToRemove) {
+      url = url + parameterName[0] + '=' + parameterName[1] + '&'
+    }
+  }
+  window.history.replaceState({}, document.title, url.substring(0, url.length - 1))
 }

--- a/kernel/packages/shared/session/index.ts
+++ b/kernel/packages/shared/session/index.ts
@@ -98,7 +98,6 @@ export class Session {
   }
 
   async redirectToSignUp() {
-    removeUrlParam('position')
     window.location.search += '&show_wallet=1'
   }
 

--- a/kernel/packages/shared/session/index.ts
+++ b/kernel/packages/shared/session/index.ts
@@ -128,16 +128,7 @@ export async function userAuthentified(): Promise<void> {
 }
 
 function removeUrlParam(paramToRemove: string) {
-  let url = window.location.href.split('?')[0] + '?'
-  let pageURL = decodeURIComponent(window.location.search.substring(1))
-  let urlVariables = pageURL.split('&')
-  let parameterName
-
-  for (let i = 0; i < urlVariables.length; i++) {
-    parameterName = urlVariables[i].split('=')
-    if (parameterName[0] !== paramToRemove) {
-      url = url + parameterName[0] + '=' + parameterName[1] + '&'
-    }
-  }
-  window.history.replaceState({}, document.title, url.substring(0, url.length - 1))
+  let params = new URLSearchParams(window.location.search)
+  params.delete(paramToRemove)
+  window.history.replaceState({}, document.title, '?' + params.toString())
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/Resources/ProfileHUD.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/Resources/ProfileHUD.prefab
@@ -3145,7 +3145,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Sign In-Up
+  m_text: Sign In
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
   m_sharedMaterial: {fileID: -6892909264025736228, guid: 26b03903800224f718b64e9afbc91b61,
@@ -3215,7 +3215,7 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 6280105334476485985}
-    characterCount: 10
+    characterCount: 7
     spriteCount: 0
     spaceCount: 1
     wordCount: 2
@@ -5750,7 +5750,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 118.99997, y: -54}
+  m_AnchoredPosition: {x: 118.99997, y: -211}
   m_SizeDelta: {x: 237.99994, y: 124}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &4694356544223813351
@@ -6963,7 +6963,7 @@ GameObject:
   - component: {fileID: 2139349118484140314}
   - component: {fileID: 3548025402700250293}
   m_Layer: 5
-  m_Name: SignUpTitle
+  m_Name: SignInTitle
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -6986,7 +6986,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 118.99997, y: -30}
-  m_SizeDelta: {x: 230, y: 60}
+  m_SizeDelta: {x: 200, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2139349118484140314
 CanvasRenderer:
@@ -7015,9 +7015,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Create an account to
-
-    fully experience Decentraland'
+  m_text: Sign In or create an account to fully experience Decentraland
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 26b03903800224f718b64e9afbc91b61, type: 2}
   m_sharedMaterial: {fileID: 2100000, guid: cbef7abfd5b4443bf9d5c298a464b5a6, type: 2}
@@ -7086,10 +7084,10 @@ MonoBehaviour:
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
     textComponent: {fileID: 3548025402700250293}
-    characterCount: 50
+    characterCount: 61
     spriteCount: 0
-    spaceCount: 6
-    wordCount: 7
+    spaceCount: 9
+    wordCount: 10
     linkCount: 0
     lineCount: 2
     pageCount: 1


### PR DESCRIPTION
This PR contemplates these **2 use cases**:

- When a **GUEST USER** clicks on `ProfileHUD` -> `Sign In` button, the app should redirect him to the landing page, adding the url param `show_wallet=1` (this will make the wallet selector be opened automatically).
- When a **LOGGED USER** clicks on `ProfileHUD` -> `LogOut` button, the app should redirect him to the landing page, removing these 2 url params: `show_wallet=1` and `position`.