### PR TITLE
fix: graphic warning notification clickable label

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/GraphicCardWarningHUD/GraphicCardWarningNotification.prefab
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/GraphicCardWarningHUD/GraphicCardWarningNotification.prefab
@@ -290,7 +290,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -600,8 +600,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 54.899963, y: -75.20007}
-  m_SizeDelta: {x: 20, y: 20}
+  m_AnchoredPosition: {x: 111.86, y: -75.20007}
+  m_SizeDelta: {x: 133.91815, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &8653346487427580486
 MonoBehaviour:


### PR DESCRIPTION
closes #1764 
use `unityInterface.ShowNotification({type:7})` to force notification if needed