### PR TITLE
feat: send parcels with access to the renderer

### DIFF
--- a/kernel/package-lock.json
+++ b/kernel/package-lock.json
@@ -2754,9 +2754,9 @@
       }
     },
     "decentraland-renderer": {
-      "version": "1.8.53550",
-      "resolved": "https://registry.npmjs.org/decentraland-renderer/-/decentraland-renderer-1.8.53550.tgz",
-      "integrity": "sha512-Beei4eUk6H6Cl3Aicp0Bhoouzqzr+ceHXopxh35hUlo4mCslYTPDx5JcZS0rTh8tNou8RAZgPpUG6Ghr/teC1w=="
+      "version": "1.8.57754",
+      "resolved": "https://registry.npmjs.org/decentraland-renderer/-/decentraland-renderer-1.8.57754.tgz",
+      "integrity": "sha512-GYA3WWGLtyR2+qVTuKvhwSSdhKwihzHGW/xTlyvBVn6biLxIccDLpIU4plpTg9NtS6LPM9xRA/RrPD0Y90p74A=="
     },
     "decentraland-rpc": {
       "version": "3.1.8",

--- a/kernel/package.json
+++ b/kernel/package.json
@@ -102,7 +102,7 @@
     "dcl-scene-writer": "^1.1.2",
     "dcl-social-client": "^1.3.10",
     "decentraland-katalyst-peer": "0.2.18",
-    "decentraland-renderer": "^1.8.53550",
+    "decentraland-renderer": "^1.8.57754",
     "decentraland-rpc": "^3.1.8",
     "devtools-protocol": "0.0.615714",
     "eth-connect": "^4.0.1",

--- a/kernel/packages/config/contracts.ts
+++ b/kernel/packages/config/contracts.ts
@@ -107,7 +107,12 @@ export const contracts = {
     'CZMercenaryMTZ': '0xc3ca6c364b854fd0a653a43f8344f8c22ddfdd26',
     'WonderzoneSteampunk': '0xb96697fa4a3361ba35b774a42c58daccaad1b8e1',
     'DCNiftyblocksmith': '0x102daabd1e9d294d4436ec4c521dce7b1f15499e',
-    'Halloween2020Collection': '0xfeb52cbf71b9adac957c6f948a6cf9980ac8c907'
+    'Halloween2020Collection': '0xfeb52cbf71b9adac957c6f948a6cf9980ac8c907',
+    'Xmas2020Collection': '0xecf073f91101ce5628669c487aee8f5822a101b1',
+    'MemeDontBuyThis': '0x1a57f6afc902d25792c53b8f19b7e17ef84222d5',
+    'ReleaseTheKraken': '0xffc5043d9a00865d089d5eefa5b3d1625aec6763',
+    '3LAUBasics': '0xe1ecb4e5130f493551c7d6df96ad19e5b431a0a9',
+    'XmashUp2020': '0xdd9c7bc159dacb19c9f6b9d7e23948c87aa2397f'
   },
   'kovan': {
     'MANAToken': '0x230fc362413d9e862326c2c7084610a5a2fdf78a',

--- a/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
@@ -331,7 +331,7 @@ export interface IEvents {
 
   // @internal
   stateEvent: {
-    type: string,
+    type: string
     payload: any
   }
 }
@@ -430,6 +430,18 @@ export type ProfileForRenderer = {
   hasConnectedWeb3: boolean
   updatedAt?: number
   createdAt?: number
+  parcelsWithAccess?: ParcelsWithAccess
+}
+
+export type ParcelsWithAccess = {
+  x: number
+  y: number
+  role: LandRole
+}[]
+
+export enum LandRole {
+  OWNER = 'owner',
+  OPERATOR = 'operator'
 }
 
 /**

--- a/kernel/packages/shared/comms/peers.ts
+++ b/kernel/packages/shared/comms/peers.ts
@@ -117,7 +117,7 @@ export function receiveUserData(uuid: string, data: Partial<UserInformation>) {
             type: AvatarMessageType.USER_DATA,
             uuid,
             data,
-            profile: profileToRendererFormat(profile, userData.identity)
+            profile: profileToRendererFormat(profile, { identity: userData.identity })
           })
         }
       })().catch((e) => {

--- a/kernel/packages/shared/profiles/fetchLand.ts
+++ b/kernel/packages/shared/profiles/fetchLand.ts
@@ -185,7 +185,7 @@ type EstateFields = {
  * This function returns all Lands (parcel or estates) that the address has access to.
  * If the address has access to 2 parcels and 2 estates (which each if composed of 3 parcels), 4 Land will be returned.
  *
- * IMPORTANT: based on a the graph restriction, estates that will only return 1000 parcels they are composed of. This might become a problem in the future.
+ * IMPORTANT: based on a restriction in the graph, estates that will only return 1000 parcels they are composed of. This might become a problem in the future.
  */
 async function fetchLand(_address: string): Promise<Land[]> {
   const address = _address.toLowerCase()

--- a/kernel/packages/shared/profiles/fetchLand.ts
+++ b/kernel/packages/shared/profiles/fetchLand.ts
@@ -1,0 +1,290 @@
+import { Fetcher } from 'dcl-catalyst-commons'
+import { decentralandConfigurations, getDefaultTLD } from 'config'
+import { LandRole, ParcelsWithAccess } from 'decentraland-ecs/src'
+
+const getLandQuery = () => `
+  query Land($address: Bytes) {
+    ownerParcels: parcels(first: 1000, where: { estate: null, owner: $address }) {
+      ...parcelFields
+    }
+    ownerEstates: estates(first: 1000, where: { owner: $address }) {
+      ...estateFields
+    }
+    updateOperatorParcels: parcels(first: 1000, where: { updateOperator: $address }) {
+      ...parcelFields
+    }
+    updateOperatorEstates: estates(first: 1000, where: { updateOperator: $address }) {
+      ...estateFields
+    }
+    ownerAuthorizations: authorizations(first: 1000, where: { owner: $address, type: "UpdateManager" }) {
+      operator
+      isApproved
+      tokenAddress
+    }
+    operatorAuthorizations: authorizations(first: 1000, where: { operator: $address, type: "UpdateManager" }) {
+      owner {
+        address
+        parcels(where: { estate: null }) {
+          ...parcelFields
+        }
+        estates {
+          ...estateFields
+        }
+      }
+      isApproved
+      tokenAddress
+    }
+  }
+  fragment parcelFields on Parcel {
+    x
+    y
+    tokenId
+    owner {
+      address
+    }
+    updateOperator
+    data {
+      name
+      description
+    }
+  }
+  fragment estateFields on Estate {
+    id
+    owner {
+      address
+    }
+    updateOperator
+    size
+    parcels {
+      x
+      y
+      tokenId
+    }
+    data {
+      name
+      description
+    }
+  }
+`
+
+type LandQueryResult = {
+  ownerParcels: ParcelFields[]
+  ownerEstates: EstateFields[]
+  updateOperatorParcels: ParcelFields[]
+  updateOperatorEstates: EstateFields[]
+  ownerAuthorizations: { operator: string; isApproved: boolean; tokenAddress: string }[]
+  operatorAuthorizations: {
+    owner: { address: string; parcels: ParcelFields[]; estates: EstateFields[] }
+    isApproved: boolean
+    tokenAddress: string
+  }[]
+}
+
+const fromParcel = (parcel: ParcelFields, role: LandRole) => {
+  const id = coordsToId(parcel.x, parcel.y)
+
+  const result: Land = {
+    id,
+    name: (parcel.data && parcel.data.name) || `Parcel ${id}`,
+    type: LandType.PARCEL,
+    role,
+    description: (parcel.data && parcel.data.description) || null,
+    x: parseInt(parcel.x, 10),
+    y: parseInt(parcel.y, 10),
+    owner: parcel.owner.address,
+    operators: []
+  }
+
+  if (parcel.updateOperator) {
+    result.operators.push(parcel.updateOperator)
+  }
+
+  return result
+}
+
+const fromEstate = (estate: EstateFields, role: LandRole) => {
+  const id = estate.id
+
+  const result: Land = {
+    id,
+    name: (estate.data && estate.data.name) || `Estate ${id}`,
+    type: LandType.ESTATE,
+    role,
+    description: (estate.data && estate.data.description) || null,
+    size: estate.size,
+    parcels: estate.parcels.map((parcel) => ({
+      x: parseInt(parcel.x, 10),
+      y: parseInt(parcel.y, 10),
+      id: coordsToId(parcel.x, parcel.y)
+    })),
+    owner: estate.owner.address,
+    operators: []
+  }
+
+  if (estate.updateOperator) {
+    result.operators.push(estate.updateOperator)
+  }
+
+  return result
+}
+
+export async function fetchParcelsWithAccess(_address: string): Promise<ParcelsWithAccess> {
+  const result: ParcelsWithAccess = []
+  const lands = await fetchLand(_address)
+  lands.forEach((land) => {
+    if (land.type === LandType.PARCEL) {
+      result.push({ x: land.x!, y: land.y!, role: land.role })
+    } else {
+      result.push(...land.parcels!.map(({ x, y }) => ({ x, y, role: land.role })))
+    }
+  })
+  return result
+}
+
+/**
+ * This function returns all Lands (parcel or estates) that the address has access to.
+ * If the address has access to 2 parcels and 2 estates (which each if composed of 3 parcels), 4 Land will be returned.
+ *
+ * IMPORTANT: based on a the graph restriction, estates that will only return 1000 parcels they are composed of. This might become a problem in the future.
+ */
+async function fetchLand(_address: string): Promise<Land[]> {
+  const address = _address.toLowerCase()
+  const fetcher = new Fetcher()
+
+  const landManagerUrl =
+    getDefaultTLD() === 'org'
+      ? 'https://api.thegraph.com/subgraphs/name/decentraland/land-manager'
+      : 'https://api.thegraph.com/subgraphs/name/decentraland/land-manager-ropsten'
+
+  const data = await fetcher.queryGraph<LandQueryResult>(landManagerUrl, getLandQuery(), { address })
+
+  const lands: Land[] = []
+  const landUpdateManagers = new Set<string>()
+  const estateUpdateManagers = new Set<string>()
+
+  // parcels and estates that I own
+  for (const parcel of data.ownerParcels) {
+    lands.push(fromParcel(parcel, LandRole.OWNER))
+  }
+  for (const estate of data.ownerEstates) {
+    lands.push(fromEstate(estate, LandRole.OWNER))
+  }
+
+  // parcels and estats that I operate
+  for (const parcel of data.updateOperatorParcels) {
+    lands.push(fromParcel(parcel, LandRole.OPERATOR))
+  }
+  for (const estate of data.updateOperatorEstates) {
+    lands.push(fromEstate(estate, LandRole.OPERATOR))
+  }
+
+  // addresses I gave UpdateManager permission are operators of all my lands
+  for (const authorization of data.ownerAuthorizations) {
+    const { operator, isApproved, tokenAddress } = authorization
+    switch (tokenAddress) {
+      case decentralandConfigurations.LANDProxy: {
+        if (isApproved) {
+          landUpdateManagers.add(operator)
+        } else {
+          landUpdateManagers.delete(operator)
+        }
+        break
+      }
+      case decentralandConfigurations.EstateProxy: {
+        if (isApproved) {
+          estateUpdateManagers.add(operator)
+        } else {
+          estateUpdateManagers.delete(operator)
+        }
+        break
+      }
+    }
+  }
+
+  // I'm operator of all the lands from addresses that gave me UpdateManager permission
+  for (const authorization of data.operatorAuthorizations) {
+    const { owner } = authorization
+    for (const parcel of owner.parcels) {
+      const land = fromParcel(parcel, LandRole.OPERATOR)
+      land.operators.push(address)
+      // skip if already owned or operated
+      if (!lands.some((_land) => _land.id === land.id)) {
+        lands.push(land)
+      }
+    }
+    for (const estate of owner.estates) {
+      if (estate.parcels.length > 0) {
+        const land = fromEstate(estate, LandRole.OPERATOR)
+        land.operators.push(address)
+        // skip if already owned or operated
+        if (!lands.some((_land) => _land.id === land.id)) {
+          lands.push(land)
+        }
+      }
+    }
+  }
+
+  return (
+    lands
+      // remove empty estates
+      .filter((land) => land.type === LandType.PARCEL || land.parcels!.length > 0)
+      // remove duplicated and zero address operators
+      .map((land) => {
+        land.operators = Array.from(new Set(land.operators)).filter((address) => !isZero(address))
+        return land
+      })
+  )
+}
+
+const coordsToId = (x: string | number, y: string | number) => x + ',' + y
+
+const isZero = (addr: string) => {
+  return /^0x(0)+$/.test(addr)
+}
+
+enum LandType {
+  PARCEL = 'parcel',
+  ESTATE = 'estate'
+}
+
+type Land = {
+  id: string
+  type: LandType
+  role: LandRole
+  x?: number
+  y?: number
+  parcels?: { x: number; y: number; id: string }[]
+  size?: number
+  name: string
+  description: string | null
+  owner: string
+  operators: string[]
+}
+
+type ParcelFields = {
+  x: string
+  y: string
+  tokenId: string
+  owner: {
+    address: string
+  }
+  updateOperator: string | null
+  data: {
+    name: string | null
+    description: string | null
+  } | null
+}
+
+type EstateFields = {
+  id: string
+  owner: {
+    address: string
+  }
+  updateOperator: string | null
+  size: number
+  parcels: Pick<ParcelFields, 'x' | 'y' | 'tokenId'>[]
+  data: {
+    name: string | null
+    description: string | null
+  } | null
+}

--- a/kernel/packages/shared/profiles/sagas.ts
+++ b/kernel/packages/shared/profiles/sagas.ts
@@ -404,7 +404,7 @@ function* sendLoadProfile(profile: Profile) {
   yield call(ensureBaseCatalogs)
 
   const identity = yield select(getCurrentIdentity)
-  const parcels: ParcelsWithAccess = identity.hasConnectedWeb3 ? yield fetchParcelsWithAccess(identity.address) : []
+  const parcels: ParcelsWithAccess = !identity.hasConnectedWeb3 ? [] : yield fetchParcelsWithAccess(identity.address)
   const rendererFormat = profileToRendererFormat(profile, { identity, parcels })
   globalThis.unityInterface.LoadProfile(rendererFormat)
 }

--- a/kernel/packages/shared/profiles/sagas.ts
+++ b/kernel/packages/shared/profiles/sagas.ts
@@ -70,6 +70,7 @@ import { getProfileType } from './getProfileType'
 import { ReportFatalError } from 'shared/loading/ReportFatalError'
 import { UNEXPECTED_ERROR } from 'shared/loading/types'
 import { fetchParcelsWithAccess } from './fetchLand'
+import { ParcelsWithAccess } from 'decentraland-ecs/src'
 
 const CID = require('cids')
 const multihashing = require('multihashing-async')
@@ -403,7 +404,7 @@ function* sendLoadProfile(profile: Profile) {
   yield call(ensureBaseCatalogs)
 
   const identity = yield select(getCurrentIdentity)
-  const parcels = yield fetchParcelsWithAccess(identity.address)
+  const parcels: ParcelsWithAccess = identity.hasConnectedWeb3 ? yield fetchParcelsWithAccess(identity.address) : []
   const rendererFormat = profileToRendererFormat(profile, { identity, parcels })
   globalThis.unityInterface.LoadProfile(rendererFormat)
 }

--- a/kernel/packages/shared/profiles/sagas.ts
+++ b/kernel/packages/shared/profiles/sagas.ts
@@ -69,6 +69,7 @@ import { LocalProfilesRepository } from './LocalProfilesRepository'
 import { getProfileType } from './getProfileType'
 import { ReportFatalError } from 'shared/loading/ReportFatalError'
 import { UNEXPECTED_ERROR } from 'shared/loading/types'
+import { fetchParcelsWithAccess } from './fetchLand'
 
 const CID = require('cids')
 const multihashing = require('multihashing-async')
@@ -402,7 +403,8 @@ function* sendLoadProfile(profile: Profile) {
   yield call(ensureBaseCatalogs)
 
   const identity = yield select(getCurrentIdentity)
-  const rendererFormat = profileToRendererFormat(profile, identity)
+  const parcels = yield fetchParcelsWithAccess(identity.address)
+  const rendererFormat = profileToRendererFormat(profile, { identity, parcels })
   globalThis.unityInterface.LoadProfile(rendererFormat)
 }
 

--- a/kernel/packages/shared/profiles/transformations/profileToRendererFormat.ts
+++ b/kernel/packages/shared/profiles/transformations/profileToRendererFormat.ts
@@ -1,5 +1,5 @@
 import { Profile } from '../types'
-import { ProfileForRenderer } from 'decentraland-ecs/src'
+import { ParcelsWithAccess, ProfileForRenderer } from 'decentraland-ecs/src'
 import { convertToRGBObject } from './convertToRGBObject'
 import { dropDeprecatedWearables } from './processServerProfile'
 import { ExplorerIdentity } from 'shared/session/types'
@@ -9,20 +9,24 @@ const profileDefaults = {
   tutorialStep: 0
 }
 
-export function profileToRendererFormat(profile: Profile, identity?: ExplorerIdentity): ProfileForRenderer {
+export function profileToRendererFormat(
+  profile: Profile,
+  options?: { identity?: ExplorerIdentity; parcels?: ParcelsWithAccess }
+): ProfileForRenderer {
   const { snapshots, ...rendererAvatar } = profile.avatar
   return {
     ...profileDefaults,
     ...profile,
     snapshots: prepareSnapshots(snapshots ?? profile.snapshots),
-    hasConnectedWeb3: identity ? identity.hasConnectedWeb3 : false,
+    hasConnectedWeb3: options?.identity ? options.identity.hasConnectedWeb3 : false,
     avatar: {
       ...rendererAvatar,
       wearables: profile.avatar.wearables.filter(dropDeprecatedWearables),
       eyeColor: convertToRGBObject(profile.avatar.eyeColor),
       hairColor: convertToRGBObject(profile.avatar.hairColor),
       skinColor: convertToRGBObject(profile.avatar.skinColor)
-    }
+    },
+    parcelsWithAccess: options?.parcels
   }
 }
 


### PR DESCRIPTION
When the client starts, we are now querying all parcels the logged in user has access to. Then, we are sending this new data to the renderer.