### PR TITLE
fix: Don't use a hardcoded catalyst when signing up

### DIFF
--- a/kernel/package-lock.json
+++ b/kernel/package-lock.json
@@ -2743,9 +2743,9 @@
       }
     },
     "decentraland-renderer": {
-      "version": "1.8.46087",
-      "resolved": "https://registry.npmjs.org/decentraland-renderer/-/decentraland-renderer-1.8.46087.tgz",
-      "integrity": "sha512-4WaAMg2ao4LZUcIEngpMbCjopBdZ76C4oTIxsT+EiMgPEBG3orvWswVII99K3mmn0PEaagQVczJ0nBUSP1xAbQ=="
+      "version": "1.8.47619",
+      "resolved": "https://registry.npmjs.org/decentraland-renderer/-/decentraland-renderer-1.8.47619.tgz",
+      "integrity": "sha512-u+GAkmPphMwZRKseLtGY/ZMimw2dwOdG9h6dWutLTVn7QlH6eHvnnuP2Ilz2ClI0YBb4wDCOlP5Ktwyp2MoTzQ=="
     },
     "decentraland-rpc": {
       "version": "3.1.8",

--- a/kernel/package.json
+++ b/kernel/package.json
@@ -101,7 +101,7 @@
     "dcl-crypto": "^2.2.0",
     "dcl-social-client": "^1.3.10",
     "decentraland-katalyst-peer": "0.2.17",
-    "decentraland-renderer": "^1.8.46087",
+    "decentraland-renderer": "^1.8.47619",
     "decentraland-rpc": "^3.1.8",
     "devtools-protocol": "0.0.615714",
     "eth-connect": "^4.0.1",

--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -262,6 +262,23 @@ export function getWearablesSafeURL() {
   return 'https://content.decentraland.org'
 }
 
+export function getNetworkFromTLD(tld: string = getTLD()): ETHEREUM_NETWORK | null {
+  if (tld === 'zone') {
+    return ETHEREUM_NETWORK.ROPSTEN
+  }
+
+  if (tld === 'today' || tld === 'org') {
+    return ETHEREUM_NETWORK.MAINNET
+  }
+
+  // if localhost
+  return null
+}
+
+export function getNetworkFromDefaultTLD(): ETHEREUM_NETWORK {
+  return getNetworkFromTLD(getDefaultTLD())!
+}
+
 export function getServerConfigurations() {
   const TLDDefault = getDefaultTLD()
   const notToday = TLDDefault === 'today' ? 'org' : TLDDefault

--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -373,3 +373,7 @@ export const genericAvatarSnapshots: Record<string, string> = {
   face256: '/images/avatar_snapshot_default256.png',
   face128: '/images/avatar_snapshot_default128.png'
 }
+
+export function getCatalystNodesDefaultURL() {
+  return `https://peer.decentraland.${getDefaultTLD()}/lambdas/contracts/servers`
+}

--- a/kernel/packages/shared/dao/index.ts
+++ b/kernel/packages/shared/dao/index.ts
@@ -103,7 +103,7 @@ async function fetchCatalystNodes(endpoint: string | undefined) {
     }
   }
 
-  return await fetchCatalystNodesFromDAO()
+  return fetchCatalystNodesFromDAO()
 }
 
 export async function fetchCatalystRealms(nodesEndpoint: string | undefined): Promise<Candidate[]> {

--- a/kernel/packages/shared/dao/index.ts
+++ b/kernel/packages/shared/dao/index.ts
@@ -10,7 +10,7 @@ import {
   getAllCatalystCandidates,
   areCandidatesFetched
 } from './selectors'
-import { fetchCatalystNodes } from 'shared/web3'
+import { fetchCatalystNodesFromDAO } from 'shared/web3'
 import { setCatalystRealm, setCatalystCandidates } from './actions'
 import { deepEqual } from 'atomicHelpers/deepEqual'
 import { worldToGrid } from 'atomicHelpers/parcelScenePositions'
@@ -88,8 +88,26 @@ export function ping(url: string, timeoutMs: number = 5000): Promise<PingResult>
   return result
 }
 
-export async function fecthCatalystRealms(): Promise<Candidate[]> {
-  const nodes: CatalystNode[] = PIN_CATALYST ? [{ domain: PIN_CATALYST }] : await fetchCatalystNodes()
+async function fetchCatalystNodes(endpoint: string | undefined) {
+  if (endpoint) {
+    try {
+      const response = await fetch(endpoint)
+      if (response.ok) {
+        const nodes = await response.json()
+        return nodes.map((node: any) => ({ ...node, domain: node.address }))
+      } else {
+        throw new Error('Response was not OK. Status was: ' + response.statusText)
+      }
+    } catch (e) {
+      defaultLogger.warn(`Tried to fetch catalysts from ${endpoint} but failed. Falling back to DAO contract`, e)
+    }
+  }
+
+  return await fetchCatalystNodesFromDAO()
+}
+
+export async function fecthCatalystRealms(nodesEndpoint: string | undefined): Promise<Candidate[]> {
+  const nodes: CatalystNode[] = PIN_CATALYST ? [{ domain: PIN_CATALYST }] : await fetchCatalystNodes(nodesEndpoint)
   if (nodes.length === 0) {
     throw new Error('no nodes are available in the DAO for the current network')
   }

--- a/kernel/packages/shared/dao/index.ts
+++ b/kernel/packages/shared/dao/index.ts
@@ -106,7 +106,7 @@ async function fetchCatalystNodes(endpoint: string | undefined) {
   return await fetchCatalystNodesFromDAO()
 }
 
-export async function fecthCatalystRealms(nodesEndpoint: string | undefined): Promise<Candidate[]> {
+export async function fetchCatalystRealms(nodesEndpoint: string | undefined): Promise<Candidate[]> {
   const nodes: CatalystNode[] = PIN_CATALYST ? [{ domain: PIN_CATALYST }] : await fetchCatalystNodes(nodesEndpoint)
   if (nodes.length === 0) {
     throw new Error('no nodes are available in the DAO for the current network')

--- a/kernel/packages/shared/dao/sagas.ts
+++ b/kernel/packages/shared/dao/sagas.ts
@@ -1,5 +1,4 @@
 import {
-  WEB3_INITIALIZED,
   catalystRealmInitialized,
   initCatalystRealm,
   setCatalystCandidates,
@@ -35,57 +34,17 @@ import { saveToLocalStorage, getFromLocalStorage } from '../../atomicHelpers/loc
 import defaultLogger from '../logger'
 import { ReportFatalError } from 'shared/loading/ReportFatalError'
 import { CATALYST_COULD_NOT_LOAD } from 'shared/loading/types'
+import { META_CONFIGURATION_INITIALIZED } from 'shared/meta/actions'
 
 const CACHE_KEY = 'realm'
 const CATALYST_CANDIDATES_KEY = CACHE_KEY + '-' + SET_CATALYST_CANDIDATES
 const CACHE_TLD_KEY = 'tld'
 
 export function* daoSaga(): any {
-  yield call(loadDefaultCatalystRealms)
-  yield takeEvery(WEB3_INITIALIZED, loadCatalystRealms)
+  yield takeEvery(META_CONFIGURATION_INITIALIZED, loadCatalystRealms)
 
   yield takeEvery([INIT_CATALYST_REALM, SET_CATALYST_REALM], cacheCatalystRealm)
   yield takeEvery([SET_CATALYST_CANDIDATES, SET_ADDED_CATALYST_CANDIDATES], cacheCatalystCandidates)
-}
-
-function* loadDefaultCatalystRealms() {
-  yield call(waitForMetaConfigurationInitialization)
-  if (WORLD_EXPLORER) {
-    let cachedRealm: Realm | null = getFromLocalStorage(CACHE_KEY)
-    if (cachedRealm && !(yield checkValidRealm(cachedRealm))) {
-      cachedRealm = null
-    }
-    const tld = getDefaultTLD().toLowerCase() !== 'org' ? 'zone' : 'org'
-    const realm: Realm = cachedRealm || {
-      domain: `https://peer.decentraland.${tld}`,
-      catalystName: 'fenrir',
-      layer: 'blue',
-      lighthouseVersion: '0.2'
-    }
-    // set default realm domain as whiteList
-    yield put(
-      setContentWhitelist([
-        {
-          domain: realm.domain,
-          catalystName: realm.catalystName,
-          elapsed: 0,
-          status: 0,
-          layer: {
-            name: realm.layer,
-            usersCount: 0,
-            maxUsers: 100,
-            usersParcels: []
-          },
-          score: -50,
-          lighthouseVersion: realm.lighthouseVersion
-        }
-      ])
-    )
-    yield put(initCatalystRealm(realm))
-  } else {
-    yield initLocalCatalyst()
-  }
-  yield put(catalystRealmInitialized())
 }
 
 /**

--- a/kernel/packages/shared/dao/sagas.ts
+++ b/kernel/packages/shared/dao/sagas.ts
@@ -28,7 +28,7 @@ import {
   ping,
   commsStatusUrl
 } from '.'
-import { getAddedServers, getContentWhitelist } from 'shared/meta/selectors'
+import { getAddedServers, getCatalystNodesEndpoint, getContentWhitelist } from 'shared/meta/selectors'
 import { getAllCatalystCandidates, isRealmInitialized } from './selectors'
 import { saveToLocalStorage, getFromLocalStorage } from '../../atomicHelpers/localStorage'
 import defaultLogger from '../logger'
@@ -141,7 +141,8 @@ function getConfiguredRealm(candidates: Candidate[]) {
 
 function* initializeCatalystCandidates() {
   yield put(catalystRealmsScanRequested())
-  const candidates: Candidate[] = yield call(fecthCatalystRealms)
+  const catalystsNodesEndpointURL = yield select(getCatalystNodesEndpoint)
+  const candidates: Candidate[] = yield call(fecthCatalystRealms, catalystsNodesEndpointURL)
 
   yield put(setCatalystCandidates(candidates))
 

--- a/kernel/packages/shared/dao/sagas.ts
+++ b/kernel/packages/shared/dao/sagas.ts
@@ -21,7 +21,7 @@ import { WORLD_EXPLORER, REALM, getDefaultTLD, PIN_CATALYST } from 'config'
 import { waitForMetaConfigurationInitialization } from '../meta/sagas'
 import { Candidate, Realm, ServerConnectionStatus } from './types'
 import {
-  fecthCatalystRealms,
+  fetchCatalystRealms,
   fetchCatalystStatuses,
   pickCatalystRealm,
   getRealmFromString,
@@ -142,7 +142,7 @@ function getConfiguredRealm(candidates: Candidate[]) {
 function* initializeCatalystCandidates() {
   yield put(catalystRealmsScanRequested())
   const catalystsNodesEndpointURL = yield select(getCatalystNodesEndpoint)
-  const candidates: Candidate[] = yield call(fecthCatalystRealms, catalystsNodesEndpointURL)
+  const candidates: Candidate[] = yield call(fetchCatalystRealms, catalystsNodesEndpointURL)
 
   yield put(setCatalystCandidates(candidates))
 

--- a/kernel/packages/shared/ethereum/Web3Connector.ts
+++ b/kernel/packages/shared/ethereum/Web3Connector.ts
@@ -1,7 +1,6 @@
 import { Eth } from 'web3x/eth'
-import { LegacyProviderAdapter } from 'web3x/providers'
-import { ETHEREUM_NETWORK, ethereumConfigurations, getTLD, WALLET_API_KEYS } from '../../config'
-import { WebSocketProvider } from 'eth-connect'
+import { LegacyProviderAdapter, WebsocketProvider } from 'web3x/providers'
+import { ETHEREUM_NETWORK, ethereumConfigurations, WALLET_API_KEYS, getNetworkFromDefaultTLD } from '../../config'
 import { ConnectorFactory } from './connector/ConnectorFactory'
 import { ProviderType } from './ProviderType'
 import { ConnectorInterface } from './connector/ConnectorInterface'
@@ -13,13 +12,13 @@ export class Web3Connector {
   private readonly network: ETHEREUM_NETWORK
 
   constructor() {
-    this.network = getTLD() === 'zone' ? ETHEREUM_NETWORK.ROPSTEN : ETHEREUM_NETWORK.MAINNET
+    this.network = getNetworkFromDefaultTLD()
     this.factory = new ConnectorFactory(WALLET_API_KEYS.get(this.network)!)
   }
 
-  static createWebSocketProvider() {
-    const network = getTLD() === 'zone' ? ETHEREUM_NETWORK.ROPSTEN : ETHEREUM_NETWORK.MAINNET
-    return new WebSocketProvider(ethereumConfigurations[network].wss)
+  static createWeb3xWebsocketProvider() {
+    const network = getNetworkFromDefaultTLD()
+    return new WebsocketProvider(ethereumConfigurations[network].wss)
   }
 
   getType() {

--- a/kernel/packages/shared/ethereum/provider.ts
+++ b/kernel/packages/shared/ethereum/provider.ts
@@ -5,6 +5,7 @@ import { Account } from 'web3x/account'
 import { Eth } from 'web3x/eth'
 import { Web3Connector } from './Web3Connector'
 import { ProviderType } from './ProviderType'
+import { LegacyProviderAdapter } from 'web3x/providers'
 
 let web3Connector: Web3Connector
 export const providerFuture = future()
@@ -15,6 +16,18 @@ export const loginCompleted = future<void>()
 
 export function createEth(provider: any = null): Eth {
   return web3Connector.createEth(provider)!
+}
+
+// This function creates a Web3x eth object without the need of having initiated sign in / sign up. Used when requesting the catalysts
+export function createEthWhenNotConnectedToWeb3(): Eth {
+  const ethereum = (window as any).ethereum
+  if (ethereum) {
+    // If we have a web3 enabled browser, we can use that
+    return new Eth(new LegacyProviderAdapter((window as any).ethereum))
+  } else {
+    // If not, we use infura
+    return new Eth(Web3Connector.createWeb3xWebsocketProvider())
+  }
 }
 
 export function createWeb3Connector(): Web3Connector {

--- a/kernel/packages/shared/meta/selectors.ts
+++ b/kernel/packages/shared/meta/selectors.ts
@@ -1,6 +1,6 @@
 import { CommsConfig, MessageOfTheDayConfig, RootMetaState } from './types'
 import { Vector2Component } from 'atomicHelpers/landHelpers'
-import { VOICE_CHAT_DISABLED_FLAG, VOICE_CHAT_ENABLED_FLAG } from 'config'
+import { getCatalystNodesDefaultURL, VOICE_CHAT_DISABLED_FLAG, VOICE_CHAT_ENABLED_FLAG } from 'config'
 
 export const getAddedServers = (store: RootMetaState): string[] => {
   const { config } = store.meta
@@ -40,3 +40,6 @@ export const getVoiceChatAllowlist = (store: RootMetaState): string[] => getComm
 
 export const isVoiceChatEnabledFor = (store: RootMetaState, userId: string): boolean =>
   isVoiceChatEnabled(store) || (getVoiceChatAllowlist(store).includes(userId) && !VOICE_CHAT_DISABLED_FLAG)
+
+export const getCatalystNodesEndpoint = (store: RootMetaState): string =>
+  store.meta.config.servers?.catalystsNodesEndpoint ?? getCatalystNodesDefaultURL()

--- a/kernel/packages/shared/meta/types.ts
+++ b/kernel/packages/shared/meta/types.ts
@@ -14,6 +14,7 @@ export type MetaConfiguration = {
     added: string[]
     denied: string[]
     contentWhitelist: string[]
+    catalystsNodesEndpoint?: string
   }
   world: WorldConfig
   comms: CommsConfig

--- a/kernel/packages/shared/session/sagas.ts
+++ b/kernel/packages/shared/session/sagas.ts
@@ -4,7 +4,7 @@ import { Personal } from 'web3x/personal/personal'
 import { Account } from 'web3x/account'
 import { Authenticator } from 'dcl-crypto'
 
-import { ENABLE_WEB3, ETHEREUM_NETWORK, getTLD, PREVIEW, setNetwork, WORLD_EXPLORER } from 'config'
+import { ENABLE_WEB3, ETHEREUM_NETWORK, getNetworkFromTLD, getTLD, PREVIEW, setNetwork, WORLD_EXPLORER } from 'config'
 
 import { createLogger } from 'shared/logger'
 import { initializeReferral, referUser } from 'shared/referral'
@@ -28,7 +28,7 @@ import {
   setTLDError
 } from 'shared/loading/types'
 import { identifyEmail, identifyUser, queueTrackingEvent } from 'shared/analytics'
-import { getAppNetwork, getNetworkFromTLD } from 'shared/web3'
+import { getAppNetwork } from 'shared/web3'
 import { getNetwork } from 'shared/ethereum/EthereumService'
 
 import { getFromLocalStorage, saveToLocalStorage } from 'atomicHelpers/localStorage'

--- a/kernel/packages/shared/web3.ts
+++ b/kernel/packages/shared/web3.ts
@@ -1,14 +1,14 @@
-import { ethereumConfigurations } from 'config'
+import { ethereumConfigurations, getNetworkFromDefaultTLD, setNetwork } from 'config'
 import { Address } from 'web3x/address'
 import { Eth } from 'web3x/eth'
 import { WebsocketProvider } from 'web3x/providers'
-import { ETHEREUM_NETWORK, getTLD } from '../config'
+import { ETHEREUM_NETWORK } from '../config'
 import { decentralandConfigurations } from '../config/index'
 import { queueTrackingEvent } from './analytics'
 import { Catalyst } from './dao/contracts/Catalyst'
 import { ERC721 } from './dao/contracts/ERC721'
 import { getNetwork, getUserAccount } from './ethereum/EthereumService'
-import { awaitWeb3Approval, createEth } from './ethereum/provider'
+import { awaitWeb3Approval, createEth, createEthWhenNotConnectedToWeb3 } from './ethereum/provider'
 import { defaultLogger } from './logger'
 import { CatalystNode, GraphResponse } from './types'
 import { retry } from '../atomicHelpers/retry'
@@ -20,20 +20,6 @@ async function getAddress(): Promise<string | undefined> {
   } catch (e) {
     defaultLogger.info(e)
   }
-}
-
-export function getNetworkFromTLD(): ETHEREUM_NETWORK | null {
-  const tld = getTLD()
-  if (tld === 'zone') {
-    return ETHEREUM_NETWORK.ROPSTEN
-  }
-
-  if (tld === 'today' || tld === 'org') {
-    return ETHEREUM_NETWORK.MAINNET
-  }
-
-  // if localhost
-  return null
 }
 
 export async function getAppNetwork(): Promise<ETHEREUM_NETWORK> {
@@ -72,15 +58,12 @@ export async function hasClaimedName(address: string) {
 }
 
 export async function fetchCatalystNodes(): Promise<CatalystNode[]> {
-  const contractAddress = Address.fromString(decentralandConfigurations.dao)
-  let eth = createEth()
-
-  if (!eth) {
-    const net = await getAppNetwork()
-    const provider = new WebsocketProvider(ethereumConfigurations[net].wss)
-
-    eth = createEth(provider)
+  if (!decentralandConfigurations.dao) {
+    setNetwork(getNetworkFromDefaultTLD())
   }
+
+  const contractAddress = Address.fromString(decentralandConfigurations.dao)
+  const eth = createEthWhenNotConnectedToWeb3()
 
   const contract = new Catalyst(eth, contractAddress)
 

--- a/kernel/packages/shared/web3.ts
+++ b/kernel/packages/shared/web3.ts
@@ -57,7 +57,7 @@ export async function hasClaimedName(address: string) {
   }
 }
 
-export async function fetchCatalystNodes(): Promise<CatalystNode[]> {
+export async function fetchCatalystNodesFromDAO(): Promise<CatalystNode[]> {
   if (!decentralandConfigurations.dao) {
     await setNetwork(getNetworkFromDefaultTLD())
   }

--- a/kernel/packages/shared/web3.ts
+++ b/kernel/packages/shared/web3.ts
@@ -59,7 +59,7 @@ export async function hasClaimedName(address: string) {
 
 export async function fetchCatalystNodes(): Promise<CatalystNode[]> {
   if (!decentralandConfigurations.dao) {
-    setNetwork(getNetworkFromDefaultTLD())
+    await setNetwork(getNetworkFromDefaultTLD())
   }
 
   const contractAddress = Address.fromString(decentralandConfigurations.dao)


### PR DESCRIPTION
Since there is a need for sign up to have a catalyst configured in order to function, a hardcoded catalyst was implemented.

But this is not necessary as we don't need to login to fetch the catalysts from the DAO.

Also: Added an http request to avoid the need to use the catalyst contract directly. This falls back to DAO if there is an issue.