### PR TITLE
feat: add support for new components for Builder In-World

### DIFF
--- a/kernel/packages/decentraland-ecs/src/decentraland/Components.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Components.ts
@@ -67,7 +67,9 @@ export enum CLASS_ID {
   AVATAR_MODIFIER_AREA = 205,
 
   // For state sync only
-  NAME = 300
+  NAME = 300,
+  LOCKED_ON_EDIT = 301,
+  VISIBLE_ON_EDIT = 302
 }
 
 export enum AvatarModifiers {
@@ -89,7 +91,7 @@ export class AvatarModifierArea extends ObservableComponent {
   @ObservableComponent.field
   modifiers!: AvatarModifiers[]
 
-  constructor(args: { area: Area, modifiers: AvatarModifiers[] }) {
+  constructor(args: { area: Area; modifiers: AvatarModifiers[] }) {
     super()
     this.area = args.area
     this.modifiers = args.modifiers
@@ -206,13 +208,13 @@ export class Shape extends ObservableComponent {
  * @public
  */
 @DisposableComponent('engine.shape', CLASS_ID.BOX_SHAPE)
-export class BoxShape extends Shape { }
+export class BoxShape extends Shape {}
 
 /**
  * @public
  */
 @DisposableComponent('engine.shape', CLASS_ID.SPHERE_SHAPE)
-export class SphereShape extends Shape { }
+export class SphereShape extends Shape {}
 
 /**
  * @public
@@ -867,8 +869,8 @@ export class OnUUIDEvent<T extends keyof IEvents> extends ObservableComponent {
 
   static uuidEvent(target: ObservableComponent, propertyKey: string) {
     if (delete (target as any)[propertyKey]) {
-      const componentSymbol = propertyKey + '_' + Math.random();
-      (target as any)[componentSymbol] = undefined
+      const componentSymbol = propertyKey + '_' + Math.random()
+      ;(target as any)[componentSymbol] = undefined
 
       Object.defineProperty(target, componentSymbol, {
         ...Object.getOwnPropertyDescriptor(target, componentSymbol),
@@ -962,7 +964,7 @@ export class OnAnimationEnd extends OnUUIDEvent<'onAnimationEnd'> {
  * @internal
  */
 @Component('engine.smartItem', CLASS_ID.SMART_ITEM)
-export class SmartItem extends ObservableComponent { }
+export class SmartItem extends ObservableComponent {}
 
 /**
  * @public
@@ -1060,7 +1062,8 @@ export class VideoTexture extends ObservableComponent {
   }
 
   toJSON() {
-    if (this.seek >= 0) { // the seek value was changed/used
+    if (this.seek >= 0) {
+      // the seek value was changed/used
       this.pause()
 
       const ret = JSON.parse(JSON.stringify(super.toJSON()))

--- a/kernel/packages/scene-system/stateful-scene/RendererStatefulActor.ts
+++ b/kernel/packages/scene-system/stateful-scene/RendererStatefulActor.ts
@@ -171,6 +171,10 @@ export class RendererStatefulActor extends StatefulActor {
         return { name: 'shape', disposability: ComponentDisposability.DISPOSABLE }
       case CLASS_ID.NFT_SHAPE:
         return { name: 'shape', disposability: ComponentDisposability.DISPOSABLE }
+      case CLASS_ID.LOCKED_ON_EDIT:
+        return { name: 'lockedOnEdit', disposability: ComponentDisposability.DISPOSABLE }
+      case CLASS_ID.VISIBLE_ON_EDIT:
+        return { name: 'visibleOnEdit', disposability: ComponentDisposability.DISPOSABLE }
     }
     throw new Error('Component not implemented yet')
   }

--- a/kernel/packages/shared/apis/SceneStateStorageController/StorableSceneStateTranslation.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/StorableSceneStateTranslation.ts
@@ -46,7 +46,9 @@ const HUMAN_READABLE_TO_ID: Map<string, number> = new Map([
   ['Transform', CLASS_ID.TRANSFORM],
   ['GLTFShape', CLASS_ID.GLTF_SHAPE],
   ['NFTShape', CLASS_ID.NFT_SHAPE],
-  ['Name', CLASS_ID.NAME]
+  ['Name', CLASS_ID.NAME],
+  ['LockedOnEdit', CLASS_ID.LOCKED_ON_EDIT],
+  ['VisibleOnEdit', CLASS_ID.VISIBLE_ON_EDIT]
 ])
 
 function toHumanReadableType(type: number): string {


### PR DESCRIPTION
We are now adding support for 2 new types of components: `LockedOnEdit`& `VisibleOnEdit`.

They will both have the same body:
```
{ value: boolean }
```

They are meant to be used for the Builder In-World feature