### PR TITLE
chore: update gifuct dependency

### DIFF
--- a/kernel/package.json
+++ b/kernel/package.json
@@ -110,7 +110,7 @@
     "ethereum-blockies": "^0.1.1",
     "fortmatic": "^2.2.1",
     "fp-future": "^1.0.1",
-    "gifuct-js": "github:decentraland/gifuct-js",
+    "gifuct-js": "^2.0.0",
     "google-protobuf": "^3.6.1",
     "keccakjs": "^0.2.3",
     "long": "^4.0.0",

--- a/kernel/package.json
+++ b/kernel/package.json
@@ -110,7 +110,7 @@
     "ethereum-blockies": "^0.1.1",
     "fortmatic": "^2.2.1",
     "fp-future": "^1.0.1",
-    "gifuct-js": "github:matt-way/gifuct-js",
+    "gifuct-js": "github:decentraland/gifuct-js",
     "google-protobuf": "^3.6.1",
     "keccakjs": "^0.2.3",
     "long": "^4.0.0",


### PR DESCRIPTION
Updated gifuct package dependency to use npm package instead of the less-safer github repo dependency