### PR TITLE
chore: fetch global time from synapse server

### DIFF
--- a/kernel/packages/shared/friends/sagas.ts
+++ b/kernel/packages/shared/friends/sagas.ts
@@ -29,7 +29,7 @@ import {
   HUDElementID
 } from 'shared/types'
 import { StoreContainer } from 'shared/store/rootTypes'
-import { getRealm, getUpdateProfileServer } from 'shared/dao/selectors'
+import { getRealm } from 'shared/dao/selectors'
 import { Realm } from 'shared/dao/types'
 import { lastPlayerPosition, positionObservable } from 'shared/world/positionThings'
 import { ensureRenderer } from 'shared/renderer/sagas'


### PR DESCRIPTION
In https://github.com/decentraland/explorer/pull/1689, we tried to get global time by fetching it from the synapse server. It wasn't possible due to CORS issues, but that has been fixed now