### PR TITLE
fix: animation culling issue

### DIFF
--- a/unity-client/Assets/Rendering/Culling/CullingControllerSettings.cs
+++ b/unity-client/Assets/Rendering/Culling/CullingControllerSettings.cs
@@ -11,7 +11,7 @@ namespace DCL.Rendering
         [NonSerialized] public float maxTimeBudget = 4 / 1000f;
         public bool enableObjectCulling = true;
         public bool enableShadowCulling = true;
-        public bool enableAnimationCulling = true;
+        public bool enableAnimationCulling = false;
 
         public float enableAnimationCullingDistance = 7.5f;
 

--- a/unity-client/Assets/Rendering/Culling/Tests/CullingControllerShould.cs
+++ b/unity-client/Assets/Rendering/Culling/Tests/CullingControllerShould.cs
@@ -29,7 +29,7 @@ namespace CullingControllerTests
                 settings ?? new CullingControllerSettings(),
                 cullingObjectsTracker ?? new CullingObjectsTracker());
 
-            result.SetSettings(new CullingControllerSettings() { maxTimeBudget = float.MaxValue });
+            result.SetSettings(new CullingControllerSettings() {maxTimeBudget = float.MaxValue});
 
             return result;
         }
@@ -139,6 +139,7 @@ namespace CullingControllerTests
 
             var settings = new CullingControllerSettings();
             settings.enableAnimationCullingDistance = 20;
+            settings.enableAnimationCulling = true;
 
             // Act
             var farTest = CullingControllerUtils.TestSkinnedRendererOffscreenRule(settings, 30);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main.cs
@@ -41,6 +41,8 @@ namespace DCL
             RenderProfileManifest.i.Initialize();
             Environment.i.Initialize();
 
+            // TODO(Brian): This is a temporary fix to address elevators issue in the xmas event.
+            // We should re-enable this later as produces a performance regression.
             if (!Configuration.EnvironmentSettings.RUNNING_TESTS)
                 Environment.i.cullingController.SetAnimationCulling(false);
         }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main.cs
@@ -40,6 +40,9 @@ namespace DCL
 
             RenderProfileManifest.i.Initialize();
             Environment.i.Initialize();
+
+            if (!Configuration.EnvironmentSettings.RUNNING_TESTS)
+                Environment.i.cullingController.SetAnimationCulling(false);
         }
 
         private void Start()


### PR DESCRIPTION
some animations are being culled even though they look close enough to avoid culling, it's probably due to a far away pivot point.

The problem is described here: https://app.zenhub.com/workspaces/explorer-5dc988c462b0b700019b0b42/issues/decentraland/explorer/1874