### PR TITLE
fix: teleport popup fetch scene json

### DIFF
--- a/kernel/packages/shared/apis/UserActionModule.ts
+++ b/kernel/packages/shared/apis/UserActionModule.ts
@@ -32,8 +32,8 @@ export class UserActionModule extends ExposableAPI implements IUserActionModule 
     let sceneCreator: string = 'Unknown'
     let sceneEvent = {}
 
-    const sceneId = await fetchSceneIds([destination])
-    const mapSceneData = sceneId ? (await fetchSceneJson([sceneId[0]!]))[0] : undefined
+    const sceneId = (await fetchSceneIds([destination]))[0]
+    const mapSceneData = sceneId ? (await fetchSceneJson([sceneId!]))[0] : undefined
 
     sceneName = this.getSceneName(destination, mapSceneData?.sceneJsonData)
     sceneCreator = getOwnerNameFromJsonData(mapSceneData?.sceneJsonData)


### PR DESCRIPTION
Null check of `sceneId` for fetching scene json was badly implemented, resulting in teleport popup never showing up if `fetchSceneIds` return null value instead of a valid `sceneId`