### PR TITLE
fix: camera add in builder in world enter/exit

### DIFF
--- a/unity-client/Assets/Builder/Scripts/DCLBuilderOutline.cs
+++ b/unity-client/Assets/Builder/Scripts/DCLBuilderOutline.cs
@@ -54,6 +54,12 @@ namespace Builder
             DCLBuilderBridge.OnPreviewModeChanged -= OnPreviewModeChanged;
         }
 
+        public void SetOutlinerMaterial(Material mat)
+        {
+            OutlineMaterial = mat;
+            outlineRawImage.material = OutlineMaterial;
+        }
+
         private void OnResize()
         {
             outlineRawImage.gameObject.SetActive(false); // Hack: force Unity to refresh the texture

--- a/unity-client/Assets/Builder/Scripts/DCLBuilderOutline.cs
+++ b/unity-client/Assets/Builder/Scripts/DCLBuilderOutline.cs
@@ -48,9 +48,9 @@ namespace Builder
 
         private void OnDestroy()
         {
-            if (outlineCanvas != null)   Destroy(outlineCanvas.gameObject);
+            if (outlineCanvas != null) Destroy(outlineCanvas.gameObject);
             if (outlineRawImage != null) Destroy(outlineRawImage.gameObject);
-            if (outlineCamera != null)   Destroy(outlineCamera.gameObject);
+            if (outlineCamera != null) Destroy(outlineCamera.gameObject);
             DCLBuilderBridge.OnPreviewModeChanged -= OnPreviewModeChanged;
         }
 
@@ -60,15 +60,15 @@ namespace Builder
             outlineCanvas.gameObject.SetActive(true);
             outlineRawImage.gameObject.SetActive(true);
         }
-    
-        public void Desactivate()
+
+        public void Deactivate()
         {
             outlineCamera.gameObject.SetActive(false);
             outlineCanvas.gameObject.SetActive(false);
             outlineRawImage.gameObject.SetActive(false);
         }
 
-        public void SetOutlinerMaterial(Material mat)
+        public void SetOutlineMaterial(Material mat)
         {
             OutlineMaterial = mat;
             outlineRawImage.material = OutlineMaterial;

--- a/unity-client/Assets/Builder/Scripts/DCLBuilderOutline.cs
+++ b/unity-client/Assets/Builder/Scripts/DCLBuilderOutline.cs
@@ -54,6 +54,20 @@ namespace Builder
             DCLBuilderBridge.OnPreviewModeChanged -= OnPreviewModeChanged;
         }
 
+        public void Activate()
+        {
+            outlineCamera.gameObject.SetActive(true);
+            outlineCanvas.gameObject.SetActive(true);
+            outlineRawImage.gameObject.SetActive(true);
+        }
+    
+        public void Desactivate()
+        {
+            outlineCamera.gameObject.SetActive(false);
+            outlineCanvas.gameObject.SetActive(false);
+            outlineRawImage.gameObject.SetActive(false);
+        }
+
         public void SetOutlinerMaterial(Material mat)
         {
             OutlineMaterial = mat;

--- a/unity-client/Assets/Scenes/InitialScene.unity
+++ b/unity-client/Assets/Scenes/InitialScene.unity
@@ -1151,8 +1151,13 @@ PrefabInstance:
     - target: {fileID: 1208871511274338203, guid: ceb04930a6bb25b44a6ad241f62abdf5,
         type: 3}
       propertyPath: activeFeature
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1208871511274338203, guid: ceb04930a6bb25b44a6ad241f62abdf5,
+        type: 3}
+      propertyPath: outlinerMaterial
+      value: 
+      objectReference: {fileID: 2100000, guid: 2bf8916261b5ffc46b4ba519ff75ede4, type: 2}
     - target: {fileID: 1208871511845330199, guid: ceb04930a6bb25b44a6ad241f62abdf5,
         type: 3}
       propertyPath: builderCamera
@@ -1268,6 +1273,16 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 326638022542921345, guid: b0965b55b892d438da492708ea09799c,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 326638022542921347, guid: b0965b55b892d438da492708ea09799c,
+        type: 3}
+      propertyPath: m_RendererIndex
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 326638023455565216, guid: b0965b55b892d438da492708ea09799c,
         type: 3}
       propertyPath: m_Name
@@ -1346,17 +1361,17 @@ PrefabInstance:
     - target: {fileID: 1271431263581989332, guid: b0965b55b892d438da492708ea09799c,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.23911755
+      value: 0.23911744
       objectReference: {fileID: 0}
     - target: {fileID: 1271431263581989332, guid: b0965b55b892d438da492708ea09799c,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.36964387
+      value: -0.36964384
       objectReference: {fileID: 0}
     - target: {fileID: 1271431263581989332, guid: b0965b55b892d438da492708ea09799c,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.099045746
+      value: 0.0990457
       objectReference: {fileID: 0}
     - target: {fileID: 1271431263581989332, guid: b0965b55b892d438da492708ea09799c,
         type: 3}
@@ -1392,6 +1407,21 @@ PrefabInstance:
         type: 3}
       propertyPath: far clip plane
       value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037588735475582821, guid: b0965b55b892d438da492708ea09799c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.80036104
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037588735475582821, guid: b0965b55b892d438da492708ea09799c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.369813
+      objectReference: {fileID: 0}
+    - target: {fileID: 4037588735475582821, guid: b0965b55b892d438da492708ea09799c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.8401191
       objectReference: {fileID: 0}
     - target: {fileID: 5671575169730573920, guid: b0965b55b892d438da492708ea09799c,
         type: 3}

--- a/unity-client/Assets/Scenes/InitialScene.unity
+++ b/unity-client/Assets/Scenes/InitialScene.unity
@@ -1151,7 +1151,7 @@ PrefabInstance:
     - target: {fileID: 1208871511274338203, guid: ceb04930a6bb25b44a6ad241f62abdf5,
         type: 3}
       propertyPath: activeFeature
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1208871511274338203, guid: ceb04930a6bb25b44a6ad241f62abdf5,
         type: 3}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuildModeController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuildModeController.cs
@@ -433,7 +433,7 @@ public class BuildModeController : MonoBehaviour
     public void SetBuildMode(EditModeState state)
     {
         if (currentActiveMode != null)
-            currentActiveMode.Desactivate();
+            currentActiveMode.Deactivate();
         isAdvancedModeActive = false;
 
         currentActiveMode = null;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuildModeController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuildModeController.cs
@@ -716,8 +716,9 @@ public class BuildModeController : MonoBehaviour
             outliner.enabled = true;
         }
 
-        UniversalAdditionalCameraData additionalCameraData = Camera.main.transform.GetComponent<UniversalAdditionalCameraData>();
+        outliner.Activate();
 
+        UniversalAdditionalCameraData additionalCameraData = Camera.main.transform.GetComponent<UniversalAdditionalCameraData>();
         additionalCameraData.SetRenderer(builderRendererIndex);
     }
 
@@ -725,6 +726,8 @@ public class BuildModeController : MonoBehaviour
     {
         DCLBuilderOutline outliner = Camera.main.GetComponent<DCLBuilderOutline>();
         outliner.enabled = false;
+        outliner.Desactivate();
+
         UniversalAdditionalCameraData additionalCameraData = Camera.main.transform.GetComponent<UniversalAdditionalCameraData>();
         additionalCameraData.SetRenderer(0);
     }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuildModeController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuildModeController.cs
@@ -117,19 +117,19 @@ public class BuildModeController : MonoBehaviour
 
     void Start()
     {
-        if (snapGO == null)       
+        if (snapGO == null)
             snapGO = new GameObject("SnapGameObject");
-        
+
         snapGO.transform.SetParent(transform);
 
-        if (freeMovementGO == null)       
+        if (freeMovementGO == null)
             freeMovementGO = new GameObject("FreeMovementGO");
-    
+
         freeMovementGO.transform.SetParent(cameraParentGO.transform);
 
-        if (editionGO == null)        
+        if (editionGO == null)
             editionGO = new GameObject("EditionGO");
-        
+
         editionGO.transform.SetParent(cameraParentGO.transform);
 
         if (undoGO == null)
@@ -264,7 +264,7 @@ public class BuildModeController : MonoBehaviour
 
     void StartTutorial()
     {
-        TutorialController.i.SetTutorialEnabled(false.ToString(),TutorialController.TutorialType.BuilderInWorld);
+        TutorialController.i.SetTutorialEnabled(false.ToString(), TutorialController.TutorialType.BuilderInWorld);
     }
 
     void MouseClick(int buttonID, Vector3 position)
@@ -376,7 +376,7 @@ public class BuildModeController : MonoBehaviour
             Utils.LockCursor();
         lastSceneObjectCreated = sceneObject;
 
-        builderInWorldBridge.AddEntityOnKernel(entity.rootEntity,sceneToEdit); 
+        builderInWorldBridge.AddEntityOnKernel(entity.rootEntity, sceneToEdit);
         InputDone();
         OnSceneObjectPlaced?.Invoke();
     }
@@ -432,14 +432,14 @@ public class BuildModeController : MonoBehaviour
 
     public void SetBuildMode(EditModeState state)
     {
-        if(currentActiveMode != null)
+        if (currentActiveMode != null)
             currentActiveMode.Desactivate();
         isAdvancedModeActive = false;
 
         currentActiveMode = null;
         switch (state)
         {
-            case EditModeState.Inactive:               
+            case EditModeState.Inactive:
                 break;
             case EditModeState.FirstPerson:
                 currentActiveMode = firstPersonMode;
@@ -473,7 +473,7 @@ public class BuildModeController : MonoBehaviour
             SetBuildMode(EditModeState.Editor);
         }
 
-   
+
 
     }
 
@@ -505,9 +505,9 @@ public class BuildModeController : MonoBehaviour
                 else
                     outlinerController.CancelUnselectedOutlines();
 
-                if (entity != null && !entity.IsSelected)             
+                if (entity != null && !entity.IsSelected)
                     outlinerController.OutlineEntity(entity);
-                
+
             }
             outlinerOptimizationCounter = 0;
         }
@@ -522,21 +522,21 @@ public class BuildModeController : MonoBehaviour
     public void ResetScaleAndRotation()
     {
         currentActiveMode.ResetScaleAndRotation();
-      
+
     }
     public void SetOutlineCheckActive(bool isActive)
     {
         isOutlineCheckActive = isActive;
     }
     public void SetSnapActive(bool isActive)
-    {      
+    {
         isSnapActive = isActive;
         currentActiveMode.SetSnapActive(isActive);
     }
 
     void InputDone()
     {
-        nexTimeToReceiveInput = Time.timeSinceLevelLoad+msBetweenInputInteraction/1000;      
+        nexTimeToReceiveInput = Time.timeSinceLevelLoad + msBetweenInputInteraction / 1000;
     }
 
     private void OnEditModeChangeAction(DCLAction_Trigger action)
@@ -555,7 +555,7 @@ public class BuildModeController : MonoBehaviour
     }
 
     void MouseClickDetected()
-    {        
+    {
         DecentralandEntityToEdit entityToSelect = GetEntityOnPointer();
         if (entityToSelect != null)
         {
@@ -588,7 +588,7 @@ public class BuildModeController : MonoBehaviour
 
             if (sceneToEdit.entities.ContainsKey(entityID))
             {
-                return builderInWorldEntityHandler.GetConvertedEntity(sceneToEdit.entities[entityID]);             
+                return builderInWorldEntityHandler.GetConvertedEntity(sceneToEdit.entities[entityID]);
             }
         }
         return null;
@@ -597,7 +597,7 @@ public class BuildModeController : MonoBehaviour
     public VoxelEntityHit GetCloserUnselectedVoxelEntityOnPointer()
     {
         RaycastHit[] hits;
-        UnityEngine.Ray ray  = Camera.main.ScreenPointToRay(Input.mousePosition); ;
+        UnityEngine.Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition); ;
 
         float currentDistance = 9999;
         VoxelEntityHit voxelEntityHit = null;
@@ -638,20 +638,20 @@ public class BuildModeController : MonoBehaviour
     {
 
         HUDController.i.buildModeHud.SetVisibility(true);
-        
+
         isEditModeActivated = true;
         ParcelSettings.VISUAL_LOADING_ENABLED = false;
 
-        inputController.isBuildModeActivate = true;  
-   
+        inputController.isBuildModeActivate = true;
+
         FindSceneToEdit();
 
 
         sceneToEdit.SetEditMode(true);
         cursorGO.SetActive(false);
-        HUDController.i.buildModeHud.SetParcelScene(sceneToEdit);   
+        HUDController.i.buildModeHud.SetParcelScene(sceneToEdit);
 
-        if(currentActiveMode == null)
+        if (currentActiveMode == null)
             SetBuildMode(EditModeState.Editor);
 
         // NOTE(Adrian): This is a temporary as the kernel should do this job instead of the client
@@ -659,14 +659,14 @@ public class BuildModeController : MonoBehaviour
         //
 
         CommonScriptableObjects.builderInWorldNotNecessaryUIVisibilityStatus.Set(false);
-     
+
         DCLCharacterController.OnPositionSet += ExitAfterCharacterTeleport;
         builderInputWrapper.gameObject.SetActive(true);
         builderInWorldEntityHandler.EnterEditMode(sceneToEdit);
 
-        SceneController.i.ActiveBuilderInWorldEditScene();
+        SceneController.i.ActivateBuilderInWorldEditScene();
 
-        ActiveBuilderInWorldCamera();
+        ActivateBuilderInWorldCamera();
     }
 
     public void ExitEditMode()
@@ -697,19 +697,19 @@ public class BuildModeController : MonoBehaviour
         builderInputWrapper.gameObject.SetActive(false);
         builderInWorldBridge.ExitKernelEditMode(sceneToEdit);
 
-        SceneController.i.DesactiveBuilderInWorldEditScene();
+        SceneController.i.DeactivateBuilderInWorldEditScene();
 
-        DesactiveBuilderInWorldCamera();
+        DeactivateBuilderInWorldCamera();
     }
 
-    public void ActiveBuilderInWorldCamera()
+    public void ActivateBuilderInWorldCamera()
     {
         DCLBuilderOutline outliner = Camera.main.GetComponent<DCLBuilderOutline>();
 
         if (outliner == null)
         {
             outliner = Camera.main.gameObject.AddComponent(typeof(DCLBuilderOutline)) as DCLBuilderOutline;
-            outliner.SetOutlinerMaterial(outlinerMaterial);
+            outliner.SetOutlineMaterial(outlinerMaterial);
         }
         else
         {
@@ -722,11 +722,11 @@ public class BuildModeController : MonoBehaviour
         additionalCameraData.SetRenderer(builderRendererIndex);
     }
 
-    public void DesactiveBuilderInWorldCamera()
+    public void DeactivateBuilderInWorldCamera()
     {
         DCLBuilderOutline outliner = Camera.main.GetComponent<DCLBuilderOutline>();
         outliner.enabled = false;
-        outliner.Desactivate();
+        outliner.Deactivate();
 
         UniversalAdditionalCameraData additionalCameraData = Camera.main.transform.GetComponent<UniversalAdditionalCameraData>();
         additionalCameraData.SetRenderer(0);
@@ -738,17 +738,17 @@ public class BuildModeController : MonoBehaviour
     }
 
     void FindSceneToEdit()
-    {      
-        foreach(ParcelScene scene in SceneController.i.scenesSortedByDistance)
+    {
+        foreach (ParcelScene scene in SceneController.i.scenesSortedByDistance)
         {
-            if(scene.IsInsideSceneBoundaries(DCLCharacterController.i.characterPosition))
+            if (scene.IsInsideSceneBoundaries(DCLCharacterController.i.characterPosition))
             {
                 if (sceneToEdit != null && sceneToEdit != scene)
                     actionController.ClearActionList();
                 sceneToEdit = scene;
                 break;
             }
-        }    
+        }
     }
     void PublishScene()
     {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuildModeController.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuildModeController.prefab
@@ -180,8 +180,10 @@ MonoBehaviour:
   actionController: {fileID: 1208871512032110241}
   builderInWorldEntityHandler: {fileID: 7801740759641975108}
   builderInWorldBridge: {fileID: 3917703040089432743}
+  outlinerMaterial: {fileID: 2100000, guid: 2bf8916261b5ffc46b4ba519ff75ede4, type: 2}
   firstPersonMode: {fileID: 1208871511546216253}
   editorMode: {fileID: 1208871512657624393}
+  builderRendererIndex: 1
   layerToRaycast:
     serializedVersion: 2
     m_Bits: 16384

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuildingTool.asmdef
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuildingTool.asmdef
@@ -27,7 +27,8 @@
         "GUID:6d5af96ebed7ed345910feebddf05c1a",
         "GUID:36f22d845f1f3174da2d5fb876f4d3c6",
         "GUID:8e14059e964ca49aeb55d0e7b2b14c3c",
-        "GUID:4973650d2444c4561a15d50f24d91cd9"
+        "GUID:4973650d2444c4561a15d50f24d91cd9",
+        "GUID:15fc0a57446b3144c949da3e2b9737a9"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/BuildMode.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/BuildMode.cs
@@ -39,7 +39,7 @@ public class BuildMode : MonoBehaviour
         isModeActive = true;
     }
 
-    public virtual void Desactivate()
+    public virtual void Deactivate()
     {
         gameObject.SetActive(false);
         isModeActive = false;
@@ -109,7 +109,7 @@ public class BuildMode : MonoBehaviour
 
     public virtual void CheckInput()
     {
-       
+
     }
 
     public virtual void CheckInputSelectedEntities()
@@ -134,7 +134,7 @@ public class BuildMode : MonoBehaviour
         freeMovementGO.transform.rotation = zeroAnglesQuaternion;
         editionGO.transform.rotation = zeroAnglesQuaternion;
 
-        foreach(DecentralandEntityToEdit decentralandEntityToEdit in selectedEntities)
+        foreach (DecentralandEntityToEdit decentralandEntityToEdit in selectedEntities)
         {
             decentralandEntityToEdit.rootEntity.gameObject.transform.eulerAngles = Vector3.zero;
         }
@@ -166,7 +166,7 @@ public class BuildMode : MonoBehaviour
     protected List<BuildModeEntityAction> actionList = new List<BuildModeEntityAction>();
     protected void TransformActionStarted(DecentralandEntity entity, string type)
     {
-        
+
         BuildModeEntityAction buildModeEntityAction = new BuildModeEntityAction(entity);
         switch (type)
         {
@@ -192,16 +192,16 @@ public class BuildMode : MonoBehaviour
         {
             if (entityAction.entity == entity)
             {
-         
+
                 switch (type)
                 {
                     case "MOVE":
-                      
+
                         entityAction.newValue = entity.gameObject.transform.position;
-                        if (Vector3.Distance((Vector3)entityAction.oldValue ,(Vector3)entityAction.newValue) <= 0.09f) removeList.Add(entityAction);
+                        if (Vector3.Distance((Vector3)entityAction.oldValue, (Vector3)entityAction.newValue) <= 0.09f) removeList.Add(entityAction);
                         break;
                     case "ROTATE":
-                    
+
                         entityAction.newValue = entity.gameObject.transform.rotation.eulerAngles;
                         if (Vector3.Distance((Vector3)entityAction.oldValue, (Vector3)entityAction.newValue) <= 0.09f) removeList.Add(entityAction);
                         break;
@@ -211,7 +211,7 @@ public class BuildMode : MonoBehaviour
                         break;
                 }
 
-             
+
             }
         }
         foreach (BuildModeEntityAction entityAction in removeList)

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/BuildEditorMode.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/States/EditorMode/BuildEditorMode.cs
@@ -60,7 +60,7 @@ public class BuildEditorMode : BuildMode
 
         focusOnSelectedEntitiesInputAction.OnTriggered += (o) => FocusOnSelectedEntitiesInput();
 
-        squareMultiSelectionInputAction.OnStarted += (o) => squareMultiSelectionButtonPressed = true;;
+        squareMultiSelectionInputAction.OnStarted += (o) => squareMultiSelectionButtonPressed = true;
         squareMultiSelectionInputAction.OnFinished += (o) => squareMultiSelectionButtonPressed = false;
     }
 
@@ -141,7 +141,7 @@ public class BuildEditorMode : BuildMode
         {
             if (isMakingSquareMultiSelection)
             {
-                EndBoundMultiSelection();          
+                EndBoundMultiSelection();
             }
         }
     }
@@ -159,14 +159,14 @@ public class BuildEditorMode : BuildMode
                 mousePressed = true;
                 freeCameraController.SetCameraCanMove(false);
                 buildModeController.SetOutlineCheckActive(false);
-  
+
             }
         }
     }
 
     public void EndBoundMultiSelection()
     {
-   
+
         isMakingSquareMultiSelection = false;
         mousePressed = false;
         freeCameraController.SetCameraCanMove(true);
@@ -213,38 +213,38 @@ public class BuildEditorMode : BuildMode
         SetLookAtObject();
 
 
-        // NOTE(Adrian): Take into account that right now to get the relative scale of the gizmos, we set the gizmos in the player position and the camera 
-        Vector3 cameraPosition = DCLCharacterController.i.characterPosition.unityPosition;   
+        // NOTE(Adrian): Take into account that right now to get the relative scale of the gizmos, we set the gizmos in the player position and the camera
+        Vector3 cameraPosition = DCLCharacterController.i.characterPosition.unityPosition;
         freeCameraController.SetPosition(cameraPosition + Vector3.up * distanceEagleCamera);
         //
 
         freeCameraController.LookAt(lookAtT);
 
-   
+
         cameraController.SetCameraMode(CameraMode.ModeId.BuildingToolGodMode);
 
-        gizmoManager.InitializeGizmos(Camera.main,freeCameraController.transform);
+        gizmoManager.InitializeGizmos(Camera.main, freeCameraController.transform);
         gizmoManager.SetAllGizmosInPosition(cameraPosition);
         if (gizmoManager.GetSelectedGizmo() == DCL.Components.DCLGizmos.Gizmo.NONE)
             gizmoManager.SetGizmoType("MOVE");
         mouseCatcher.enabled = false;
         SceneController.i.IsolateScene(sceneToEdit);
         Utils.UnlockCursor();
-       
+
         RenderSettings.fog = false;
         gizmoManager.HideGizmo();
         editionGO.transform.SetParent(null);
     }
-    public override void Desactivate()
+    public override void Deactivate()
     {
-        base.Desactivate();
+        base.Deactivate();
         mouseCatcher.enabled = true;
         Utils.LockCursor();
         cameraController.SetCameraMode(CameraMode.ModeId.FirstPerson);
 
 
         SceneController.i.ReIntegrateIsolatedScene();
-        
+
         gizmoManager.HideGizmo();
         RenderSettings.fog = true;
     }
@@ -306,7 +306,7 @@ public class BuildEditorMode : BuildMode
     public override void EntityDeselected(DecentralandEntityToEdit entityDeselected)
     {
         base.EntityDeselected(entityDeselected);
-        if(selectedEntities.Count <= 0)
+        if (selectedEntities.Count <= 0)
             gizmoManager.HideGizmo();
         isPlacingNewObject = false;
         DesactivateVoxelMode();
@@ -374,7 +374,7 @@ public class BuildEditorMode : BuildMode
             else
                 gizmoManager.HideGizmo();
         }
-        
+
     }
 
     public void ScaleMode()
@@ -398,7 +398,7 @@ public class BuildEditorMode : BuildMode
     {
         foreach (DecentralandEntityToEdit entity in selectedEntities)
         {
-            TransformActionStarted(entity.rootEntity,gizmoType);
+            TransformActionStarted(entity.rootEntity, gizmoType);
         }
     }
     void OnGizmosTransformEnd(string gizmoType)
@@ -408,8 +408,8 @@ public class BuildEditorMode : BuildMode
             TransformActionEnd(entity.rootEntity, gizmoType);
         }
 
-        switch(gizmoType)
-        {           
+        switch (gizmoType)
+        {
             case "MOVE":
 
                 ActionFinish(BuildModeAction.ActionType.MOVE);
@@ -422,7 +422,7 @@ public class BuildEditorMode : BuildMode
                 ActionFinish(BuildModeAction.ActionType.SCALE);
                 break;
         }
-    }   
+    }
 
     void ShowGizmos()
     {
@@ -435,7 +435,7 @@ public class BuildEditorMode : BuildMode
 
         lookAtT.position = SceneController.i.ConvertSceneToUnityPosition(middlePoint);
     }
-   
+
     Vector3 CalculateMiddlePoint(Vector2Int[] positions)
     {
         Vector3 position;
@@ -465,11 +465,11 @@ public class BuildEditorMode : BuildMode
         position.y = totalY;
         position.z = centerZ;
 
-        int amountParcelsX = Mathf.Abs(maxX - minX)+1;
-        int amountParcelsZ = Mathf.Abs(maxY - minY)+1;
+        int amountParcelsX = Mathf.Abs(maxX - minX) + 1;
+        int amountParcelsZ = Mathf.Abs(maxY - minY) + 1;
 
-        position.x += ParcelSettings.PARCEL_SIZE/2 * amountParcelsX;
-        position.z += ParcelSettings.PARCEL_SIZE/2 * amountParcelsZ;
+        position.x += ParcelSettings.PARCEL_SIZE / 2 * amountParcelsX;
+        position.z += ParcelSettings.PARCEL_SIZE / 2 * amountParcelsZ;
 
         return position;
     }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Resources/CameraController.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Resources/CameraController.prefab
@@ -968,7 +968,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_VerticalAxis:
-    Value: 29.999994
+    Value: 29.99998
     m_MaxSpeed: 200
     m_AccelTime: 0.2
     m_DecelTime: 0.03
@@ -1140,7 +1140,6 @@ GameObject:
   - component: {fileID: 8626449322338435419}
   - component: {fileID: 682333195972692980}
   - component: {fileID: 1060609013}
-  - component: {fileID: 1237533440}
   - component: {fileID: 1237533442}
   m_Layer: 15
   m_Name: MainCamera
@@ -1156,8 +1155,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5902165421965975136}
-  m_LocalRotation: {x: 0.23911755, y: -0.36964387, z: 0.099045746, w: 0.89239913}
-  m_LocalPosition: {x: -0.80036104, y: 1.369813, z: 1.8401191}
+  m_LocalRotation: {x: 0.23911744, y: -0.36964384, z: 0.0990457, w: 0.89239913}
+  m_LocalPosition: {x: -553.2, y: -329.36002, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1379362891393605244}
@@ -1260,19 +1259,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 2, y: 2, z: 2}
   m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &1237533440
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5902165421965975136}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e938e4e3938944fafbbc66bbcfc95c3b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  OutlineMaterial: {fileID: 2100000, guid: 2bf8916261b5ffc46b4ba519ff75ede4, type: 2}
 --- !u!114 &1237533442
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1329,7 +1315,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6406064072910471882}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.80036104, y: 1.369813, z: 1.8401191}
+  m_LocalPosition: {x: -553.2, y: -329.36002, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 6695749068451744534}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
@@ -566,12 +566,12 @@ namespace DCL
             return solvedPosition;
         }
 
-        public void ActiveBuilderInWorldEditScene()
+        public void ActivateBuilderInWorldEditScene()
         {
             InitializeSceneBoundariesChecker(true);
         }
 
-        public void DesactiveBuilderInWorldEditScene()
+        public void DeactivateBuilderInWorldEditScene()
         {
             InitializeSceneBoundariesChecker(false);
         }

--- a/unity-client/ProjectSettings/QualitySettings.asset
+++ b/unity-client/ProjectSettings/QualitySettings.asset
@@ -21,7 +21,7 @@ QualitySettings:
     skinWeights: 4
     textureQuality: 0
     anisotropicTextures: 2
-    antiAliasing: 2
+    antiAliasing: 0
     softParticles: 0
     softVegetation: 0
     realtimeReflectionProbes: 0


### PR DESCRIPTION
#What? 
Now the BuilderInWorld activates/deactivates the additional camera and its components. Also, it only set the renderer when necessary

# Why? 
This PR solves the issue with the builder in world camera lowering the overall performance of the client
