### PR TITLE
fix: unsubscribe autoquality controller listeners

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/AutoQualitySettingsController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/AutoQualitySettingsController.cs
@@ -30,6 +30,13 @@ public class AutoQualitySettingsController : MonoBehaviour
         SetAutoSettings(autoQualityEnabled.Get(), !autoQualityEnabled.Get());
     }
 
+    private void OnDestroy()
+    {
+        if (autoQualityEnabled == null)
+            return;
+        autoQualityEnabled.OnChange -= SetAutoSettings;
+    }
+
     private void SetAutoSettings(bool newValue, bool oldValue)
     {
         if (settingsCheckerCoroutine != null)


### PR DESCRIPTION
Autoquality controller is throwing errors when destroyed due to not unsubscribing from a variable