### PR TITLE
feat: add name component

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/BuilderInWorld.meta
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/BuilderInWorld.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 86e87c38ac9b27749824f0dea2ded3cc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/BuilderInWorld/DCLName.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/BuilderInWorld/DCLName.cs
@@ -1,0 +1,34 @@
+using DCL;
+using DCL.Components;
+using DCL.Controllers;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DCLName : BaseDisposable
+{
+    [System.Serializable]
+    public class Model
+    {
+        public string value;
+    }
+
+    public Model model;
+
+    public DCLName(ParcelScene scene) : base(scene)
+    {
+        model = new Model();
+    }
+
+    public override IEnumerator ApplyChanges(string newJson)
+    {
+        Model newModel = SceneController.i.SafeFromJson<Model>(newJson);
+        if(newModel.value != model.value)
+        {
+            model = newModel;
+            RaiseOnAppliedChanges();
+        }
+    
+        yield return null;
+    }
+}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/BuilderInWorld/DCLName.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/BuilderInWorld/DCLName.cs
@@ -5,6 +5,10 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+/// <summary>
+/// This component is a descriptive name of the Entity. In the BuilderInWorld you can give an entity a descriptive name through the entity list.
+/// Builder in World send a message to kernel to change the value of this component in order to assign a descriptive name
+/// </summary>
 public class DCLName : BaseDisposable
 {
     [System.Serializable]
@@ -29,6 +33,6 @@ public class DCLName : BaseDisposable
             RaiseOnAppliedChanges();
         }
     
-        yield return null;
+        return null;
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/BuilderInWorld/DCLName.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/BuilderInWorld/DCLName.cs
@@ -1,6 +1,7 @@
 using DCL;
 using DCL.Components;
 using DCL.Controllers;
+using DCL.Models;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -29,10 +30,20 @@ public class DCLName : BaseDisposable
         Model newModel = SceneController.i.SafeFromJson<Model>(newJson);
         if(newModel.value != model.value)
         {
+            string oldValue = model.value;
+
             model = newModel;
             RaiseOnAppliedChanges();
+
+#if UNITY_EDITOR
+            foreach (DecentralandEntity decentralandEntity in this.attachedEntities)
+            {
+                decentralandEntity.gameObject.name.Replace(oldValue, "");
+                decentralandEntity.gameObject.name += "-"+model.value;
+            }
+#endif
         }
-    
+
         return null;
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/BuilderInWorld/DCLName.cs.meta
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/BuilderInWorld/DCLName.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 69cfd42607861914bba1d4e52243f7ad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScene.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ParcelScene.cs
@@ -999,6 +999,11 @@ namespace DCL.Controllers
                         newComponent = new DCLFont(this);
                         break;
                     }
+                case CLASS_ID.NAME:
+                    {
+                        newComponent = new DCLName(this);                      
+                        break;
+                    }
 
                 default:
                     Debug.LogError($"Unknown classId");

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Models/Protocol/Protocol.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Models/Protocol/Protocol.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.InteropServices;
+using System.Runtime.InteropServices;
 using DCL.Interface;
 using UnityEngine;
 
@@ -58,7 +58,9 @@ namespace DCL.Models
         VIDEO_CLIP = 70,
         VIDEO_TEXTURE = 71,
 
-        AUDIO_CLIP = 200
+        AUDIO_CLIP = 200,
+
+        NAME = 300
     }
 
     public static class Protocol


### PR DESCRIPTION

# What? 
This PR adds a new component called "NAME" for entities

# Why? <!-- Explain the reason -->
The Builder In World needs to give a descriptive name so we decide to create a new component to represent this value.

This is created as a shared component for performance reasons. In order to avoid mono behaviors being created and added for each name component we used shared component.
