### PR TITLE
fix: add branch library cache for circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,10 @@ jobs:
           name: Restore decentraland-renderer if exists
           keys:
             - unity-build-{{ checksum "../.unitysources-checksum" }}
+      - restore_cache:
+          name: Restore library
+          keys: 
+            - library-{{ .Branch }}
       - run:
           name: Build decentraland-renderer
           command: |
@@ -168,6 +172,11 @@ jobs:
           key: unity-build-{{ checksum "../.unitysources-checksum" }}
           paths:
             - /tmp/explorer/unity-client/Builds/
+      - save_cache:
+          name: Store library
+          key: library-{{ .Branch }}
+          paths:
+            - /tmp/explorer/unity-client/Library/
       - store_artifacts:
           name: Store logs
           path: /tmp/buildlog.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,13 +100,13 @@ jobs:
           command: |
             find Assets -type f \( -not -path '*Plugins*' \) \( -iname \*.unity -o -iname \*.cs -o -iname \*.meta -o -iname \*.xml -o -iname \*.shader -o -iname \*.prefab -o -iname \*.yml -o -iname \*.mat -o -iname \*.json -o -iname \*.js -o -iname \*.jspre  -o -iname \*.jslib  -o -iname \*.hlsl  -o -iname \*.asmdef  -o -iname \*.csproj  -o -iname \*.spriteatlas  \) \( -exec md5sum "$PWD"/{} \; \) | sort > ../.unitysources-checksum
       - restore_cache:
-          name: Restore decentraland-renderer if exists
-          keys:
-            - unity-build-{{ checksum "../.unitysources-checksum" }}
-      - restore_cache:
           name: Restore test results if they exist
           keys:
             - unity-tests-{{ checksum "../.unitysources-checksum" }}
+      - restore_cache:
+          name: Restore library if exists
+          keys: 
+            - library-{{ .Branch }}
       - run:
           name: Run tests
           command: |
@@ -151,7 +151,7 @@ jobs:
           keys:
             - unity-build-{{ checksum "../.unitysources-checksum" }}
       - restore_cache:
-          name: Restore library
+          name: Restore library if exists
           keys: 
             - library-{{ .Branch }}
       - run:
@@ -174,9 +174,9 @@ jobs:
             - /tmp/explorer/unity-client/Builds/
       - save_cache:
           name: Store library
-          key: library-{{ .Branch }}
+          key: library-{{ .Branch }}-{{ epoch }}
           paths:
-            - /tmp/explorer/unity-client/Library/
+            - /tmp/explorer/unity-client/Library
       - store_artifacts:
           name: Store logs
           path: /tmp/buildlog.txt


### PR DESCRIPTION
This PR should improve all the Unity jobs speed by caching the Library folder.

Before:
![image](https://user-images.githubusercontent.com/6875814/101088343-53103300-3592-11eb-8725-276dcc49e374.png)

After:
![image](https://user-images.githubusercontent.com/6875814/101088246-222ffe00-3592-11eb-8b40-cb859c7dd92c.png)

### How it works:
- First push on any branch should take same time as always (around 15 mins).
- Library is cached after the build finishes with the `<branch>-library-<epoch>` key. epoch is posix time in seconds.
- When cache is restored, CircleCI will try to match only the first part of the key to the newest cache available. So we just query the `library-<branch>` key and the latest cache should be restored. (1)
- This means N > 0 pushes will get the cache benefit.

Also, using cache from `master` was considered for the first push. Holding on that for now because `master` cache can be updated with newer contents than the current branch, and that can potentially screw up the CI flow.  

--- 

1. For more on this, check: https://circleci.com/docs/2.0/configuration-reference/#save_cache

>A key is searched against existing keys as a prefix.
>
>Note: When there are multiple matches, the most recent match will be used, even if there is a more precise match.
