### PR TITLE
fix: connection to matrix fails because of timestamp

### DIFF
--- a/kernel/packages/shared/friends/sagas.ts
+++ b/kernel/packages/shared/friends/sagas.ts
@@ -712,7 +712,7 @@ function* fetchTimeFromSynapseServer(synapseUrl: string) {
   try {
     const response = yield fetch(`${synapseUrl}/.well-known/matrix/client`)
     if (response.ok && response.headers.has(DATE_TIME_HTTP_HEADER)) {
-      const dateTime = response.headers.get(DATE_TIME_HTTP_HEADER)!
+      const dateTime: string = response.headers.get(DATE_TIME_HTTP_HEADER)
       return new Date(dateTime).getTime()
     }
   } catch (e) {

--- a/kernel/packages/shared/friends/sagas.ts
+++ b/kernel/packages/shared/friends/sagas.ts
@@ -717,7 +717,7 @@ function* fetchTimeFromCatalystServer() {
       return currentTime
     }
   } catch (e) {
-    logger.warn(`Failed to fetch time from synapse server`, e)
+    logger.warn(`Failed to fetch time from catalyst server`, e)
   }
 }
 

--- a/kernel/packages/shared/friends/sagas.ts
+++ b/kernel/packages/shared/friends/sagas.ts
@@ -90,7 +90,8 @@ function* initializeSaga() {
 
     const identity = yield select(getCurrentIdentity)
     try {
-      yield call(initializePrivateMessaging, getServerConfigurations().synapseUrl, identity)
+      const { synapseUrl } = getServerConfigurations()
+      yield call(initializePrivateMessaging, synapseUrl, identity)
     } catch (e) {
       logger.error(`error initializing private messaging`, e)
 
@@ -710,7 +711,7 @@ function toSocialData(socialIds: string[]) {
 
 function* fetchTimeFromSynapseServer(synapseUrl: string) {
   try {
-    const response = yield fetch(`${synapseUrl}/.well-known/matrix/client`)
+    const response = yield fetch(`${synapseUrl}/.well-known/matrix/client`, { method: 'HEAD', mode: 'no-cors' })
     if (response.ok && response.headers.has(DATE_TIME_HTTP_HEADER)) {
       const dateTime: string = response.headers.get(DATE_TIME_HTTP_HEADER)
       return new Date(dateTime).getTime()


### PR DESCRIPTION
Fixes https://github.com/decentraland/explorer/issues/1662

The problem here is that we need a new mechanism to find out the global time. We need it in order to log into Matrix.

Ideally, we would get this time from the Matrix server itself, but we can't due to CORS issues. We will create a [PR](https://github.com/matrix-org/synapse/pull/8804) for them, to see if they will be ok with letting the `Date` header go through CORS.

If they don't, then we should use the connected catalyst server to figure out the global time. This would avoid dependencies to external APIs, that specially affect China. We also need to add support for the `Date` header, so we are using the content server's `/status` endpoint for now. If the Matrix team doesn't accept our PR, then we will change the catalyst, and stop using the content server.