### PR TITLE
fix: currentSceneId null check on preview and builder

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/PointerEventsController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/PointerEventsController.cs
@@ -49,10 +49,12 @@ namespace DCL
             // We use Physics.Raycast() instead of our raycastHandler.Raycast() as that one is slower, sometimes 2x, because it fetches info we don't need here
             bool didHit = Physics.Raycast(GetRayFromCamera(), out hitInfo, Mathf.Infinity, PhysicsLayers.physicsCastLayerMaskWithoutCharacter);
             bool uiIsBlocking = false;
+            string currentSceneId = SceneController.i.currentSceneId;
 
-            if (didHit && SceneController.i.loadedScenes.ContainsKey(SceneController.i.currentSceneId))
+            // NOTE: in case of a single scene loaded (preview or builder) sceneId is set to null when stepping outside
+            if (!string.IsNullOrEmpty(currentSceneId) && didHit && SceneController.i.loadedScenes.ContainsKey(currentSceneId))
             {
-                GraphicRaycaster raycaster = SceneController.i.loadedScenes[SceneController.i.currentSceneId].uiScreenSpace?.graphicRaycaster;
+                GraphicRaycaster raycaster = SceneController.i.loadedScenes[currentSceneId].uiScreenSpace?.graphicRaycaster;
                 if (raycaster)
                 {
                     uiGraphicRaycastPointerEventData.position = new Vector2(Screen.width / 2, Screen.height / 2);


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
check that `currentSceneId` is not `null` or empty when testing UI raycast

# Why? <!-- Explain the reason -->
when running isolated scenes (preview or builder) `currentSceneId` is set to `null` when player goes outside the scene
