### PR TITLE
fix: website pre-start.js symlink windows issue

### DIFF
--- a/website/scripts/pre-start.js
+++ b/website/scripts/pre-start.js
@@ -13,22 +13,27 @@ let files = [
 ];
 
 console.log("\nREFRESH KERNEL FILES\n");
-const kernelPath = path.resolve("../kernel");
+const kernelPath = path.resolve( __dirname + "/../../kernel");
 files
   .map((p) => ({
-    dest: path.resolve(p.dest),
+    dest: path.resolve( __dirname + "/../" + p.dest),
     origin: path.resolve(kernelPath + "/" + p.origin),
   }))
   .map((p) => {
     if (fs.existsSync(p.dest)) {
       console.log("removing old version of ", path.basename(p.dest));
-      fs.unlinkSync(p.dest);
+      const lstat = fs.lstatSync(p.dest)
+      if (lstat.isDirectory()) {
+        fs.rmdirSync(p.dest, { recursive:true } );
+      } else {
+        fs.unlinkSync(p.dest);
+      }
     }
     return p;
   })
-  .map(({ origin, dest }) => {
+  .map(({ origin, dest, type }) => {
     console.log(`linking ${origin} -> ${dest}`);
-    fs.symlinkSync(origin, dest);
+    fs.symlinkSync(origin, dest, 'junction');
   });
 
 console.log("\nREPLACE KERNEL VERSION\n");


### PR DESCRIPTION
Symlinks were not being correctly generated in windows. This PR fixes this.

- fix: add 'junction' type to symlinkSync to enable creating symlinks without admin privileges
- fix: in some cases, directories can be found instead of symlinks and a ENOENT error is thrown
- fix: depending on the path you are standing when running the script, the calculated kernel path can be wrong.

Known issue: when using windows 10 and linux subsystem, the symlinks will appear as empty files from windows, however they seem to work fine from the linux console context. `¯\_(ツ)_/¯`