### PR TITLE
fix: World Chat Window is being hidden when click on the world

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Resources/World Chat Window.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/WorldChatWindowHUD/Resources/World Chat Window.prefab
@@ -1196,7 +1196,6 @@ GameObject:
   - component: {fileID: 5309770394841409927}
   - component: {fileID: 9066852120691048329}
   - component: {fileID: 6037274476719757411}
-  - component: {fileID: 6944842080470827101}
   m_Layer: 5
   m_Name: World Chat Window
   m_TagString: Untagged
@@ -1251,27 +1250,6 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
---- !u!223 &6944842080470827101
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8602856546858110084}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 2
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 1
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 25
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
 --- !u!1 &9148549031739847183
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity-client/Assets/Tutorial/Prefabs/Steps/InitialTutorial/TutorialStep_TaskbarTooltip_SocialFeatures.prefab
+++ b/unity-client/Assets/Tutorial/Prefabs/Steps/InitialTutorial/TutorialStep_TaskbarTooltip_SocialFeatures.prefab
@@ -403,7 +403,7 @@ Canvas:
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 25
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 3
   m_TargetDisplay: 0
 --- !u!114 &7166723591416357984
 MonoBehaviour:

--- a/unity-client/Assets/Tutorial/Scripts/Steps/Initial/TutorialStep_Tooltip_SocialFeatures.cs
+++ b/unity-client/Assets/Tutorial/Scripts/Steps/Initial/TutorialStep_Tooltip_SocialFeatures.cs
@@ -7,11 +7,18 @@ namespace DCL.Tutorial
     /// </summary>
     public class TutorialStep_Tooltip_SocialFeatures : TutorialStep_Tooltip
     {
+        private const int TEACHER_CANVAS_SORT_ORDER_START = 4;
+
         [SerializeField] InputAction_Hold voiceChatAction;
+
+        private int defaultTeacherCanvasSortOrder;
 
         public override void OnStepStart()
         {
             base.OnStepStart();
+
+            defaultTeacherCanvasSortOrder = tutorialController.teacherCanvas.sortingOrder;
+            tutorialController.SetTeacherCanvasSortingOrder(TEACHER_CANVAS_SORT_ORDER_START);
 
             if (tutorialController != null &&
                 tutorialController.hudController != null)
@@ -38,6 +45,8 @@ namespace DCL.Tutorial
         public override void OnStepFinished()
         {
             base.OnStepFinished();
+
+            tutorialController.SetTeacherCanvasSortingOrder(defaultTeacherCanvasSortOrder);
 
             if (tutorialController != null &&
                 tutorialController.hudController != null)


### PR DESCRIPTION
World Chat Window is being hidden when click on the world.

It started to happen when we changed the sorting order of the chat in order to not to overlap the new tutorial tooltip `TutorialStep_Tooltip_SocialFeatures`. So we have revert the changes in the chat prefab and have fixed the problem from the own step controller.