### PR TITLE
fix: loading message with two lines

### DIFF
--- a/website/src/components/loading/LoadingContainer.stories.tsx
+++ b/website/src/components/loading/LoadingContainer.stories.tsx
@@ -9,7 +9,8 @@ export default {
     state: {
       status: "Getting things ready...",
       helpText: 0,
-      message: "",
+      message:
+        "Loading scenes 98%\nDownloading images, 3D models, and sounds 95%",
       pendingScenes: 4,
       loadPercentage: 30,
       subsystemsLoad: 0,
@@ -17,7 +18,7 @@ export default {
       showLoadingScreen: true,
     },
     showWalletPrompt: false,
-  } as LoadingContainerProps,
+  },
   component: LoadingContainer,
 } as Meta;
 

--- a/website/src/components/loading/LoadingMessage.tsx
+++ b/website/src/components/loading/LoadingMessage.tsx
@@ -21,7 +21,14 @@ export const LoadingMessage: React.FC<LoadingMessageProps> = (props) => (
           Request.
         </div>
       )}
-      <div id="subtext-messages">{props.subMessage}</div>
+      <div id="subtext-messages">
+        {props.subMessage.split("\n").map((item) => (
+          <React.Fragment>
+            {item}
+            <br />
+          </React.Fragment>
+        ))}
+      </div>
     </div>
   </div>
 );


### PR DESCRIPTION
# What? <!-- what is this PR? -->
Fixes loading screen when loading message has two lines
