### PR TITLE
fix: macosx 11

### DIFF
--- a/kernel/static/unity/Build/DCLUnityLoader.js
+++ b/kernel/static/unity/Build/DCLUnityLoader.js
@@ -5214,7 +5214,7 @@ var UnityLoader = UnityLoader || {
     var p = n
     switch ((/Windows/.test(u) && ((p = /Windows (.*)/.exec(u)[1]), (u = 'Windows')), u)) {
       case 'Mac OS X':
-        p = /Mac OS X (10[\.\_\d]+)/.exec(i)[1]
+        p = /Mac OS X (1[01][\.\_\d]+)/.exec(i)[1]
         break
       case 'Android':
         p = /Android ([\.\_\d]+)/.exec(i)[1]


### PR DESCRIPTION
Unity Builds for WebGL are not working due to questionable browser detection techniques. This PR fixes that.