### PR TITLE
fix: Make the Backpack tutorial tooltip hides when the ProfileHUD is open

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUDController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUDController.cs
@@ -29,6 +29,9 @@ public class ProfileHUDController : IHUD
 
     public RectTransform backpackTooltipReference { get => view.backpackTooltipReference; }
 
+    public event Action OnOpen;
+    public event Action OnClose;
+
     public ProfileHUDController()
     {
         mouseCatcher = InitialSceneReferences.i?.mouseCatcher;
@@ -52,6 +55,8 @@ public class ProfileHUDController : IHUD
         view.buttonTermsOfServiceForNonConnectedWallets.onPointerDown += () => WebInterface.OpenURL(URL_TERMS_OF_USE);
         view.buttonPrivacyPolicyForNonConnectedWallets.onPointerDown += () => WebInterface.OpenURL(URL_PRIVACY_POLICY);
         view.inputName.onSubmit.AddListener(UpdateProfileName);
+        view.OnOpen += () => OnOpen?.Invoke();
+        view.OnClose += () => OnClose?.Invoke();
 
         manaCounterView = view.GetComponentInChildren<ManaCounterView>(true);
         if (manaCounterView)

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUDView.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUDView.cs
@@ -62,6 +62,9 @@ internal class ProfileHUDView : MonoBehaviour
     private UserProfile profile = null;
     private Regex nameRegex = null;
 
+    internal event Action OnOpen;
+    internal event Action OnClose;
+
     private void Awake()
     {
         closeActionDelegate = (x) => HideMenu();
@@ -102,6 +105,7 @@ internal class ProfileHUDView : MonoBehaviour
         {
             menuShowHideAnimator.Show();
             CommonScriptableObjects.isProfileHUDOpen.Set(true);
+            OnOpen?.Invoke();
         }
     }
 
@@ -111,6 +115,7 @@ internal class ProfileHUDView : MonoBehaviour
         {
             menuShowHideAnimator.Hide();
             CommonScriptableObjects.isProfileHUDOpen.Set(false);
+            OnClose?.Invoke();
         }
     }
 

--- a/unity-client/Assets/Tutorial/Scripts/Steps/Initial/TutorialStep_Tooltip_BackpackButton.cs
+++ b/unity-client/Assets/Tutorial/Scripts/Steps/Initial/TutorialStep_Tooltip_BackpackButton.cs
@@ -11,10 +11,10 @@ namespace DCL.Tutorial
 
             if (tutorialController != null &&
                 tutorialController.hudController != null &&
-                tutorialController.hudController.avatarEditorHud != null)
+                tutorialController.hudController.profileHud != null)
             {
-                tutorialController.hudController.avatarEditorHud.OnOpen += AvatarEditorHud_OnOpen;
-                tutorialController.hudController.avatarEditorHud.OnClose += AvatarEditorHud_OnClose;
+                tutorialController.hudController.profileHud.OnOpen += ProfileHud_OnOpen;
+                tutorialController.hudController.profileHud.OnClose += ProfileHud_OnClose;
             }
         }
 
@@ -24,10 +24,10 @@ namespace DCL.Tutorial
 
             if (tutorialController != null &&
                 tutorialController.hudController != null &&
-                tutorialController.hudController.avatarEditorHud != null)
+                tutorialController.hudController.profileHud != null)
             {
-                tutorialController.hudController.avatarEditorHud.OnOpen -= AvatarEditorHud_OnOpen;
-                tutorialController.hudController.avatarEditorHud.OnClose -= AvatarEditorHud_OnClose;
+                tutorialController.hudController.profileHud.OnOpen -= ProfileHud_OnOpen;
+                tutorialController.hudController.profileHud.OnClose -= ProfileHud_OnClose;
             }
         }
 
@@ -43,14 +43,14 @@ namespace DCL.Tutorial
             }
         }
 
-        private void AvatarEditorHud_OnOpen()
+        private void ProfileHud_OnOpen()
         {
             isRelatedFeatureActived = true;
             stepIsFinished = true;
             tutorialController.PlayTeacherAnimation(TutorialTeacher.TeacherAnimation.QuickGoodbye);
         }
 
-        private void AvatarEditorHud_OnClose()
+        private void ProfileHud_OnClose()
         {
             if (isRelatedFeatureActived)
                 isRelatedFeatureActived = false;


### PR DESCRIPTION
Make the Backpack tutorial tooltip hides directly when the ProfileHUD is open (before this change the tooltip was being hidden when we clicked on the ProfileHUD + clicked on the Backpack button).