### PR TITLE
fix: send publish scene result properly

### DIFF
--- a/kernel/packages/scene-system/stateful-scene/RendererStatefulActor.ts
+++ b/kernel/packages/scene-system/stateful-scene/RendererStatefulActor.ts
@@ -13,7 +13,6 @@ import {
 import { Component, ComponentData, ComponentId, EntityId, StatefulActor } from './types'
 import { EventSubscriber } from 'decentraland-rpc'
 import { generatePBObjectJSON } from 'scene-system/sdk/Utils'
-import { DeploymentResult } from 'shared/apis/SceneStateStorageController/types'
 
 export class RendererStatefulActor extends StatefulActor {
   private readonly eventSubscriber: EventSubscriber
@@ -111,10 +110,6 @@ export class RendererStatefulActor extends StatefulActor {
         listener(payload.entityId, payload.componentId)
       }
     })
-  }
-
-  informPublishResult(result: DeploymentResult) {
-    this.engine.sendBatch([{ type: 'PublishSceneResult', payload: result }])
   }
 
   private mapComponentToActions(entityId: EntityId, componentId: ComponentId, data: ComponentData): EntityAction[] {

--- a/kernel/packages/scene-system/stateful.scene.system.ts
+++ b/kernel/packages/scene-system/stateful.scene.system.ts
@@ -55,7 +55,6 @@ class StatefulWebWorkerScene extends Script {
       if (data.type === 'StoreSceneState') {
         this.sceneStateStorage
           .storeState(sceneId, serializeSceneState(this.sceneState))
-          .then((result) => this.renderer.informPublishResult(result))
           .catch((error) => this.error(`Failed to store the scene's state`, error))
       }
     })

--- a/kernel/packages/shared/apis/SceneStateStorageController/SceneStateStorageController.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/SceneStateStorageController.ts
@@ -20,6 +20,7 @@ import { Store } from 'redux'
 import { RootState } from 'shared/store/rootTypes'
 import { getUpdateProfileServer } from 'shared/dao/selectors'
 import { createGameFile } from './SceneStateDefinitionCodeGenerator'
+import { unityInterface } from 'unity-interface/UnityInterface'
 
 declare const window: any
 
@@ -29,56 +30,66 @@ export class SceneStateStorageController extends ExposableAPI {
 
   @exposeMethod
   async storeState(sceneId: string, sceneState: SerializedSceneState): Promise<DeploymentResult> {
+    let result: DeploymentResult
+
     // Convert to storable format
     const storableFormat = fromSerializedStateToStorableFormat(sceneState)
 
     if (DEBUG) {
       saveToLocalStorage(`scene-state-${sceneId}`, storableFormat)
-      return { ok: true }
-    }
+      result = { ok: true }
+    } else {
+      try {
+        // Fetch all asset metadata
+        const assets = await this.getAllAssets(sceneState)
 
-    try {
-      // Fetch all asset metadata
-      const assets = await this.getAllAssets(sceneState)
+        // Download asset files
+        const models = await this.downloadAssetFiles(assets)
 
-      // Download asset files
-      const models = await this.downloadAssetFiles(assets)
+        // Generate game file
+        const gameFile: string = createGameFile(sceneState, assets)
 
-      // Generate game file
-      const gameFile: string = createGameFile(sceneState, assets)
+        // Prepare scene.json
+        const sceneJson = this.parcelIdentity.land.sceneJsonData
 
-      // Prepare scene.json
-      const sceneJson = this.parcelIdentity.land.sceneJsonData
+        // Group all entity files
+        const entityFiles: Map<string, Buffer> = new Map([
+          [CONTENT_PATH.DEFINITION_FILE, Buffer.from(JSON.stringify(storableFormat))],
+          [CONTENT_PATH.BUNDLED_GAME_FILE, Buffer.from(gameFile)],
+          [CONTENT_PATH.SCENE_FILE, Buffer.from(JSON.stringify(sceneJson))],
+          ...models
+        ])
 
-      // Group all entity files
-      const entityFiles: Map<string, Buffer> = new Map([
-        [CONTENT_PATH.DEFINITION_FILE, Buffer.from(JSON.stringify(storableFormat))],
-        [CONTENT_PATH.BUNDLED_GAME_FILE, Buffer.from(gameFile)],
-        [CONTENT_PATH.SCENE_FILE, Buffer.from(JSON.stringify(sceneJson))],
-        ...models
-      ])
+        // Build the entity
+        const parcels = this.getParcels()
+        const { files, entityId } = await DeploymentBuilder.buildEntity(
+          EntityType.SCENE,
+          parcels,
+          entityFiles,
+          sceneJson
+        )
 
-      // Build the entity
-      const parcels = this.getParcels()
-      const { files, entityId } = await DeploymentBuilder.buildEntity(EntityType.SCENE, parcels, entityFiles, sceneJson)
+        // Sign entity id
+        const store: Store<RootState> = window['globalStore']
+        const identity = getCurrentIdentity(store.getState())
+        if (!identity) {
+          throw new Error('Identity not found when trying to deploy an entity')
+        }
+        const authChain = Authenticator.signPayload(identity, entityId)
 
-      // Sign entity id
-      const store: Store<RootState> = window['globalStore']
-      const identity = getCurrentIdentity(store.getState())
-      if (!identity) {
-        throw new Error('Identity not found when trying to deploy an entity')
+        // Deploy
+        const contentClient = this.getContentClient()
+        await contentClient.deployEntity({ files, entityId, authChain })
+
+        result = { ok: true }
+      } catch (error) {
+        defaultLogger.error('Deployment failed', error)
+        result = { ok: false, error: `${error}` }
       }
-      const authChain = Authenticator.signPayload(identity, entityId)
-
-      // Deploy
-      const contentClient = this.getContentClient()
-      await contentClient.deployEntity({ files, entityId, authChain })
-
-      return { ok: true }
-    } catch (error) {
-      defaultLogger.error('Deployment failed', error)
-      return { ok: false, error: `${error}` }
     }
+
+    unityInterface.SendPublishSceneResult(result)
+    return result
   }
 
   @exposeMethod

--- a/kernel/packages/shared/apis/SceneStateStorageController/SceneStateStorageController.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/SceneStateStorageController.ts
@@ -20,7 +20,6 @@ import { Store } from 'redux'
 import { RootState } from 'shared/store/rootTypes'
 import { getUpdateProfileServer } from 'shared/dao/selectors'
 import { createGameFile } from './SceneStateDefinitionCodeGenerator'
-import { unityInterface } from 'unity-interface/UnityInterface'
 
 declare const window: any
 
@@ -88,7 +87,7 @@ export class SceneStateStorageController extends ExposableAPI {
       }
     }
 
-    unityInterface.SendPublishSceneResult(result)
+    window.unityInterface.SendPublishSceneResult(result)
     return result
   }
 

--- a/kernel/packages/shared/comms/index.ts
+++ b/kernel/packages/shared/comms/index.ts
@@ -1,3 +1,4 @@
+import { setInterval } from 'timers'
 import {
   commConfigurations,
   parcelLimits,

--- a/kernel/packages/shared/comms/index.ts
+++ b/kernel/packages/shared/comms/index.ts
@@ -49,7 +49,6 @@ import {
   position2parcel,
   sameParcel,
   squareDistance,
-  ParcelArray,
   rotateUsingQuaternion
 } from './interface/utils'
 import { BrokerWorldInstanceConnection } from '../comms/v1/brokerWorldInstanceConnection'
@@ -62,7 +61,7 @@ import { LighthouseWorldInstanceConnection } from './v2/LighthouseWorldInstanceC
 
 import { Authenticator, AuthIdentity } from 'dcl-crypto'
 import { getCommsServer, getRealm, getAllCatalystCandidates } from '../dao/selectors'
-import { Realm, LayerUserInfo } from 'shared/dao/types'
+import { Realm } from 'shared/dao/types'
 import { Store } from 'redux'
 import { RootState } from 'shared/store/rootTypes'
 import { store } from 'shared/store/store'
@@ -1267,21 +1266,6 @@ export function disconnect() {
       context.worldInstanceConnection.close()
     }
   }
-}
-
-export async function fetchLayerUsersParcels(): Promise<ParcelArray[]> {
-  const realm = getRealm(store.getState())
-  const commsUrl = getCommsServer(store.getState())
-
-  if (realm && realm.layer && commsUrl) {
-    const layerUsersResponse = await fetch(`${commsUrl}/layers/${realm.layer}/users`)
-    if (layerUsersResponse.ok) {
-      const layerUsers: LayerUserInfo[] = await layerUsersResponse.json()
-      return layerUsers.filter((it) => it.parcel).map((it) => it.parcel!)
-    }
-  }
-
-  return []
 }
 
 globalThis.printCommsInformation = function () {

--- a/kernel/packages/shared/types.ts
+++ b/kernel/packages/shared/types.ts
@@ -65,7 +65,6 @@ export type EntityActionType =
   | 'InitMessagesFinished'
   | 'OpenExternalUrl'
   | 'OpenNFTDialog'
-  | 'PublishSceneResult'
 
 export type QueryPayload = { queryId: string; payload: RayQuery }
 

--- a/kernel/packages/shared/world/TeleportController.ts
+++ b/kernel/packages/shared/world/TeleportController.ts
@@ -2,7 +2,6 @@ import { parcelLimits } from 'config'
 
 import { lastPlayerPosition, teleportObservable } from 'shared/world/positionThings'
 import { POIs } from 'shared/comms/POIs'
-import { store } from 'shared/store/store'
 import { countParcelsCloseTo, ParcelArray } from 'shared/comms/interface/utils'
 import defaultLogger from 'shared/logger'
 import { ensureUnityInterface } from 'shared/renderer'
@@ -170,8 +169,8 @@ export class TeleportController {
 }
 
 async function fetchLayerUsersParcels(): Promise<ParcelArray[]> {
-  const realm = getRealm(store.getState())
-  const commsUrl = getCommsServer(store.getState())
+  const realm = getRealm(globalThis.globalStore.getState())
+  const commsUrl = getCommsServer(globalThis.globalStore.getState())
 
   if (realm && realm.layer && commsUrl) {
     const layerUsersResponse = await fetch(`${commsUrl}/layers/${realm.layer}/users`)

--- a/kernel/packages/unity-interface/UnityInterface.ts
+++ b/kernel/packages/unity-interface/UnityInterface.ts
@@ -24,6 +24,7 @@ import { HotSceneInfo } from 'shared/social/hotScenes'
 import { defaultLogger } from 'shared/logger'
 import { setDelightedSurveyEnabled } from './delightedSurvey'
 import { renderStateObservable } from '../shared/world/worldState'
+import { DeploymentResult } from '../shared/apis/SceneStateStorageController/types'
 
 const MINIMAP_CHUNK_SIZE = 100
 
@@ -413,6 +414,10 @@ export class UnityInterface {
 
   public UpdateRealmsInfo(realmsInfo: Partial<RealmsInfoForRenderer>) {
     this.gameInstance.SendMessage('Bridges', 'UpdateRealmsInfo', JSON.stringify(realmsInfo))
+  }
+
+  public SendPublishSceneResult(result: DeploymentResult) {
+    this.gameInstance.SendMessage('Main', 'PublishSceneResult', JSON.stringify(result))
   }
 
   // *********************************************************************************

--- a/kernel/packages/unity-interface/delightedSurvey.ts
+++ b/kernel/packages/unity-interface/delightedSurvey.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'timers'
 import { defaultLogger } from 'shared/logger'
 import { getCurrentUserProfile } from 'shared/profiles/selectors'
 import { StoreContainer } from 'shared/store/rootTypes'


### PR DESCRIPTION
In https://github.com/decentraland/explorer/pull/1792, we started returning the result of the publish action to the renderer. However, this was done by sending a new `EntityAction` through the scene's messages.

This proved to be a mistake at this point. Scene messages need to be sent via native messages or protocol buffer, they can't be plain JSON. Also, this messages are received, decoded and interpreted by the SceneController, which is not what we wanted for this particular action. 

We tried to come up with a generic way to re-route messages that are sent this way, but this already exists by using the `UnityInterface`. For all these reasons, we are now sending the message directly from the controller.