### PR TITLE
fix: Make the GPU warning waits for tutorial ends

### DIFF
--- a/kernel/packages/entryPoints/website.ts
+++ b/kernel/packages/entryPoints/website.ts
@@ -122,12 +122,12 @@ namespace webApp {
         i.ConfigureHUDElement(HUDElementID.PROFILE_HUD, { active: true, visible: true })
         i.ConfigureHUDElement(HUDElementID.USERS_AROUND_LIST_HUD, { active: voiceChatEnabled, visible: false })
         i.ConfigureHUDElement(HUDElementID.FRIENDS, { active: identity.hasConnectedWeb3, visible: false })
-        i.ConfigureHUDElement(HUDElementID.GRAPHIC_CARD_WARNING, { active: true, visible: true })
 
         EnsureProfile(identity.address)
           .then((profile) => {
             i.ConfigureEmailPrompt(profile.tutorialStep)
             i.ConfigureTutorial(profile.tutorialStep, HAS_INITIAL_POSITION_MARK)
+            i.ConfigureHUDElement(HUDElementID.GRAPHIC_CARD_WARNING, { active: true, visible: true })
             globalThis.globalStore.dispatch(setLoadingWaitTutorial(false))
             Html.switchGameContainer(true)
           })

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/GraphicCardWarningHUD/GraphicCardWarningHUDController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/GraphicCardWarningHUD/GraphicCardWarningHUDController.cs
@@ -1,4 +1,4 @@
-﻿
+
 public class GraphicCardWarningHUDController : IHUD
 {
     private const string GRAPHIC_CARD_MESSAGE = "An integrated Graphic Card has been detected.\nYou might encounter performance issues";
@@ -7,16 +7,33 @@ public class GraphicCardWarningHUDController : IHUD
 
     public void SetVisibility(bool visible)
     {
+        CommonScriptableObjects.tutorialActive.OnChange -= TutorialActiveChanged;
         CommonScriptableObjects.rendererState.OnChange -= RendererStateChanged;
 
         if (!visible)
             return;
 
-        if (CommonScriptableObjects.rendererState)
+        if (!CommonScriptableObjects.tutorialActive.Get() && CommonScriptableObjects.rendererState)
+        {
             TryShowNotification();
+        }
         else
-            CommonScriptableObjects.rendererState.OnChange += RendererStateChanged;
+        {
+            if (CommonScriptableObjects.tutorialActive)
+                CommonScriptableObjects.tutorialActive.OnChange += TutorialActiveChanged;
+            else
+                CommonScriptableObjects.rendererState.OnChange += RendererStateChanged;
+            
+        }
 
+    }
+
+    private void TutorialActiveChanged(bool newState, bool oldState)
+    {
+        if (newState) return;
+
+        CommonScriptableObjects.tutorialActive.OnChange -= TutorialActiveChanged;
+        TryShowNotification();
     }
 
     private void RendererStateChanged(bool newState, bool oldState)


### PR DESCRIPTION
Make the GPU warning waits for tutorial ends (if it is actived).