### PR TITLE
fix: Fix the characters counter in the avatar name edition

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUDView.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUDView.cs
@@ -264,7 +264,7 @@ internal class ProfileHUDView : MonoBehaviour
 
     private void UpdateCharLimit(string newValue)
     {
-        textCharLimit.text = $"{inputName.characterLimit - newValue.Length}/{inputName.characterLimit}";
+        textCharLimit.text = $"{newValue.Length}/{inputName.characterLimit}";
     }
 
     internal void SetProfileName(string newName)

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/Tests/ProfileHUDTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/Tests/ProfileHUDTests.cs
@@ -156,11 +156,11 @@ public class ProfileHUDTests : TestsBase
     {
         controller.view.inputName.characterLimit = 100;
         controller.view.inputName.text = "";
-        Assert.IsTrue(controller.view.textCharLimit.text == $"{controller.view.inputName.characterLimit - controller.view.inputName.text.Length}/{controller.view.inputName.characterLimit}");
+        Assert.IsTrue(controller.view.textCharLimit.text == $"{controller.view.inputName.text.Length}/{controller.view.inputName.characterLimit}");
 
         controller.view.inputName.characterLimit = 50;
         controller.view.inputName.text = "test name";
-        Assert.IsTrue(controller.view.textCharLimit.text == $"{controller.view.inputName.characterLimit - controller.view.inputName.text.Length}/{controller.view.inputName.characterLimit}");
+        Assert.IsTrue(controller.view.textCharLimit.text == $"{controller.view.inputName.text.Length}/{controller.view.inputName.characterLimit}");
     }
 
     [Test]


### PR DESCRIPTION
Fix the characters counter in the avatar name edition.
The correct behaviour should be: `{current length}`/`{max characters limit}`.