### PR TITLE
fix: avoid weird getSceneIds error in preview mode

### DIFF
--- a/kernel/packages/shared/world/sceneState.ts
+++ b/kernel/packages/shared/world/sceneState.ts
@@ -1,3 +1,4 @@
+import { WORLD_EXPLORER } from 'config'
 import { Observable } from 'decentraland-ecs/src/ecs/Observable'
 import { fetchSceneIds } from 'decentraland-loader/lifecycle/utils/fetchSceneIds'
 import { fetchSceneJson } from 'decentraland-loader/lifecycle/utils/fetchSceneJson'
@@ -15,16 +16,19 @@ export type SceneReport = {
 export const sceneObservable = new Observable<SceneReport>()
 export let lastPlayerScene: ILand
 
-// Listen to parcel changes, and notify if the scene changed
-parcelObservable.add(async ({ newParcel }) => {
-  const parcelString = `${newParcel.x},${newParcel.y}`
-  if (!lastPlayerScene || !lastPlayerScene.sceneJsonData.scene.parcels.includes(parcelString)) {
-    const scenesId = await fetchSceneIds([parcelString])
-    const sceneId = scenesId[0]
-    if (sceneId) {
-      const land = (await fetchSceneJson([sceneId]))[0]
-      sceneObservable.notifyObservers({ previousScene: lastPlayerScene, newScene: land })
-      lastPlayerScene = land
+// TODO: fetchSceneIds and fetchSceneJson don't work on preview mode, so we are disabling this for now. We need to figure out a way to make those queries in a way that they work in preview mode also
+if (WORLD_EXPLORER) {
+  // Listen to parcel changes, and notify if the scene changed
+  parcelObservable.add(async ({ newParcel }) => {
+    const parcelString = `${newParcel.x},${newParcel.y}`
+    if (!lastPlayerScene || !lastPlayerScene.sceneJsonData.scene.parcels.includes(parcelString)) {
+      const scenesId = await fetchSceneIds([parcelString])
+      const sceneId = scenesId[0]
+      if (sceneId) {
+        const land = (await fetchSceneJson([sceneId]))[0]
+        sceneObservable.notifyObservers({ previousScene: lastPlayerScene, newScene: land })
+        lastPlayerScene = land
+      }
     }
-  }
-})
+  })
+}


### PR DESCRIPTION
We are seeing a weird error when a scene loads in preview mode:
```
preview.js:40 Uncaught (in promise) TypeError: Cannot read property 'getSceneIds' of undefined
    at Object.t.fetchSceneIds (preview.js:40)
    at i.callback (preview.js:51)
    at s.notifyObservers (preview.js:23)
    at i.callback (preview.js:23)
    at s.notifyObservers (preview.js:23)
    at H.ReportPosition (preview.js:51)
    at Object.onMessage (preview.js:40)
    at preview.js:46
````

The problem seems to be that `fetchSceneIds` and `fetchSceneJson` call the lifecycle worker, but it never starts during preview mode. We are now removing this error, but we will need to figure out how to perform these calls in preview mode also.