### PR TITLE
fix: loading stuck in debug mode

### DIFF
--- a/kernel/packages/decentraland-loader/lifecycle/manager.ts
+++ b/kernel/packages/decentraland-loader/lifecycle/manager.ts
@@ -94,7 +94,7 @@ export async function initParcelSceneWorker() {
   server.enable()
 
   const state = globalThis.globalStore.getState()
-  const localServer = resolveUrl(document.location.origin, '/local-ipfs')
+  const localServer = resolveUrl(`${document.location.protocol}//${document.location.hostname}:${8080}`, '/local-ipfs')
 
   // NOTE(Brian): In branch urls we can't just use location.source - the value returned doesn't include
   //              the branch full path! With this, we ensure the /branch/<branch-name> is included in the root url.


### PR DESCRIPTION
Recently, the decentraland app has been converted into a React app.

Locally, it is on `localhost:3000`. However, the server that used to serve it, is still on `8080`. This server continues to serve scene data, so we need to continue using it when fetching scenes.

We are doing a small emergency fix to unblock the use of debug mode, but we will need to make the fix a little more stable later.