### PR TITLE
chore: override outside limits spawn point

### DIFF
--- a/kernel/packages/atomicHelpers/parcelScenePositions.ts
+++ b/kernel/packages/atomicHelpers/parcelScenePositions.ts
@@ -41,6 +41,21 @@ export function isInParcel(test: Vector3Component, center: Vector3Component): bo
   )
 }
 
+/**
+ * Returns true if a world position is inside a group of parcels
+ */
+export function isWorldPositionInsideParcels(parcels: string[], testWorldPosition: Vector3Component): boolean {
+  let isInside = false
+
+  parcels.some((parcel) => {
+    const { x, y } = parseParcelPosition(parcel)
+    isInside = isInParcel(testWorldPosition, gridToWorld(x, y))
+    return isInside
+  })
+
+  return isInside
+}
+
 export function isOnLimits({ maximum, minimum }: BoundingInfo, parcels: Vector3Component[]): boolean {
   // Computes the world-axis-aligned bounding box of an object (including its children),
   // accounting for both the object's, and children's, world transforms

--- a/kernel/packages/shared/apis/RestrictedActions.ts
+++ b/kernel/packages/shared/apis/RestrictedActions.ts
@@ -4,7 +4,11 @@ import defaultLogger from '../logger'
 import { unityInterface } from 'unity-interface/UnityInterface'
 import { ParcelIdentity } from './ParcelIdentity'
 import { Quaternion, Vector3 } from 'decentraland-ecs/src'
-import { gridToWorld, isInParcel, parseParcelPosition } from '../../atomicHelpers/parcelScenePositions'
+import {
+  gridToWorld,
+  isWorldPositionInsideParcels,
+  parseParcelPosition
+} from '../../atomicHelpers/parcelScenePositions'
 import { lastPlayerPosition } from '../world/positionThings'
 import { browserInterface } from "../../unity-interface/BrowserInterface"
 
@@ -84,10 +88,7 @@ export class RestrictedActions extends ExposableAPI {
   }
 
   private isPositionValid(position: Vector3) {
-    return this.getSceneData().scene.parcels.some((parcel) => {
-      const { x, y } = parseParcelPosition(parcel)
-      return isInParcel(position, gridToWorld(x, y))
-    })
+    return isWorldPositionInsideParcels(this.getSceneData().scene.parcels, position)
   }
 }
 

--- a/kernel/packages/shared/world/TeleportController.ts
+++ b/kernel/packages/shared/world/TeleportController.ts
@@ -105,7 +105,7 @@ export class TeleportController {
       const currentParcel = worldToGrid(lastPlayerPosition)
 
       usersParcels = usersParcels.filter(
-        (it) => isInsideParcelLimits(it[0], it[1]) && currentParcel.x !== it[0] && currentParcel.y !== it[1]
+        (it) => isInsideWorldLimits(it[0], it[1]) && currentParcel.x !== it[0] && currentParcel.y !== it[1]
       )
 
       if (usersParcels.length > 0) {
@@ -151,7 +151,7 @@ export class TeleportController {
   public static goTo(x: number, y: number, teleportMessage?: string): { message: string; success: boolean } {
     const tpMessage: string = teleportMessage ? teleportMessage : `Teleporting to ${x}, ${y}...`
 
-    if (isInsideParcelLimits(x, y)) {
+    if (isInsideWorldLimits(x, y)) {
       teleportObservable.notifyObservers({
         x: x,
         y: y,
@@ -183,7 +183,7 @@ async function fetchLayerUsersParcels(): Promise<ParcelArray[]> {
   return []
 }
 
-function isInsideParcelLimits(x: number, y: number) {
+function isInsideWorldLimits(x: number, y: number) {
   return (
     x > parcelLimits.minLandCoordinateX &&
     x <= parcelLimits.maxLandCoordinateX &&

--- a/kernel/packages/shared/world/positionThings.ts
+++ b/kernel/packages/shared/world/positionThings.ts
@@ -140,12 +140,33 @@ function pickSpawnpoint(land: ILand): InstancedSpawnPoint | undefined {
   const { position, cameraTarget } = eligiblePoints[Math.floor(Math.random() * eligiblePoints.length)]
 
   // 4 - generate random x, y, z components when in arrays
+  let finalPosition = {
+    x: computeComponentValue(position.x),
+    y: computeComponentValue(position.y),
+    z: computeComponentValue(position.z)
+  }
+
+  // 5 - If the final position is outside the scene limits, we zero it
+  let isInside = false
+  const flooredFinalPosX = Math.floor(finalPosition.x).toString()
+  const flooredFinalPosY = Math.floor(finalPosition.y).toString()
+
+  for (const parcel of land.sceneJsonData.scene.parcels) {
+    const parcelCoords = parcel.split(',')
+
+    if (flooredFinalPosX === parcelCoords[0] && flooredFinalPosY === parcelCoords[1]) {
+      isInside = true
+      break
+    }
+  }
+
+  if (!isInside) {
+    finalPosition.x = 0
+    finalPosition.y = 0
+  }
+
   return {
-    position: {
-      x: computeComponentValue(position.x),
-      y: computeComponentValue(position.y),
-      z: computeComponentValue(position.z)
-    },
+    position: finalPosition,
     cameraTarget
   }
 }

--- a/kernel/packages/shared/world/positionThings.ts
+++ b/kernel/packages/shared/world/positionThings.ts
@@ -1,5 +1,3 @@
-import { DEBUG, parcelLimits } from "../../config"
-
 const qs: any = require('query-string')
 import { worldToGrid, gridToWorld, parseParcelPosition } from 'atomicHelpers/parcelScenePositions'
 import {
@@ -12,6 +10,7 @@ import {
 import { Observable } from 'decentraland-ecs/src/ecs/Observable'
 import { ILand } from 'shared/types'
 import { InstancedSpawnPoint } from '../types'
+import { DEBUG, parcelLimits } from "../../config"
 import parcelSize = parcelLimits.parcelSize
 
 declare var location: any
@@ -152,8 +151,10 @@ function pickSpawnpoint(land: ILand): InstancedSpawnPoint | undefined {
   // 5 - If the final position is outside the scene limits, we zero it
   if (!DEBUG) {
     let isInside = false
-    const flooredFinalPosX = Math.floor(finalPosition.x / parcelSize).toString()
-    const flooredFinalPosZ = Math.floor(finalPosition.z / parcelSize).toString()
+
+    const sceneBaseParcelCoords = land.sceneJsonData.scene.base.split(',')
+    const flooredFinalPosX = Math.floor(parseInt(sceneBaseParcelCoords[0], 10) + (finalPosition.x / parcelSize)).toString()
+    const flooredFinalPosZ = Math.floor(parseInt(sceneBaseParcelCoords[1], 10) + (finalPosition.z / parcelSize)).toString()
 
     for (const parcel of land.sceneJsonData.scene.parcels) {
       const parcelCoords = parcel.split(',')

--- a/kernel/packages/shared/world/positionThings.ts
+++ b/kernel/packages/shared/world/positionThings.ts
@@ -1,4 +1,4 @@
-import { DEBUG } from "../../config"
+import { DEBUG, parcelLimits } from "../../config"
 
 const qs: any = require('query-string')
 import { worldToGrid, gridToWorld, parseParcelPosition } from 'atomicHelpers/parcelScenePositions'
@@ -12,6 +12,7 @@ import {
 import { Observable } from 'decentraland-ecs/src/ecs/Observable'
 import { ILand } from 'shared/types'
 import { InstancedSpawnPoint } from '../types'
+import parcelSize = parcelLimits.parcelSize
 
 declare var location: any
 declare var history: any
@@ -151,13 +152,13 @@ function pickSpawnpoint(land: ILand): InstancedSpawnPoint | undefined {
   // 5 - If the final position is outside the scene limits, we zero it
   if (!DEBUG) {
     let isInside = false
-    const flooredFinalPosX = Math.floor(finalPosition.x).toString()
-    const flooredFinalPosY = Math.floor(finalPosition.y).toString()
+    const flooredFinalPosX = Math.floor(finalPosition.x / parcelSize).toString()
+    const flooredFinalPosZ = Math.floor(finalPosition.z / parcelSize).toString()
 
     for (const parcel of land.sceneJsonData.scene.parcels) {
       const parcelCoords = parcel.split(',')
 
-      if (flooredFinalPosX === parcelCoords[0] && flooredFinalPosY === parcelCoords[1]) {
+      if (flooredFinalPosX === parcelCoords[0] && flooredFinalPosZ === parcelCoords[1]) {
         isInside = true
         break
       }
@@ -165,7 +166,7 @@ function pickSpawnpoint(land: ILand): InstancedSpawnPoint | undefined {
 
     if (!isInside) {
       finalPosition.x = 0
-      finalPosition.y = 0
+      finalPosition.z = 0
     }
   }
 

--- a/kernel/packages/shared/world/positionThings.ts
+++ b/kernel/packages/shared/world/positionThings.ts
@@ -1,4 +1,4 @@
-import {DEBUG} from "../../config";
+import { DEBUG } from "../../config"
 
 const qs: any = require('query-string')
 import { worldToGrid, gridToWorld, parseParcelPosition } from 'atomicHelpers/parcelScenePositions'

--- a/kernel/packages/shared/world/positionThings.ts
+++ b/kernel/packages/shared/world/positionThings.ts
@@ -1,3 +1,5 @@
+import {DEBUG} from "../../config";
+
 const qs: any = require('query-string')
 import { worldToGrid, gridToWorld, parseParcelPosition } from 'atomicHelpers/parcelScenePositions'
 import {
@@ -147,22 +149,24 @@ function pickSpawnpoint(land: ILand): InstancedSpawnPoint | undefined {
   }
 
   // 5 - If the final position is outside the scene limits, we zero it
-  let isInside = false
-  const flooredFinalPosX = Math.floor(finalPosition.x).toString()
-  const flooredFinalPosY = Math.floor(finalPosition.y).toString()
+  if (!DEBUG) {
+    let isInside = false
+    const flooredFinalPosX = Math.floor(finalPosition.x).toString()
+    const flooredFinalPosY = Math.floor(finalPosition.y).toString()
 
-  for (const parcel of land.sceneJsonData.scene.parcels) {
-    const parcelCoords = parcel.split(',')
+    for (const parcel of land.sceneJsonData.scene.parcels) {
+      const parcelCoords = parcel.split(',')
 
-    if (flooredFinalPosX === parcelCoords[0] && flooredFinalPosY === parcelCoords[1]) {
-      isInside = true
-      break
+      if (flooredFinalPosX === parcelCoords[0] && flooredFinalPosY === parcelCoords[1]) {
+        isInside = true
+        break
+      }
     }
-  }
 
-  if (!isInside) {
-    finalPosition.x = 0
-    finalPosition.y = 0
+    if (!isInside) {
+      finalPosition.x = 0
+      finalPosition.y = 0
+    }
   }
 
   return {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
@@ -578,7 +578,7 @@ namespace DCL
                 }
             }
 
-            if (string.IsNullOrEmpty(worldState.currentSceneId))
+            if (!DataStore.debugConfig.isDebugMode && string.IsNullOrEmpty(worldState.currentSceneId))
             {
                 // When we don't know the current scene yet, we must lock the rendering from enabling until it is set
                 CommonScriptableObjects.rendererState.AddLock(this);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/WorldState.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/WorldState.cs
@@ -50,7 +50,7 @@ namespace DCL
         {
             scene = null;
 
-            if (!loadedScenes.ContainsKey(id))
+            if (string.IsNullOrEmpty(id) || !loadedScenes.ContainsKey(id))
                 return false;
 
             scene = loadedScenes[id];


### PR DESCRIPTION
**WHY?**
In preview mode if a parcel dev sets the scene spawn point as a position outside the scene limits, the unity client never gets a "current scene" since there is no scene to load there, thus locking the rendering forever as it can't wait for an unxistent scene to finish loading to unlock it...

**WHAT**
* Only in debug mode we no longer lock the rendering based on an "unexistent current scene" (as that can't happen in prod)
* Only in debug mode we don't override the unallowed position spawn point if used (as a parcel dev may use those spawn positions for developing more comfortably)
* In prod we override unallowed position spawn points with 0, 0 scene relative position.

this PR tackles the issue: https://github.com/decentraland/explorer/issues/1897