### PR TITLE
fix: generated meshes on GLTF import were not optimized

### DIFF
--- a/unity-client/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/unity-client/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -2131,13 +2131,16 @@ namespace UnityGLTF
                 yield return YieldOnTimeout();
             }
 
+// Disable it in runtime so this optimization only takes place in
+// asset bundle converter time.
+#if UNITY_EDITOR
             mesh.Optimize();
 
             if (ShouldYieldOnTimeout())
             {
                 yield return YieldOnTimeout();
             }
-
+#endif
             if (!KeepCPUCopyOfMesh)
             {
                 mesh.UploadMeshData(true);

--- a/unity-client/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/unity-client/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -2126,6 +2126,18 @@ namespace UnityGLTF
                 mesh.RecalculateNormals();
             }
 
+            if (ShouldYieldOnTimeout())
+            {
+                yield return YieldOnTimeout();
+            }
+
+            mesh.Optimize();
+
+            if (ShouldYieldOnTimeout())
+            {
+                yield return YieldOnTimeout();
+            }
+
             if (!KeepCPUCopyOfMesh)
             {
                 mesh.UploadMeshData(true);


### PR DESCRIPTION
For some reason, GLTFSceneImporter was not optimizing the meshes at all. 

The mesh optimization is done to shuffle the mesh attributes in memory and make them as small as possible. This can improve rendering times, because we are taking advantage of the GPU cache. 

The optimization will only be done in Unity editor so its only reflected in asset bundle conversion until further notice.