### PR TITLE
fix: SettingsPanelHUD - The control labels don't initialize correctly

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Scripts/ControlsModule/SliderSettingsControlView.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Scripts/ControlsModule/SliderSettingsControlView.cs
@@ -24,6 +24,8 @@ namespace DCL.SettingsPanelHUD.Controls
             slider.wholeNumbers = this.sliderControlConfig.sliderWholeNumbers;
 
             base.Initialize(controlConfig, settingsControlController);
+            OverrideIndicatorLabel(slider.value.ToString());
+            settingsControlController.OnControlChanged(slider.value);
 
             slider.onValueChanged.AddListener(sliderValue =>
             {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Scripts/ControlsModule/SpinBoxSettingsControlView.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Scripts/ControlsModule/SpinBoxSettingsControlView.cs
@@ -16,6 +16,7 @@ namespace DCL.SettingsPanelHUD.Controls
             SetLabels(((SpinBoxControlModel)controlConfig).spinBoxLabels);
 
             base.Initialize(controlConfig, settingsControlController);
+            settingsControlController.OnControlChanged(spinBox.value);
 
             spinBox.onValueChanged.AddListener(spinBoxValue =>
             {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Scripts/ControlsModule/ToggleSettingsControlView.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/SettingsPanelHUD/Scripts/ControlsModule/ToggleSettingsControlView.cs
@@ -15,6 +15,7 @@ namespace DCL.SettingsPanelHUD.Controls
         public override void Initialize(SettingsControlModel controlConfig, SettingsControlController settingsControlController)
         {
             base.Initialize(controlConfig, settingsControlController);
+            settingsControlController.OnControlChanged(toggle.isOn);
 
             toggle.onValueChanged.AddListener(isOn =>
             {


### PR DESCRIPTION
The labels associated to each settings control was not being initialized with the correct string value.

![image](https://user-images.githubusercontent.com/64659061/102384244-c40d0d00-3fcc-11eb-942f-ef037a0fb311.png)