### PR TITLE
fix: use every environments content asset as bundle

### DIFF
--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -99,7 +99,6 @@ export const FETCH_CONTENT_SERVICE = qs.FETCH_CONTENT_SERVICE
 export const FETCH_META_CONTENT_SERVICE = qs.FETCH_META_CONTENT_SERVICE
 export const COMMS_SERVICE = qs.COMMS_SERVICE
 export const RESIZE_SERVICE = qs.RESIZE_SERVICE
-export const ASSET_BUNDLES_DOMAIN = qs.ASSET_BUNDLES_DOMAIN || 'content-assets-as-bundle.decentraland.org'
 export const HOTSCENES_SERVICE = qs.HOTSCENES_SERVICE
 export const REALM = qs.realm
 
@@ -124,11 +123,9 @@ export const DEBUG_SCENE_LOG = DEBUG || location.search.includes('DEBUG_SCENE_LO
 
 export const INIT_PRE_LOAD = location.search.includes('INIT_PRE_LOAD')
 
-export const AWS = location.search.includes('AWS')
 export const NO_MOTD = location.search.includes('NO_MOTD')
 export const RESET_TUTORIAL = location.search.includes('RESET_TUTORIAL')
 
-export const DISABLE_AUTH = location.search.includes('DISABLE_AUTH') || DEBUG
 export const ENGINE_DEBUG_PANEL = location.search.includes('ENGINE_DEBUG_PANEL')
 export const SCENE_DEBUG_PANEL = location.search.includes('SCENE_DEBUG_PANEL') && !ENGINE_DEBUG_PANEL
 export const SHOW_FPS_COUNTER = location.search.includes('SHOW_FPS_COUNTER') || DEBUG
@@ -277,6 +274,7 @@ export function getServerConfigurations() {
   const synapseUrl = TLDDefault === 'zone' ? `https://matrix.decentraland.zone` : `https://decentraland.modular.im`
 
   const metaConfigBaseUrl = META_CONFIG_URL || `https://config.decentraland.${notToday}/explorer.json`
+  const ASSET_BUNDLES_DOMAIN = qs.ASSET_BUNDLES_DOMAIN || `content-assets-as-bundle.decentraland.${TLDDefault}`
 
   return {
     contentAsBundle: `https://${ASSET_BUNDLES_DOMAIN}`,


### PR DESCRIPTION
We currently have deployed different versions of the 'content-asset-as-bundle` endpoints. Those are configurables by pipeline. 