### PR TITLE
fix: use correct property name for components in stateful workers

### DIFF
--- a/kernel/packages/scene-system/stateful-scene/SceneStateDefinitionSerializer.ts
+++ b/kernel/packages/scene-system/stateful-scene/SceneStateDefinitionSerializer.ts
@@ -22,7 +22,7 @@ export class SceneStateDefinitionSerializer {
       const id: EntityId = entity.id
       const components: Component[] | undefined = entity.components
         ?.map((component: any) => ({
-          id: humanReadableTypeToId(component.type),
+          componentId: humanReadableTypeToId(component.type),
           data: component.value,
         }))
       sceneState.addEntity(id, components)


### PR DESCRIPTION
In https://github.com/decentraland/explorer/pull/1608 we changed the property `id` to `componentId`, but we missed one place. Type validations failed to detect the mismatch for some reason.