### PR TITLE
fix: misc fixes in components (2)

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioClip.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioClip.cs
@@ -22,6 +22,7 @@ namespace DCL.Components
 
         public Model model;
         public AudioClip audioClip;
+        private bool isDisposed = false;
 
         public enum LoadState
         {
@@ -108,6 +109,11 @@ namespace DCL.Components
         {
             yield return new WaitUntil(() => CommonScriptableObjects.rendererState.Get());
 
+            //If the scene creates and destroy the component before our renderer has been turned on bad things happen!
+            //TODO: Analyze if we can catch this upstream and stop the IEnumerator
+            if(isDisposed)
+                yield break;
+
             model = Utils.SafeFromJson<Model>(newJson);
 
             if (!string.IsNullOrEmpty(model.url))
@@ -127,6 +133,7 @@ namespace DCL.Components
 
         public override void Dispose()
         {
+            isDisposed = true;
             Utils.SafeDestroy(audioClip);
             base.Dispose();
         }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioSource.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioSource.cs
@@ -22,6 +22,8 @@ namespace DCL.Components
         internal AudioSource audioSource;
         DCLAudioClip lastDCLAudioClip;
 
+        private bool isDestroyed = false;
+
         private void Awake()
         {
             audioSource = gameObject.GetOrCreateComponent<AudioSource>();
@@ -45,6 +47,11 @@ namespace DCL.Components
         public override IEnumerator ApplyChanges(string newJson)
         {
             yield return new WaitUntil(() => CommonScriptableObjects.rendererState.Get());
+
+            //If the scene creates and destroy an audiosource before our renderer has been turned on bad things happen!
+            //TODO: Analyze if we can catch this upstream and stop the IEnumerator
+            if (isDestroyed)
+                yield break;
 
             model = Utils.SafeFromJson<Model>(newJson);
 
@@ -113,6 +120,7 @@ namespace DCL.Components
 
         private void OnDestroy()
         {
+            isDestroyed = true;
             CommonScriptableObjects.sceneID.OnChange -= OnCurrentSceneChanged;
 
             //NOTE(Brian): Unsuscribe events.

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioSource.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioSource.cs
@@ -107,7 +107,8 @@ namespace DCL.Components
 
         private void OnCurrentSceneChanged(string currentSceneId, string previousSceneId)
         {
-            audioSource.volume = (scene.sceneData.id == currentSceneId) ? model.volume : 0f;
+            if(audioSource != null)
+                audioSource.volume = (scene.sceneData.id == currentSceneId) ? model.volume : 0f;
         }
 
         private void OnDestroy()

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioStream.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Audio/DCLAudioStream.cs
@@ -17,6 +17,7 @@ namespace DCL.Components
         public Model model;
         private bool isPlaying = false;
         private float settingsVolume = 0;
+        private bool isDestroyed = false;
 
         public override object GetModel()
         {
@@ -26,6 +27,11 @@ namespace DCL.Components
         public override IEnumerator ApplyChanges(string newJson)
         {
             yield return new WaitUntil(() => CommonScriptableObjects.rendererState.Get());
+
+            //If the scene creates and destroy the component before our renderer has been turned on bad things happen!
+            //TODO: Analyze if we can catch this upstream and stop the IEnumerator
+            if(isDestroyed)
+                yield break;
 
             Model prevModel = model;
             model = Utils.SafeFromJson<Model>(newJson);
@@ -47,6 +53,7 @@ namespace DCL.Components
 
         private void OnDestroy()
         {
+            isDestroyed = true;
             CommonScriptableObjects.sceneID.OnChange -= OnSceneChanged;
             CommonScriptableObjects.rendererState.OnChange -= OnRendererStateChanged;
             Settings.i.OnGeneralSettingsChanged -= OnSettingsChanged;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/LoadWrapper_GLTF.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadWrapper/LoadWrapper_GLTF.cs
@@ -46,7 +46,7 @@ namespace DCL.Components
             }
 
             loadHelper.OnSuccessEvent += (x) => OnSuccessWrapper(OnSuccess);
-            loadHelper.OnFailEvent += () => OnFailWrapper(OnSuccess);
+            loadHelper.OnFailEvent += () => OnFailWrapper(OnFail);
             loadHelper.Load(targetUrl);
         }
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Textures/DCLTexture.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Textures/DCLTexture.cs
@@ -32,6 +32,7 @@ namespace DCL
         public TextureWrapMode unityWrap;
         public FilterMode unitySamplingMode;
         public Texture2D texture;
+        protected bool isDisposed;
 
         public override int GetClassId()
         {
@@ -78,6 +79,11 @@ namespace DCL
         public override IEnumerator ApplyChanges(string newJson)
         {
             yield return new WaitUntil(() => CommonScriptableObjects.rendererState.Get());
+
+            //If the scene creates and destroy the component before our renderer has been turned on bad things happen!
+            //TODO: Analyze if we can catch this upstream and stop the IEnumerator
+            if(isDisposed)
+                yield break;
 
             model = Utils.SafeFromJson<Model>(newJson);
 
@@ -194,6 +200,7 @@ namespace DCL
 
         public override void Dispose()
         {
+            isDisposed = true;
             if (texturePromise != null)
             {
                 AssetPromiseKeeper_Texture.i.Forget(texturePromise);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Video/DCLVideoTexture.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Video/DCLVideoTexture.cs
@@ -49,6 +49,11 @@ namespace DCL.Components
         {
             yield return new WaitUntil(() => CommonScriptableObjects.rendererState.Get());
 
+            //If the scene creates and destroy the component before our renderer has been turned on bad things happen!
+            //TODO: Analyze if we can catch this upstream and stop the IEnumerator
+            if(isDisposed)
+                yield break;
+
             model = Utils.SafeFromJson<Model>(newJson);
 
             unitySamplingMode = model.samplingMode;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/MaterialHelpers/MaterialCachingHelper/MaterialCachingHelper.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/MaterialHelpers/MaterialCachingHelper/MaterialCachingHelper.cs
@@ -141,7 +141,8 @@ namespace DCL.Helpers
                     }
                 }
 
-                r.sharedMaterials = matList.ToArray();
+                if(r != null)
+                    r.sharedMaterials = matList.ToArray();
             }
         }
     }


### PR DESCRIPTION
Some miscellaneous fixes.

- Fail flow in GLTF now is triggered properly.
- Issues when a `DCLAudioSource` is created and destroyed before the renderer is even enabled.
- `MaterialCaching` acting on destroyed renderers after waiting for time budget