### PR TITLE
feat: adding support for NFTShape & names in stateful scenes

### DIFF
--- a/kernel/packages/decentraland-ecs/src/decentraland/Components.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Components.ts
@@ -64,7 +64,11 @@ export enum CLASS_ID {
   AUDIO_STREAM = 202,
   GIZMOS = 203,
   SMART_ITEM = 204,
-  AVATAR_MODIFIER_AREA = 205
+  AVATAR_MODIFIER_AREA = 205,
+
+
+  // For state sync only
+  NAME = 300
 }
 
 export enum AvatarModifiers {

--- a/kernel/packages/decentraland-ecs/src/decentraland/Components.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Components.ts
@@ -66,7 +66,6 @@ export enum CLASS_ID {
   SMART_ITEM = 204,
   AVATAR_MODIFIER_AREA = 205,
 
-
   // For state sync only
   NAME = 300
 }

--- a/kernel/packages/scene-system/stateful-scene/SceneStateDefinition.ts
+++ b/kernel/packages/scene-system/stateful-scene/SceneStateDefinition.ts
@@ -5,7 +5,7 @@ export class SceneStateDefinition implements StateContainer {
   private readonly entities: Map<EntityId, Map<ComponentId, ComponentData>> = new Map()
 
   addEntity(entityId: EntityId, components?: Component[]): void {
-    const componentMap: Map<ComponentId, ComponentData> = new Map((components ?? []).map(({ id, data }) => [id, data]))
+    const componentMap: Map<ComponentId, ComponentData> = new Map((components ?? []).map(({ componentId, data }) => [componentId, data]))
     this.entities.set(entityId, componentMap)
   }
 
@@ -24,7 +24,7 @@ export class SceneStateDefinition implements StateContainer {
   sendStateTo(container: StateContainer) {
     for (const [entityId, components] of this.entities.entries()) {
       const mappedComponents = Array.from(components.entries())
-        .map(([id, data]) => ({ id, data }))
+        .map(([componentId, data]) => ({ componentId, data }))
       container.addEntity(entityId, mappedComponents)
     }
   }

--- a/kernel/packages/scene-system/stateful-scene/SceneStateDefinitionSerializer.ts
+++ b/kernel/packages/scene-system/stateful-scene/SceneStateDefinitionSerializer.ts
@@ -37,7 +37,12 @@ export class SceneStateDefinitionSerializer {
  * but until this feature is stable enough, it's better to store it in a way that it is easy to debug.
  */
 
-const HUMAN_READABLE_TO_ID: Map<string, ComponentId> = new Map([['Transform', CLASS_ID.TRANSFORM], ['GLTFShape', CLASS_ID.GLTF_SHAPE]])
+const HUMAN_READABLE_TO_ID: Map<string, ComponentId> = new Map([
+  ['Transform', CLASS_ID.TRANSFORM],
+  ['GLTFShape', CLASS_ID.GLTF_SHAPE],
+  ['NFTShape', CLASS_ID.NFT_SHAPE],
+  ['Name', CLASS_ID.NAME]
+])
 
 function idToHumanReadableType(id: ComponentId): string {
   const type = Array.from(HUMAN_READABLE_TO_ID.entries())

--- a/kernel/packages/scene-system/stateful-scene/types.ts
+++ b/kernel/packages/scene-system/stateful-scene/types.ts
@@ -3,7 +3,7 @@ export type EntityId = string
 export type ComponentId = number
 export type ComponentData = any
 export type Component = {
-  id: ComponentId
+  componentId: ComponentId
   data: ComponentData
 }
 


### PR DESCRIPTION
We are doing a few different things here:
1. We are making names consistent in the messaging between Unity and Kernel. We are calling the component id `componentId`, and the component's data `data` always now
1. We added a new type of component called `Name`. It's data should be:  ```data: { value: "Some name" }```
1. We are removing default handling, since the renderer will send the full component payload. If this becomes a problem in the future, we might revisit it and start sending partial component updates