### PR TITLE
chore: handle video playing as a promise

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Video/Plugins/WebVideoPlayer.jslib
@@ -142,7 +142,17 @@ var WebVideoPlayer = {
       if (videoData.hlsInstance !== undefined) {
         videoData.hlsInstance.attachMedia(videoData.video);
       }
-      videoData.video.play();
+
+      const playPromise = videoData.video.play();
+      if (playPromise !== undefined) {
+          playPromise.then(function () {
+            // Playback starts with no problem
+          })
+          .catch(function (error) {
+            // Playback cancelled before the video finished loading (e.g. when teleporting)
+            // we mustn't report this error as it's harmless and affects our metrics
+          });
+        }
     } catch (err) {
       // Exception!
     }


### PR DESCRIPTION
**WHY**
When a video player in-world hasn't finished loading the video and the user teleports, we get a harmless error that is affecting our metrics: `Uncaught (in promise) DOMException: The play() request was interrupted by a new load request.`.
That is due to the `video.play()` being a promise that is getting aborted when teleporting.

**WHAT**
Added promise handling for the `video.play()` to avoid the harmless error.

----------------------------------------------------------
In case you want to check it out in the browser's console:

1. Enter https://play.decentraland.org/?position=35%2C-29
2. Enter the "NFT42" building and stand next to the big screen at the stage
3. Teleport somewhere else
4. You'll see the error in the console

If you repeat those same steps with [the build from this PR](https://explorer.decentraland.zone/branch/chore/HandleVideoPlayAsPromise/index.html?ENV=org&position=35%2C-29), you'll see the error is not there.

Additionally, you can check that video playing still works with the videos at maker's place gallery
https://explorer.decentraland.zone/branch/chore/HandleVideoPlayAsPromise/index.html?ENV=org&position=56%2C99