### PR TITLE
chore: reduce GLTF tests duration

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/Tests/GLTFShape_Tests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/Tests/GLTFShape_Tests.cs
@@ -23,7 +23,7 @@ public class GLTFShape_Tests : TestsBase
         TestHelpers.CreateAndSetShape(scene, entityId, DCL.Models.CLASS_ID.GLTF_SHAPE, JsonConvert.SerializeObject(
             new
             {
-                src = Utils.GetTestsAssetsPath() + "/GLB/Lantern/Lantern.glb"
+                src = Utils.GetTestsAssetsPath() + "/GLB/Trunk/Trunk.glb"
             }));
 
         LoadWrapper gltfShape = GLTFShape.GetLoaderForEntity(scene.entities[entityId]);
@@ -44,7 +44,7 @@ public class GLTFShape_Tests : TestsBase
         var componentId = TestHelpers.CreateAndSetShape(scene, entityId, DCL.Models.CLASS_ID.GLTF_SHAPE, JsonConvert.SerializeObject(
             new
             {
-                src = Utils.GetTestsAssetsPath() + "/GLB/Lantern/Lantern.glb"
+                src = Utils.GetTestsAssetsPath() + "/GLB/Trunk/Trunk.glb"
             }));
 
         LoadWrapper gltfShape = GLTFShape.GetLoaderForEntity(scene.entities[entityId]);
@@ -54,13 +54,13 @@ public class GLTFShape_Tests : TestsBase
             var gltfObject = scene.entities[entityId].gameObject.GetComponentInChildren<InstantiatedGLTFObject>();
 
             Assert.IsTrue(gltfObject != null, "InstantiatedGLTFObject is null in first object!");
-            Assert.IsTrue(gltfObject.transform.Find("Lantern") != null, "Can't find \"Lantern!\"");
+            Assert.IsTrue(gltfObject.transform.Find("TreeStump_01") != null, "Can't find \"TreeStump_01!\"");
         }
 
         TestHelpers.UpdateShape(scene, componentId, JsonConvert.SerializeObject(
             new
             {
-                src = Utils.GetTestsAssetsPath() + "/GLB/DamagedHelmet/DamagedHelmet.glb"
+                src = Utils.GetTestsAssetsPath() + "/GLB/PalmTree_01.glb"
             }));
 
         gltfShape = GLTFShape.GetLoaderForEntity(scene.entities[entityId]);
@@ -70,8 +70,8 @@ public class GLTFShape_Tests : TestsBase
             var gltfObject = scene.entities[entityId].gameObject.GetComponentInChildren<InstantiatedGLTFObject>();
 
             Assert.IsTrue(gltfObject != null, "InstantiatedGLTFObject is null in second object!");
-            Assert.IsTrue(gltfObject.transform.Find("node_damagedHelmet_-6514") != null,
-                "Can't find \"node_damagedHelmet_-6514\"!");
+            Assert.IsTrue(gltfObject.transform.Find("PalmTree_01") != null,
+                "Can't find \"PalmTree_01\"!");
         }
     }
 
@@ -84,7 +84,7 @@ public class GLTFShape_Tests : TestsBase
         var componentId = TestHelpers.CreateAndSetShape(scene, entityId, DCL.Models.CLASS_ID.GLTF_SHAPE, JsonConvert.SerializeObject(
             new
             {
-                src = Utils.GetTestsAssetsPath() + "/GLB/Lantern/Lantern.glb"
+                src = Utils.GetTestsAssetsPath() + "/GLB/Trunk/Trunk.glb"
             }));
 
         LoadWrapper gltfShape = GLTFShape.GetLoaderForEntity(scene.entities[entityId]);
@@ -93,7 +93,7 @@ public class GLTFShape_Tests : TestsBase
         TestHelpers.UpdateShape(scene, componentId, JsonConvert.SerializeObject(
             new
             {
-                src = Utils.GetTestsAssetsPath() + "/GLB/DamagedHelmet/DamagedHelmet.glb"
+                src = Utils.GetTestsAssetsPath() + "/GLB/PalmTree_01.glb"
             }));
 
         gltfShape = GLTFShape.GetLoaderForEntity(scene.entities[entityId]);
@@ -126,7 +126,7 @@ public class GLTFShape_Tests : TestsBase
         string gltfId2 = TestHelpers.CreateAndSetShape(scene, entity.entityId, DCL.Models.CLASS_ID.GLTF_SHAPE,
             JsonConvert.SerializeObject(new
             {
-                src = Utils.GetTestsAssetsPath() + "/GLB/Lantern/Lantern.glb"
+                src = Utils.GetTestsAssetsPath() + "/GLB/Trunk/Trunk.glb"
             }));
 
         gltfLoader = GLTFShape.GetLoaderForEntity(entity);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Tests/SceneTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Tests/SceneTests.cs
@@ -128,14 +128,14 @@ namespace Tests
             var lanternEntity = TestHelpers.CreateSceneEntity(scene);
             var lanternShape = TestHelpers.AttachGLTFShape(lanternEntity, scene, new Vector3(8, 1, 8), new LoadableShape.Model()
             {
-                src = DCL.Helpers.Utils.GetTestsAssetsPath() + "/GLB/Lantern/Lantern.glb"
+                src = DCL.Helpers.Utils.GetTestsAssetsPath() + "/GLB/Trunk/Trunk.glb"
             });
             yield return TestHelpers.WaitForGLTFLoad(lanternEntity);
 
             var cesiumManEntity = TestHelpers.CreateSceneEntity(scene);
             var cesiumManShape = TestHelpers.AttachGLTFShape(cesiumManEntity, scene, new Vector3(8, 1, 8), new LoadableShape.Model()
             {
-                src = DCL.Helpers.Utils.GetTestsAssetsPath() + "/GLB/CesiumMan/CesiumMan.glb"
+                src = DCL.Helpers.Utils.GetTestsAssetsPath() + "/GLB/Shark/shark_anim.gltf"
             });
             yield return TestHelpers.WaitForGLTFLoad(cesiumManEntity);
 
@@ -145,7 +145,7 @@ namespace Tests
             TestHelpers.DetachSharedComponent(scene, cesiumManEntity.entityId, cesiumManShape.id);
             cesiumManShape = TestHelpers.AttachGLTFShape(cesiumManEntity, scene, new Vector3(8, 1, 8), new LoadableShape.Model()
             {
-                src = DCL.Helpers.Utils.GetTestsAssetsPath() + "/GLB/Lantern/Lantern.glb"
+                src = DCL.Helpers.Utils.GetTestsAssetsPath() + "/GLB/Trunk/Trunk.glb"
             });
             yield return TestHelpers.WaitForGLTFLoad(cesiumManEntity);
 
@@ -153,11 +153,11 @@ namespace Tests
             TestHelpers.InstantiateEntityWithShape(scene, "2", DCL.Models.CLASS_ID.SPHERE_SHAPE, new Vector3(8, 1, 8));
 
             AssertMetricsModel(scene,
-                triangles: 6214,
+                triangles: 1126,
                 materials: 2,
                 entities: 4,
-                meshes: 6,
-                bodies: 6,
+                meshes: 4,
+                bodies: 4,
                 textures: 0);
 
             TestHelpers.RemoveSceneEntity(scene, "1");

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/QualitySettingsController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Settings/SettingsControllers/QualitySettingsController.cs
@@ -37,6 +37,8 @@ namespace DCL.SettingsController
             {
                 lightweightRenderPipelineAsset = GraphicsSettings.renderPipelineAsset as UniversalRenderPipelineAsset;
 
+                if (lightweightRenderPipelineAsset == null) return;
+
                 // NOTE: LightweightRenderPipelineAsset doesn't expose properties to set any of the following fields
                 lwrpaShadowField = lightweightRenderPipelineAsset.GetType().GetField("m_MainLightShadowsSupported", BindingFlags.NonPublic | BindingFlags.Instance);
                 lwrpaSoftShadowField = lightweightRenderPipelineAsset.GetType().GetField("m_SoftShadowsSupported", BindingFlags.NonPublic | BindingFlags.Instance);


### PR DESCRIPTION
replaced Lantern GLB to reduce tests duration

* Removed Lantern glb usage (almost 10mb)
* Added Trunk and PalmTree usage (26kb and 32kb)

Local testing showed a 14 seconds gain