### PR TITLE
fix: scene doesn't load when exiting stateful mode

### DIFF
--- a/kernel/packages/decentraland-loader/lifecycle/controllers/scene.ts
+++ b/kernel/packages/decentraland-loader/lifecycle/controllers/scene.ts
@@ -50,6 +50,7 @@ export class SceneLifeCycleController extends EventEmitter {
 
       // Unload and re-load scenes
       this.emit('Unload scene', sceneId)
+      this.sceneStatus.delete(sceneId)
       const newScenes = await this.fetchSceneIds(parcels)
       await this.startSceneLoading(newScenes)
     }


### PR DESCRIPTION
Right now, when a user enters into edit mode, they can publish a new scene or they can go back without making changes.
If they did publish a new scene, when they exited edit mode, it would load correctly. However, if they went back without publishing, the scene would never load.

By taking a look at the code, we realized that this was because the scene already had an "active" state assigned to its id, so it wouldn't load again. When unloading the scene, we are now deleting the "active" state, so it then loads normally.

Note: it worked when a new scene was published, because the scene id would be different.