### PR TITLE
fix: add position validation to emote trigger

### DIFF
--- a/kernel/packages/shared/apis/RestrictedActions.ts
+++ b/kernel/packages/shared/apis/RestrictedActions.ts
@@ -56,6 +56,11 @@ export class RestrictedActions extends ExposableAPI {
       return
     }
 
+    if (!this.isPositionValid(lastPlayerPosition)) {
+      defaultLogger.error('Error: Player is not inside of scene', lastPlayerPosition)
+      return
+    }
+
     unityInterface.TriggerSelfUserExpression(emote.predefined)
   }
 

--- a/kernel/test/unit/RestrictedActions.test.tsx
+++ b/kernel/test/unit/RestrictedActions.test.tsx
@@ -48,18 +48,27 @@ describe('RestrictedActions tests', () => {
       await module.triggerEmote({ predefined: 'emote' })
       sinon.verify()
     })
+
+    it('should fail when player is out of scene and try to move', async () => {
+      mockLastPlayerPosition(false)
+      mockPermissionsWith(Permission.ALLOW_TO_MOVE_PLAYER_INSIDE_SCENE)
+
+      sinon.mock(unityInterface).expects('TriggerSelfUserExpression').never()
+
+      sinon
+        .mock(defaultLogger)
+        .expects('error')
+        .once()
+        .withExactArgs('Error: Player is not inside of scene', lastPlayerPosition)
+
+      const module = new RestrictedActions(options)
+
+      await module.movePlayerTo(new Vector3(8, 0, 8))
+      sinon.verify()
+    })
   })
 
   describe('MovePlayerTo tests', () => {
-
-    const mockLastPlayerPosition = (inside: boolean = true) => {
-      const position = inside
-        ? { x: 7.554769515991211, y: 1.7549998760223389, z: 1622.2711181640625 } // in
-        : { x: -1.0775706768035889, y: 1.774094820022583, z: 1621.8487548828125 } // out
-      sinon.stub(lastPlayerPosition, 'x').value(position.x)
-      sinon.stub(lastPlayerPosition, 'y').value(position.y)
-      sinon.stub(lastPlayerPosition, 'z').value(position.z)
-    }
 
     it('should move the player', async () => {
       mockLastPlayerPosition()
@@ -127,6 +136,15 @@ describe('RestrictedActions tests', () => {
       sinon.verify()
     })
   })
+
+  const mockLastPlayerPosition = (inside: boolean = true) => {
+    const position = inside
+      ? { x: 7.554769515991211, y: 1.7549998760223389, z: 1622.2711181640625 } // in
+      : { x: -1.0775706768035889, y: 1.774094820022583, z: 1621.8487548828125 } // out
+    sinon.stub(lastPlayerPosition, 'x').value(position.x)
+    sinon.stub(lastPlayerPosition, 'y').value(position.y)
+    sinon.stub(lastPlayerPosition, 'z').value(position.z)
+  }
 
   function mockPermissionsWith(...permissions: Permission[]) {
     sinon

--- a/kernel/test/unit/RestrictedActions.test.tsx
+++ b/kernel/test/unit/RestrictedActions.test.tsx
@@ -19,9 +19,9 @@ describe('RestrictedActions tests', () => {
   }
 
   describe('TriggerEmote tests', () => {
-    it('should trigger emote', async () => {
-      const emote = 'emote'
+    const emote = 'emote'
 
+    it('should trigger emote', async () => {
       mockLastPlayerPosition()
       mockPermissionsWith(Permission.ALLOW_TO_TRIGGER_AVATAR_EMOTE)
       sinon
@@ -53,7 +53,7 @@ describe('RestrictedActions tests', () => {
 
     it('should fail when player is out of scene and try to move', async () => {
       mockLastPlayerPosition(false)
-      mockPermissionsWith(Permission.ALLOW_TO_MOVE_PLAYER_INSIDE_SCENE)
+      mockPermissionsWith(Permission.ALLOW_TO_TRIGGER_AVATAR_EMOTE)
 
       sinon.mock(unityInterface).expects('TriggerSelfUserExpression').never()
 
@@ -64,8 +64,7 @@ describe('RestrictedActions tests', () => {
         .withExactArgs('Error: Player is not inside of scene', lastPlayerPosition)
 
       const module = new RestrictedActions(options)
-
-      await module.movePlayerTo(new Vector3(8, 0, 8))
+      await module.triggerEmote({ predefined: emote })
       sinon.verify()
     })
   })

--- a/kernel/test/unit/RestrictedActions.test.tsx
+++ b/kernel/test/unit/RestrictedActions.test.tsx
@@ -22,6 +22,7 @@ describe('RestrictedActions tests', () => {
     it('should trigger emote', async () => {
       const emote = 'emote'
 
+      mockLastPlayerPosition()
       mockPermissionsWith(Permission.ALLOW_TO_TRIGGER_AVATAR_EMOTE)
       sinon
         .mock(unityInterface)
@@ -36,6 +37,7 @@ describe('RestrictedActions tests', () => {
 
 
     it('should fail when scene does not have permissions', async () => {
+      mockLastPlayerPosition()
       mockPermissionsWith()
       sinon.mock(unityInterface).expects('TriggerSelfUserExpression').never()
       sinon


### PR DESCRIPTION
In https://github.com/decentraland/explorer/pull/1489 we added the ability to trigger emotes from the SDK. However, we forgot to add a validation that makes sure that the user is inside the scene when the animation is triggered. That is what we are adding here