### PR TITLE
fix: website problem with scroll event on some browsers

### DIFF
--- a/website/src/components/auth/terms/TermsOfServices.tsx
+++ b/website/src/components/auth/terms/TermsOfServices.tsx
@@ -14,7 +14,7 @@ export const TermsOfServices: React.FC<TermsOfServicesProps> = (props) => {
   const [read, setRead] = useState(false);
   const handleScroll = (e: any) => {
     const isBottom =
-      e.target.scrollHeight - e.target.scrollTop === e.target.clientHeight;
+      e.target.scrollHeight - e.target.scrollTop <= e.target.clientHeight * 1.1;
     setRead(isBottom);
   };
   const handleClose = props.loading ? null : props.handleCancel;


### PR DESCRIPTION
# What?
Fix a problem with scroll event on some browser when we're validating that user read terms
