### PR TITLE
fix: collectible info asset destruction error

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCollectibleItem.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCollectibleItem.cs
@@ -49,7 +49,7 @@ public class PlayerInfoCollectibleItem : MonoBehaviour
     private void OnThumbnailReady(Asset_Texture texture)
     {
         // we override the previously stored placeholder image (a referenced asset), we don't destroy it as it
-        // references the asset and it will provoke a "Destroying assets it not permitted to avoid data loss" error
+        // references the asset and it will provoke a "Destroying assets is not permitted to avoid data loss" error
         thumbnail.sprite = ThumbnailsManager.CreateSpriteFromTexture(texture.texture);
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCollectibleItem.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCollectibleItem.cs
@@ -8,9 +8,11 @@ public class PlayerInfoCollectibleItem : MonoBehaviour
 
     internal WearableItem collectible;
     private AssetPromise_Texture thumbnailPromise;
+    private Sprite placeholderSprite;
 
     public void Initialize(WearableItem collectible)
     {
+        placeholderSprite = thumbnail.sprite;
         this.collectible = collectible;
 
         if (this.collectible == null) return;
@@ -48,7 +50,8 @@ public class PlayerInfoCollectibleItem : MonoBehaviour
 
     private void OnThumbnailReady(Asset_Texture texture)
     {
-        if (thumbnail.sprite != null)
+        // we can't destroy the referenced asset placeholder sprite or we get the "Destroying assets it not permitted to avoid data loss" error
+        if (thumbnail.sprite != null && thumbnail.sprite != placeholderSprite)
             Destroy(thumbnail.sprite);
 
         thumbnail.sprite = ThumbnailsManager.CreateSpriteFromTexture(texture.texture);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCollectibleItem.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCollectibleItem.cs
@@ -8,11 +8,9 @@ public class PlayerInfoCollectibleItem : MonoBehaviour
 
     internal WearableItem collectible;
     private AssetPromise_Texture thumbnailPromise;
-    private Sprite placeholderSprite;
 
     public void Initialize(WearableItem collectible)
     {
-        placeholderSprite = thumbnail.sprite;
         this.collectible = collectible;
 
         if (this.collectible == null) return;
@@ -50,10 +48,8 @@ public class PlayerInfoCollectibleItem : MonoBehaviour
 
     private void OnThumbnailReady(Asset_Texture texture)
     {
-        // we can't destroy the referenced asset placeholder sprite or we get the "Destroying assets it not permitted to avoid data loss" error
-        if (thumbnail.sprite != null && thumbnail.sprite != placeholderSprite)
-            Destroy(thumbnail.sprite);
-
+        // we override the previously stored placeholder image (a referenced asset), we don't destroy it as it
+        // references the asset and it will provoke a "Destroying assets it not permitted to avoid data loss" error
         thumbnail.sprite = ThumbnailsManager.CreateSpriteFromTexture(texture.texture);
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCollectibleItem.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/PlayerInfoCardHUD/PlayerInfoCollectibleItem.cs
@@ -8,6 +8,7 @@ public class PlayerInfoCollectibleItem : MonoBehaviour
 
     internal WearableItem collectible;
     private AssetPromise_Texture thumbnailPromise;
+    private bool finishedLoading = false;
 
     public void Initialize(WearableItem collectible)
     {
@@ -29,7 +30,12 @@ public class PlayerInfoCollectibleItem : MonoBehaviour
     private void OnDisable()
     {
         if (collectible != null)
+        {
             ForgetThumbnail();
+
+            if(thumbnail.sprite != null && finishedLoading)
+                Destroy(thumbnail.sprite);
+        }
     }
 
     private void GetThumbnail()
@@ -51,5 +57,7 @@ public class PlayerInfoCollectibleItem : MonoBehaviour
         // we override the previously stored placeholder image (a referenced asset), we don't destroy it as it
         // references the asset and it will provoke a "Destroying assets is not permitted to avoid data loss" error
         thumbnail.sprite = ThumbnailsManager.CreateSpriteFromTexture(texture.texture);
+
+        finishedLoading = true;
     }
 }


### PR DESCRIPTION
Added check to avoid trying to destroy the preloaded (not-instantiated) asset sprite as that triggers an error in unity.

Added a placeholder sprite check in case we decide to pool these instances some day (Currently, they are not being recycled)

This error was seen a lot during the new years eve event:

<img width="514" alt="Screen Shot 2020-12-30 at 20 56 49" src="https://user-images.githubusercontent.com/1031741/103549766-a671eb80-4e86-11eb-8833-447cbdde2f57.png">

<img width="993" alt="Screen Shot 2020-12-30 at 21 04 48" src="https://user-images.githubusercontent.com/1031741/103549770-a8d44580-4e86-11eb-92e1-8c5730b9ad83.png">
