### PR TITLE
fix: The MANA HUD is always initialized with balance 0

### DIFF
--- a/kernel/packages/entryPoints/website.ts
+++ b/kernel/packages/entryPoints/website.ts
@@ -76,7 +76,6 @@ namespace webApp {
     const i = (await instancedJS).unityInterface
 
     i.ConfigureHUDElement(HUDElementID.MINIMAP, { active: true, visible: true })
-    i.ConfigureHUDElement(HUDElementID.PROFILE_HUD, { active: true, visible: true })
     i.ConfigureHUDElement(HUDElementID.NOTIFICATION, { active: true, visible: true })
     i.ConfigureHUDElement(HUDElementID.AVATAR_EDITOR, {
       active: true,
@@ -112,6 +111,7 @@ namespace webApp {
 
         configureTaskbarDependentHUD(i, voiceChatEnabled)
 
+        i.ConfigureHUDElement(HUDElementID.PROFILE_HUD, { active: true, visible: true })
         i.ConfigureHUDElement(HUDElementID.USERS_AROUND_LIST_HUD, { active: voiceChatEnabled, visible: false })
         i.ConfigureHUDElement(HUDElementID.FRIENDS, { active: identity.hasConnectedWeb3, visible: false })
 


### PR DESCRIPTION
When we enter the world, the MANA HUD is always initialized with balance 0 and 1 minute after, the MANA balance is correctly updated.

The correct bahaviour should be to update it correctly at the beggining and not to have to wait for 1 minute.