### PR TITLE
refactor: small changes to stateful workers

### DIFF
--- a/kernel/packages/scene-system/stateful-scene/RendererStatefulActor.ts
+++ b/kernel/packages/scene-system/stateful-scene/RendererStatefulActor.ts
@@ -5,7 +5,7 @@ import { Component, ComponentData, ComponentId, EntityId, StatefulActor } from "
 import { EventSubscriber } from "decentraland-rpc";
 import { generatePBObjectJSON } from "scene-system/sdk/Utils";
 
-export class RendererActor extends StatefulActor {
+export class RendererStatefulActor extends StatefulActor {
 
   private readonly eventSubscriber: EventSubscriber
   private disposableComponents: number = 0;

--- a/kernel/packages/scene-system/stateful-scene/SceneStateDefinition.ts
+++ b/kernel/packages/scene-system/stateful-scene/SceneStateDefinition.ts
@@ -1,4 +1,3 @@
-import { CLASS_ID } from "decentraland-ecs/src";
 import { Component, ComponentData, ComponentId, EntityId, StateContainer } from "./types";
 
 export class SceneStateDefinition implements StateContainer {
@@ -30,55 +29,13 @@ export class SceneStateDefinition implements StateContainer {
     }
   }
 
-  toStorableFormat(): any {
-    const entities = []
-    for (const [entityId, entityComponents] of this.entities.entries()) {
-      const components = []
-      for (const [componentId, componentData] of entityComponents.entries()) {
-        components.push({ type: idToHumanReadableType(componentId), value: componentData })
-      }
-      entities.push({ id: entityId, components })
-    }
-    return { entities }
+  /**
+   * Returns a copy of the state
+   */
+  getState(): Map<EntityId, Map<ComponentId, ComponentData>> {
+    const newEntries: [EntityId, Map<ComponentId, ComponentData>][] = Array.from(this.entities.entries())
+      .map(([entityId, components]) => [entityId, new Map(components)])
+    return new Map(newEntries)
   }
 
-  static fromStorableFormat(data: any): SceneStateDefinition {
-    const sceneState = new SceneStateDefinition()
-    for (const entity of data.entities) {
-      const id: EntityId = entity.id
-      const components: Component[] | undefined = entity.components
-        ?.map((component: any) => ({
-          id: humanReadableTypeToId(component.type),
-          data: component.value,
-        }))
-      sceneState.addEntity(id, components)
-    }
-    return sceneState
-  }
-}
-
-
-/**
- * We are converting from numeric ids to a more human readable format. It might make sense to change this in the future,
- * but until this feature is stable enough, it's better to store it in a way that it is easy to debug.
- */
-
-const HUMAN_READABLE_TO_ID: Map<string, ComponentId> = new Map([['Transform', CLASS_ID.TRANSFORM], ['GLTFShape', CLASS_ID.GLTF_SHAPE]])
-
-function idToHumanReadableType(id: ComponentId): string {
-  const type = Array.from(HUMAN_READABLE_TO_ID.entries())
-    .filter(([, componentId]) => componentId === id)
-    .map(([type]) => type)[0]
-  if (!type) {
-    throw new Error(`Unknown id ${id}`)
-  }
-  return type
-}
-
-function humanReadableTypeToId(type: string): ComponentId {
-  const componentId = HUMAN_READABLE_TO_ID.get(type)
-  if (!componentId) {
-    throw new Error(`Unknown type ${type}`)
-  }
-  return componentId
 }

--- a/kernel/packages/scene-system/stateful-scene/SceneStateDefinitionSerializer.ts
+++ b/kernel/packages/scene-system/stateful-scene/SceneStateDefinitionSerializer.ts
@@ -1,0 +1,58 @@
+import { CLASS_ID } from "decentraland-ecs/src";
+import { SceneStateDefinition } from "./SceneStateDefinition";
+import { Component, ComponentId, EntityId } from "./types";
+
+export class SceneStateDefinitionSerializer {
+
+  static toStorableFormat(state: SceneStateDefinition): any {
+    const entities = []
+    for (const [entityId, entityComponents] of state.getState().entries()) {
+      const components = []
+      for (const [componentId, componentData] of entityComponents.entries()) {
+        components.push({ type: idToHumanReadableType(componentId), value: componentData })
+      }
+      entities.push({ id: entityId, components })
+    }
+    return { entities }
+  }
+
+  static fromStorableFormat(data: any): SceneStateDefinition {
+    const sceneState = new SceneStateDefinition()
+    for (const entity of data.entities) {
+      const id: EntityId = entity.id
+      const components: Component[] | undefined = entity.components
+        ?.map((component: any) => ({
+          id: humanReadableTypeToId(component.type),
+          data: component.value,
+        }))
+      sceneState.addEntity(id, components)
+    }
+    return sceneState
+  }
+}
+
+
+/**
+ * We are converting from numeric ids to a more human readable format. It might make sense to change this in the future,
+ * but until this feature is stable enough, it's better to store it in a way that it is easy to debug.
+ */
+
+const HUMAN_READABLE_TO_ID: Map<string, ComponentId> = new Map([['Transform', CLASS_ID.TRANSFORM], ['GLTFShape', CLASS_ID.GLTF_SHAPE]])
+
+function idToHumanReadableType(id: ComponentId): string {
+  const type = Array.from(HUMAN_READABLE_TO_ID.entries())
+    .filter(([, componentId]) => componentId === id)
+    .map(([type]) => type)[0]
+  if (!type) {
+    throw new Error(`Unknown id ${id}`)
+  }
+  return type
+}
+
+function humanReadableTypeToId(type: string): ComponentId {
+  const componentId = HUMAN_READABLE_TO_ID.get(type)
+  if (!componentId) {
+    throw new Error(`Unknown type ${type}`)
+  }
+  return componentId
+}

--- a/kernel/packages/unity-interface/BrowserInterface.ts
+++ b/kernel/packages/unity-interface/BrowserInterface.ts
@@ -212,13 +212,13 @@ export class BrowserInterface {
         }
         break
       }
-      case 'StartStateMode': {
+      case 'StartStatefulMode': {
         const { sceneId } = payload
         const parcelScene = this.resetScene(sceneId)
         setNewParcelScene(sceneId, new StatefulWorker(parcelScene))
         break
       }
-      case 'StopStateMode': {
+      case 'StopStatefulMode': {
         const { sceneId } = payload
         const parcelScene = this.resetScene(sceneId)
         setNewParcelScene(sceneId, new SceneSystemWorker(parcelScene))


### PR DESCRIPTION
We are tackling the comments in https://github.com/decentraland/explorer/pull/1519

We are making the following changes:
1. We are renaming `RendererActor` to `RendererStatefulActor`
1. We created the concept of `SceneStateDefinitionSerializer`. This entity will be in charge of translating from human readable format to a more code friendly format
1. We renamed the messages `StartStateMode`/`StopStateMode ` to `StartStatefulMode`/`StopStatefulMode`