### PR TITLE
fix: Do not show voice chat tooltip if the feature is disabled

### DIFF
--- a/unity-client/Assets/Tutorial/Scripts/TutorialController.cs
+++ b/unity-client/Assets/Tutorial/Scripts/TutorialController.cs
@@ -183,8 +183,7 @@ namespace DCL.Tutorial
         public void SetTutorialEnabledForUsersThatAlreadyDidTheTutorial()
         {
             // TODO (Santi): This a TEMPORAL fix. It will be removed when we refactorize the tutorial system in order to make it compatible with incremental features.
-            if (PlayerPrefs.GetInt(PLAYER_PREFS_VOICE_CHAT_FEATURE_SHOWED) == 1 ||
-                CommonScriptableObjects.voiceChatDisabled.Get())
+            if (PlayerPrefs.GetInt(PLAYER_PREFS_VOICE_CHAT_FEATURE_SHOWED) == 1)
                 return;
 
             SetupTutorial(false.ToString(), TutorialType.Initial, true);
@@ -454,6 +453,11 @@ namespace DCL.Tutorial
             for (int i = startingStepIndex; i < steps.Count; i++)
             {
                 var stepPrefab = steps[i];
+
+                // TODO (Santi): This a TEMPORAL fix. It will be removed when we refactorize the tutorial system in order to make it compatible with incremental features.
+                if (stepPrefab is TutorialStep_Tooltip_UsersAround &&
+                    CommonScriptableObjects.voiceChatDisabled.Get())
+                    continue;
 
                 if (stepPrefab.letInstantiation)
                     runningStep = Instantiate(stepPrefab, this.transform).GetComponent<TutorialStep>();


### PR DESCRIPTION
Do not show voice chat tooltip if the feature is disabled.

The check was being done only for users that already saw the tutorial, but not for those who have to do the tutorial from the beginning.