### PR TITLE
refactor: move SafeFromJson to Utils

### DIFF
--- a/unity-client/Assets/Builder/Scripts/DCLBuilderBridge.cs
+++ b/unity-client/Assets/Builder/Scripts/DCLBuilderBridge.cs
@@ -107,7 +107,7 @@ namespace Builder
         public void GetMousePosition(string newJson)
         {
             if (LOG_MESSAGES) Debug.Log($"RECEIVE: GetMousePosition {newJson}");
-            MousePayload m = SceneController.i.SafeFromJson<MousePayload>(newJson);
+            MousePayload m = Utils.SafeFromJson<MousePayload>(newJson);
 
             Vector3 mousePosition = new Vector3(m.x, Screen.height - m.y, 0);
             Vector3 hitPoint;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Animator/DCLAnimator.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Animator/DCLAnimator.cs
@@ -1,6 +1,7 @@
-using DCL.Models;
+﻿using DCL.Models;
 using System.Collections;
 using System.Collections.Generic;
+using DCL.Helpers;
 using UnityEngine;
 
 namespace DCL.Components
@@ -55,7 +56,7 @@ namespace DCL.Components
 
         public override IEnumerator ApplyChanges(string newJson)
         {
-            model = SceneController.i.SafeFromJson<Model>(newJson);
+            model = Utils.SafeFromJson<Model>(newJson);
 
             //NOTE(Brian): Horrible fix to the double ApplyChanges call, as its breaking the needed logic.
             if (newJson == "{}")

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioClip.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioClip.cs
@@ -98,6 +98,7 @@ namespace DCL.Components
                 loadingState = LoadState.IDLE;
             }
         }
+
         public override object GetModel()
         {
             return model;
@@ -107,7 +108,7 @@ namespace DCL.Components
         {
             yield return new WaitUntil(() => CommonScriptableObjects.rendererState.Get());
 
-            model = SceneController.i.SafeFromJson<Model>(newJson);
+            model = Utils.SafeFromJson<Model>(newJson);
 
             if (!string.IsNullOrEmpty(model.url))
             {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioSource.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioSource.cs
@@ -46,7 +46,7 @@ namespace DCL.Components
         {
             yield return new WaitUntil(() => CommonScriptableObjects.rendererState.Get());
 
-            model = SceneController.i.SafeFromJson<Model>(newJson);
+            model = Utils.SafeFromJson<Model>(newJson);
 
             CommonScriptableObjects.sceneID.OnChange -= OnCurrentSceneChanged;
             CommonScriptableObjects.sceneID.OnChange += OnCurrentSceneChanged;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioStream.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioStream.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using DCL.Controllers;
+using DCL.Helpers;
 
 namespace DCL.Components
 {
@@ -27,7 +28,7 @@ namespace DCL.Components
             yield return new WaitUntil(() => CommonScriptableObjects.rendererState.Get());
 
             Model prevModel = model;
-            model = SceneController.i.SafeFromJson<Model>(newJson);
+            model = Utils.SafeFromJson<Model>(newJson);
 
             bool forceUpdate = prevModel.volume != model.volume;
             settingsVolume = Settings.i.generalSettings.sfxVolume;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/AvatarModifierArea.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/AvatarModifierArea.cs
@@ -1,9 +1,10 @@
-using System;
+﻿using System;
 using DCL;
 using DCL.Components;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using DCL.Helpers;
 using UnityEngine;
 
 public class AvatarModifierArea : BaseComponent
@@ -49,7 +50,7 @@ public class AvatarModifierArea : BaseComponent
         OnAvatarExit = null;
 
         // Update
-        model = SceneController.i.SafeFromJson<Model>(newJson);
+        model = Utils.SafeFromJson<Model>(newJson);
         if (model.modifiers != null)
         {
             // Add all listeners

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarShape.cs
@@ -4,6 +4,7 @@ using DCL.Interface;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using DCL.Helpers;
 using DCL.Models;
 using UnityEngine;
 
@@ -64,7 +65,7 @@ namespace DCL
 
             DisablePassport();
 
-            model = SceneController.i.SafeFromJson<AvatarModel>(newJson);
+            model = Utils.SafeFromJson<AvatarModel>(newJson);
 
             everythingIsLoaded = false;
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Billboard/Billboard.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Billboard/Billboard.cs
@@ -1,5 +1,6 @@
 ﻿using DCL.Components;
 using System.Collections;
+using DCL.Helpers;
 using UnityEngine;
 
 namespace DCL
@@ -30,7 +31,7 @@ namespace DCL
             cameraPosition.OnChange -= CameraPositionChanged;
             cameraPosition.OnChange += CameraPositionChanged;
 
-            model = SceneController.i.SafeFromJson<Model>(newJson);
+            model = Utils.SafeFromJson<Model>(newJson);
 
             ChangeOrientation();
 
@@ -38,12 +39,13 @@ namespace DCL
             {
                 //NOTE(Zak): We have to wait one frame because if not the entity will be null. (I'm Brian, but Zak wrote the code so read this in his voice)
                 yield return null;
-                
+
                 if (entity == null || entity.gameObject == null)
                 {
                     Debug.LogWarning("It seems skipping a frame didnt work, entity/GO is still null");
                     yield break;
                 }
+
                 entityTransform = entity.gameObject.transform;
             }
         }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/BuilderInWorld/DCLName.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/BuilderInWorld/DCLName.cs
@@ -4,6 +4,7 @@ using DCL.Controllers;
 using DCL.Models;
 using System.Collections;
 using System.Collections.Generic;
+using DCL.Helpers;
 using UnityEngine;
 
 /// <summary>
@@ -39,14 +40,14 @@ public class DCLName : BaseDisposable
     {
         Model newModel = new Model();
         newModel.value = value;
-      
+
         UpdateFromJSON(JsonUtility.ToJson(newModel));
     }
 
     public override IEnumerator ApplyChanges(string newJson)
     {
-        Model newModel = SceneController.i.SafeFromJson<Model>(newJson);
-        if(newModel.value != model.value)
+        Model newModel = Utils.SafeFromJson<Model>(newJson);
+        if (newModel.value != model.value)
         {
             string oldValue = model.value;
             model = newModel;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Font/DCLFont.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Font/DCLFont.cs
@@ -1,5 +1,6 @@
-using System.Collections;
+﻿using System.Collections;
 using DCL.Controllers;
+using DCL.Helpers;
 using DCL.Models;
 using TMPro;
 using UnityEngine;
@@ -67,7 +68,7 @@ namespace DCL.Components
 
         public override IEnumerator ApplyChanges(string newJson)
         {
-            model = SceneController.i.SafeFromJson<Model>(newJson);
+            model = Utils.SafeFromJson<Model>(newJson);
 
             if (string.IsNullOrEmpty(model.src))
             {
@@ -90,6 +91,7 @@ namespace DCL.Components
                 {
                     Debug.Log($"couldn't fetch font from resources {resourceName}");
                 }
+
                 loaded = true;
                 error = fontAsset == null;
             }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Gizmos/DCLGizmos.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Gizmos/DCLGizmos.cs
@@ -1,4 +1,5 @@
-using System.Collections;
+﻿using System.Collections;
+using DCL.Helpers;
 
 namespace DCL.Components
 {
@@ -32,7 +33,7 @@ namespace DCL.Components
 
         public override IEnumerator ApplyChanges(string newJson)
         {
-            model = SceneController.i.SafeFromJson<Model>(newJson);
+            model = Utils.SafeFromJson<Model>(newJson);
             yield return null;
         }
     }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadableShape.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadableShape.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using DCL.Controllers;
 using DCL.Helpers;
 using DCL.Models;
@@ -113,7 +113,7 @@ namespace DCL.Components
         public override IEnumerator ApplyChanges(string newJson)
         {
             previousModel = model;
-            model = SceneController.i.SafeFromJson<LoadWrapperModelType>(newJson);
+            model = Utils.SafeFromJson<LoadWrapperModelType>(newJson);
 
             bool updateVisibility = previousModel.visible != model.visible;
             bool updateCollisions = previousModel.withCollisions != model.withCollisions || previousModel.isPointerBlocker != model.isPointerBlocker;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Materials/BasicMaterial.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Materials/BasicMaterial.cs
@@ -67,7 +67,7 @@ namespace DCL.Components
             material.name = "BasicMaterial_" + id;
 #endif
 
-            model = SceneController.i.SafeFromJson<Model>(newJson);
+            model = Utils.SafeFromJson<Model>(newJson);
 
             if (!string.IsNullOrEmpty(model.texture))
             {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Materials/PBRMaterial.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Materials/PBRMaterial.cs
@@ -91,7 +91,7 @@ namespace DCL.Components
 
         public override IEnumerator ApplyChanges(string newJson)
         {
-            model = SceneController.i.SafeFromJson<Model>(newJson);
+            model = Utils.SafeFromJson<Model>(newJson);
 
             LoadMaterial(PBR_MATERIAL_NAME);
 
@@ -283,7 +283,7 @@ namespace DCL.Components
                     CoroutineStarter.Start(DCLTexture.FetchTextureComponent(scene, textureComponentId,
                         (fetchedDCLTexture) =>
                         {
-                            if(material != null)
+                            if (material != null)
                             {
                                 material.SetTexture(materialPropertyId, fetchedDCLTexture.texture);
                                 SwitchTextureComponent(cachedDCLTexture, fetchedDCLTexture);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/ParametrizedShapes/ParametrizedShape.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/ParametrizedShapes/ParametrizedShape.cs
@@ -1,4 +1,4 @@
-using DCL.Controllers;
+﻿using DCL.Controllers;
 using DCL.Helpers;
 using DCL.Models;
 using System.Collections;
@@ -63,7 +63,7 @@ namespace DCL.Components
 
             MeshFilter meshFilter = entity.meshRootGameObject.AddComponent<MeshFilter>();
             MeshRenderer meshRenderer = entity.meshRootGameObject.AddComponent<MeshRenderer>();
-            entity.meshesInfo.renderers = new Renderer[] { meshRenderer };
+            entity.meshesInfo.renderers = new Renderer[] {meshRenderer};
             entity.meshesInfo.currentShape = this;
 
             meshFilter.sharedMesh = currentMesh;
@@ -113,7 +113,7 @@ namespace DCL.Components
 
         public override IEnumerator ApplyChanges(string newJson)
         {
-            var newModel = SceneController.i.SafeFromJson<T>(newJson);
+            var newModel = Utils.SafeFromJson<T>(newJson);
             visibilityDirty = newModel.visible != model.visible;
             collisionsDirty = newModel.withCollisions != model.withCollisions || newModel.isPointerBlocker != model.isPointerBlocker;
             bool shouldGenerateMesh = ShouldGenerateNewMesh(newModel);
@@ -132,7 +132,6 @@ namespace DCL.Components
                     bool cachedCollisionDirty = collisionsDirty;
                     while (iterator.MoveNext())
                     {
-
                         //NOTE(Alex): Since UpdateRenderer updates the dirty flags as well we have to make sure every entity
                         //            gets updated accordingly to the original flags.
                         visibilityDirty = cachedVisibilityDirty;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/TextShape/TextShape.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/TextShape/TextShape.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using DCL.Controllers;
+using DCL.Helpers;
 using TMPro;
 using UnityEngine;
 
@@ -12,8 +13,7 @@ namespace DCL.Components
         {
             public bool billboard;
 
-            [Header("Font Properties")]
-            public string value = "";
+            [Header("Font Properties")] public string value = "";
 
             public bool visible = true;
 
@@ -24,8 +24,7 @@ namespace DCL.Components
             public string fontWeight = "normal";
             public string font;
 
-            [Header("Text box properties")]
-            public string hTextAlign = "bottom";
+            [Header("Text box properties")] public string hTextAlign = "bottom";
 
             public string vTextAlign = "left";
             public float width = 1f;
@@ -40,15 +39,13 @@ namespace DCL.Components
             public int lineCount = 0;
             public bool textWrapping = false;
 
-            [Header("Text shadow properties")]
-            public float shadowBlur = 0f;
+            [Header("Text shadow properties")] public float shadowBlur = 0f;
 
             public float shadowOffsetX = 0f;
             public float shadowOffsetY = 0f;
             public Color shadowColor = new Color(1, 1, 1);
 
-            [Header("Text outline properties")]
-            public float outlineWidth = 0f;
+            [Header("Text outline properties")] public float outlineWidth = 0f;
 
             public Color outlineColor = Color.white;
         }
@@ -74,7 +71,7 @@ namespace DCL.Components
         {
             if (rectTransform == null) yield break;
 
-            model = SceneController.i.SafeFromJson<Model>(newJson);
+            model = Utils.SafeFromJson<Model>(newJson);
 
             rectTransform.sizeDelta = new Vector2(model.width, model.height);
 
@@ -96,7 +93,7 @@ namespace DCL.Components
             text.text = model.value;
 
             text.color = new Color(model.color.r, model.color.g, model.color.b, model.visible ? model.opacity : 0);
-            text.fontSize = (int)model.fontSize;
+            text.fontSize = (int) model.fontSize;
             text.richText = true;
             text.overflowMode = TextOverflowModes.Overflow;
             text.enableAutoSizing = model.fontAutoSize;
@@ -104,10 +101,10 @@ namespace DCL.Components
             text.margin =
                 new Vector4
                 (
-                    (int)model.paddingLeft,
-                    (int)model.paddingTop,
-                    (int)model.paddingRight,
-                    (int)model.paddingBottom
+                    (int) model.paddingLeft,
+                    (int) model.paddingTop,
+                    (int) model.paddingRight,
+                    (int) model.paddingBottom
                 );
 
             text.alignment = GetAlignment(model.vTextAlign, model.hTextAlign);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Textures/DCLTexture.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Textures/DCLTexture.cs
@@ -3,6 +3,7 @@ using DCL.Controllers;
 using DCL.Models;
 using System;
 using System.Collections;
+using DCL.Helpers;
 using UnityEngine;
 
 namespace DCL
@@ -78,7 +79,7 @@ namespace DCL
         {
             yield return new WaitUntil(() => CommonScriptableObjects.rendererState.Get());
 
-            model = SceneController.i.SafeFromJson<Model>(newJson);
+            model = Utils.SafeFromJson<Model>(newJson);
 
             unitySamplingMode = model.samplingMode;
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIInputText/UIInputText.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIInputText/UIInputText.cs
@@ -1,6 +1,7 @@
 using DCL.Controllers;
 using DCL.Models;
 using System.Collections;
+using DCL.Helpers;
 using TMPro;
 using UnityEngine;
 
@@ -34,7 +35,7 @@ namespace DCL.Components
 
         public override int GetClassId()
         {
-            return (int)CLASS_ID.UI_INPUT_TEXT_SHAPE;
+            return (int) CLASS_ID.UI_INPUT_TEXT_SHAPE;
         }
 
         public override void AttachTo(DecentralandEntity entity, System.Type overridenAttachedType = null)
@@ -53,7 +54,7 @@ namespace DCL.Components
             //             client data structure to be like this, so we can serialize all of it in one shot.
             if (!scene.isTestScene)
             {
-                model.textModel = SceneController.i.SafeFromJson<TextShape.Model>(newJson);
+                model.textModel = Utils.SafeFromJson<TextShape.Model>(newJson);
             }
 
             inputField.textViewport = referencesContainer.rectTransform;
@@ -116,7 +117,7 @@ namespace DCL.Components
         {
             bool validString = !string.IsNullOrEmpty(tmpText.text);
 
-            if (tmpText.text.Length == 1 && (byte)tmpText.text[0] == 11) //NOTE(Brian): Trim doesn't work. neither IsNullOrWhitespace.
+            if (tmpText.text.Length == 1 && (byte) tmpText.text[0] == 11) //NOTE(Brian): Trim doesn't work. neither IsNullOrWhitespace.
             {
                 validString = false;
             }
@@ -127,7 +128,7 @@ namespace DCL.Components
 
                 ForceFocus();
             }
-            else if(scene.isPersistent) // DCL UI Chat text input
+            else if (scene.isPersistent) // DCL UI Chat text input
             {
                 inputField.DeactivateInputField();
                 referencesContainer.mouseCatcher.LockCursor();

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIScreenSpace/UIScreenSpace.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIScreenSpace/UIScreenSpace.cs
@@ -32,7 +32,7 @@ namespace DCL.Components
 
         public override int GetClassId()
         {
-            return (int)CLASS_ID.UI_SCREEN_SPACE_SHAPE;
+            return (int) CLASS_ID.UI_SCREEN_SPACE_SHAPE;
         }
 
         public override void AttachTo(DecentralandEntity entity, System.Type overridenAttachedType = null)
@@ -47,7 +47,7 @@ namespace DCL.Components
 
         public override IEnumerator ApplyChanges(string newJson)
         {
-            model = SceneController.i.SafeFromJson<Model>(newJson);
+            model = Utils.SafeFromJson<Model>(newJson);
 
             if (scene.uiScreenSpace == null)
             {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIShape.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIShape.cs
@@ -79,7 +79,7 @@ namespace DCL.Components
         /// </summary>
         public void PreApplyChanges(string newJson)
         {
-            model = SceneController.i.SafeFromJson<ModelType>(newJson);
+            model = Utils.SafeFromJson<ModelType>(newJson);
 
             raiseOnAttached = false;
             firstApplyChangesCall = false;
@@ -165,7 +165,7 @@ namespace DCL.Components
 
         public override int GetClassId()
         {
-            return (int)CLASS_ID.UI_IMAGE_SHAPE;
+            return (int) CLASS_ID.UI_IMAGE_SHAPE;
         }
 
         public string GetDebugName()
@@ -447,7 +447,12 @@ namespace DCL.Components
             base.Dispose();
         }
 
-        public virtual void OnChildAttached(UIShape parentComponent, UIShape childComponent) { }
-        public virtual void OnChildDetached(UIShape parentComponent, UIShape childComponent) { }
+        public virtual void OnChildAttached(UIShape parentComponent, UIShape childComponent)
+        {
+        }
+
+        public virtual void OnChildDetached(UIShape parentComponent, UIShape childComponent)
+        {
+        }
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIText/UIText.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UI/UIText/UIText.cs
@@ -22,7 +22,7 @@ namespace DCL.Components
 
         public override int GetClassId()
         {
-            return (int)CLASS_ID.UI_TEXT_SHAPE;
+            return (int) CLASS_ID.UI_TEXT_SHAPE;
         }
 
         public override void AttachTo(DecentralandEntity entity, System.Type overridenAttachedType = null)
@@ -38,7 +38,7 @@ namespace DCL.Components
         {
             if (!scene.isTestScene)
             {
-                model.textModel = SceneController.i.SafeFromJson<TextShape.Model>(newJson);
+                model.textModel = Utils.SafeFromJson<TextShape.Model>(newJson);
             }
 
             yield return TextShape.ApplyModelChanges(scene, referencesContainer.text, model.textModel);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/UUIDComponent.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/UUIDComponent/UUIDComponent.cs
@@ -70,7 +70,7 @@ namespace DCL
 
         public override IEnumerator ApplyChanges(string newJson)
         {
-            model = SceneController.i.SafeFromJson<Model>(newJson);
+            model = Utils.SafeFromJson<Model>(newJson);
 
             if (!string.IsNullOrEmpty(model.uuid))
             {
@@ -79,7 +79,5 @@ namespace DCL
 
             return null;
         }
-
-       
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Video/DCLVideoClip.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Video/DCLVideoClip.cs
@@ -1,6 +1,7 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Linq;
 using DCL.Controllers;
+using DCL.Helpers;
 using DCL.Models;
 
 namespace DCL.Components
@@ -34,7 +35,7 @@ namespace DCL.Components
 
         public override IEnumerator ApplyChanges(string newJson)
         {
-            model = SceneController.i.SafeFromJson<Model>(newJson);
+            model = Utils.SafeFromJson<Model>(newJson);
             isExternalURL = model.url.StartsWith("http://") || model.url.StartsWith("https://");
             isStream = !new[] { ".mp4", ".ogg", ".mov", ".webm" }.Any(x => model.url.EndsWith(x));
             yield break;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Video/DCLVideoTexture.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Video/DCLVideoTexture.cs
@@ -49,7 +49,7 @@ namespace DCL.Components
         {
             yield return new WaitUntil(() => CommonScriptableObjects.rendererState.Get());
 
-            model = SceneController.i.SafeFromJson<Model>(newJson);
+            model = Utils.SafeFromJson<Model>(newJson);
 
             unitySamplingMode = model.samplingMode;
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ProfilingEvents.cs.meta
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ProfilingEvents.cs.meta
@@ -1,3 +1,3 @@
 ﻿fileFormatVersion: 2
-guid: 595f09a8a78b4f95b4704ed434145738
+guid: 4a919901021d2c34a9bc1b6551553a3f
 timeCreated: 1607362302

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ProfilingEvents.meta
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ProfilingEvents.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 490614a38019f8a41af23759df86fd8b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ProfilingEvents/ProfilingEvents.asmdef
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ProfilingEvents/ProfilingEvents.asmdef
@@ -1,0 +1,3 @@
+﻿{
+	"name": "ProfilingEvents"
+}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ProfilingEvents/ProfilingEvents.asmdef.meta
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ProfilingEvents/ProfilingEvents.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 16ad09a45a70eac4fa3ab1c6650ae7ae
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ProfilingEvents/ProfilingEvents.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ProfilingEvents/ProfilingEvents.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace DCL
+{
+    public static class ProfilingEvents
+    {
+        //NOTE(Brian): For performance reasons, these events may need to be removed for production.
+        public static Action<string> OnMessageWillQueue;
+        public static Action<string> OnMessageWillDequeue;
+
+        public static Action<string> OnMessageProcessStart;
+        public static Action<string> OnMessageProcessEnds;
+
+        public static Action<string> OnMessageDecodeStart;
+        public static Action<string> OnMessageDecodeEnds;
+    }
+}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ProfilingEvents/ProfilingEvents.cs.meta
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/ProfilingEvents/ProfilingEvents.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 595f09a8a78b4f95b4704ed434145738
+timeCreated: 1607362302

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
@@ -175,15 +175,6 @@ namespace DCL
         const float MAX_TIME_FOR_DECODE = 0.005f;
         public bool msgStepByStep = false;
 
-        public T SafeFromJson<T>(string data)
-        {
-            ProfilingEvents.OnMessageDecodeStart?.Invoke("Misc");
-            T result = Utils.SafeFromJson<T>(data);
-            ProfilingEvents.OnMessageDecodeEnds?.Invoke("Misc");
-
-            return result;
-        }
-
         public bool ProcessMessage(MessagingBus.QueuedSceneMessage_Scene msgObject, out CleanableYieldInstruction yieldInstruction)
         {
             string sceneId = msgObject.sceneId;
@@ -632,7 +623,7 @@ namespace DCL
             LoadParcelScenesMessage.UnityParcelScene scene;
 
             ProfilingEvents.OnMessageDecodeStart?.Invoke(MessagingTypes.SCENE_LOAD);
-            scene = SafeFromJson<LoadParcelScenesMessage.UnityParcelScene>(decentralandSceneJSON);
+            scene = Utils.SafeFromJson<LoadParcelScenesMessage.UnityParcelScene>(decentralandSceneJSON);
             ProfilingEvents.OnMessageDecodeEnds?.Invoke(MessagingTypes.SCENE_LOAD);
 
             if (scene == null || scene.id == null) return;
@@ -686,7 +677,7 @@ namespace DCL
             LoadParcelScenesMessage.UnityParcelScene scene;
 
             ProfilingEvents.OnMessageDecodeStart?.Invoke(MessagingTypes.SCENE_UPDATE);
-            scene = SafeFromJson<LoadParcelScenesMessage.UnityParcelScene>(decentralandSceneJSON);
+            scene = Utils.SafeFromJson<LoadParcelScenesMessage.UnityParcelScene>(decentralandSceneJSON);
             ProfilingEvents.OnMessageDecodeEnds?.Invoke(MessagingTypes.SCENE_UPDATE);
 
             if (Environment.i.worldState.loadedScenes.ContainsKey(scene.id))
@@ -803,7 +794,7 @@ namespace DCL
             if (debugScenes && ignoreGlobalScenes)
                 return;
 #endif
-            CreateUISceneMessage uiScene = SafeFromJson<CreateUISceneMessage>(json);
+            CreateUISceneMessage uiScene = Utils.SafeFromJson<CreateUISceneMessage>(json);
 
             string uiSceneId = uiScene.id;
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.asmdef
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.asmdef
@@ -3,7 +3,8 @@
     "references": [
         "GUID:6055be8ebefd69e48b49212b09b47b2f",
         "GUID:cc6bfabbfe87b7949aa248893f89ce37",
-        "GUID:760a1d365aad58044916992b072cf2a6"
+        "GUID:760a1d365aad58044916992b072cf2a6",
+        "GUID:16ad09a45a70eac4fa3ab1c6650ae7ae"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/Utils/Utils.cs
@@ -125,7 +125,6 @@ namespace DCL.Helpers
         }
 
 
-
         /// <summary>
         /// Reimplementation of the LayoutRebuilder.ForceRebuildLayoutImmediate() function (Unity UI API) for make it more performant.
         /// </summary>
@@ -137,7 +136,7 @@ namespace DCL.Helpers
             // NOTE(Santi): It seems to be very much cheaper to execute the next instructions manually than execute directly the function
             //              'LayoutRebuilder.ForceRebuildLayoutImmediate()', that theorically already contains these instructions.
             var layoutElements = rectTransformRoot.GetComponentsInChildren(typeof(ILayoutElement), true).ToList();
-            layoutElements.RemoveAll(e => (e is Behaviour && !((Behaviour)e).isActiveAndEnabled) || e is TextMeshProUGUI);
+            layoutElements.RemoveAll(e => (e is Behaviour && !((Behaviour) e).isActiveAndEnabled) || e is TextMeshProUGUI);
             foreach (var layoutElem in layoutElements)
             {
                 (layoutElem as ILayoutElement).CalculateLayoutInputHorizontal();
@@ -145,7 +144,7 @@ namespace DCL.Helpers
             }
 
             var layoutControllers = rectTransformRoot.GetComponentsInChildren(typeof(ILayoutController), true).ToList();
-            layoutControllers.RemoveAll(e => e is Behaviour && !((Behaviour)e).isActiveAndEnabled);
+            layoutControllers.RemoveAll(e => e is Behaviour && !((Behaviour) e).isActiveAndEnabled);
             foreach (var layoutCtrl in layoutControllers)
             {
                 (layoutCtrl as ILayoutController).SetLayoutHorizontal();
@@ -346,6 +345,8 @@ namespace DCL.Helpers
 
         public static T SafeFromJson<T>(string json)
         {
+            ProfilingEvents.OnMessageDecodeStart?.Invoke("Misc");
+
             T returningValue = default(T);
 
             if (!string.IsNullOrEmpty(json))
@@ -359,6 +360,8 @@ namespace DCL.Helpers
                     Debug.LogError("ArgumentException Fail!... Json = " + json + " " + e.ToString());
                 }
             }
+
+            ProfilingEvents.OnMessageDecodeEnds?.Invoke("Misc");
 
             return returningValue;
         }

--- a/unity-client/Assets/Scripts/MainScripts/MainScripts.asmdef
+++ b/unity-client/Assets/Scripts/MainScripts/MainScripts.asmdef
@@ -43,7 +43,8 @@
         "GUID:3f13bd1a926f03a4cab988f06a80c1fd",
         "GUID:086c21f5b0c2a6a488e34b5e5da4eb40",
         "GUID:e945202cffc30cc479229aef4577a74c",
-        "GUID:b97702e026e0dbd4397dc4013ef9fcb3"
+        "GUID:b97702e026e0dbd4397dc4013ef9fcb3",
+        "GUID:16ad09a45a70eac4fa3ab1c6650ae7ae"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
This PR moves all `SceneController.SafeFromJson` calls to to already existing `Utils.SafeFromJson`. This will aid us in the removal of the `SceneController` class monolith status and disaggregate the `MainScripts` assembly.