### PR TITLE
fix: avatar editor culling not rendering wearables

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/AvatarEditorHUD.asmdef
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/AvatarEditorHUD.asmdef
@@ -20,7 +20,8 @@
         "GUID:98bf3bf29030cbf4092d89a7cc28b7fb",
         "GUID:cc6bfabbfe87b7949aa248893f89ce37",
         "GUID:3f13bd1a926f03a4cab988f06a80c1fd",
-        "GUID:28f74c468a54948bfa9f625c5d428f56"
+        "GUID:28f74c468a54948bfa9f625c5d428f56",
+        "GUID:b97702e026e0dbd4397dc4013ef9fcb3"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/CharacterPreviewController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/CharacterPreviewController.cs
@@ -54,6 +54,9 @@ public class CharacterPreviewController : MonoBehaviour
             {CameraFocus.FaceSnapshot, faceSnapshotTemplate},
             {CameraFocus.BodySnapshot, bodySnapshotTemplate},
         };
+        var cullingSettings = DCL.Environment.i.platform.cullingController.GetSettingsCopy();
+        cullingSettings.ignoredLayersMask |= 1 << CHARACTER_PREVIEW_LAYER;
+        DCL.Environment.i.platform.cullingController.SetSettings(cullingSettings);
     }
 
     public void UpdateModel(AvatarModel newModel, Action onDone)


### PR DESCRIPTION
What?
set culling manager to ignore `CharacterPreview` layer.

Why?
In some situations when opening avatar editor wearables are not show on the avatar.

I could reproduce it in most cases doing the following:
https://play.decentraland.zone/?ALL_WEARABLES&ENV=zone&position=141%2C-1&realm=hermes-amber
1- enter as guest as a new profile
2- create your profile
3- enter the world
4- open avatar editor

if your see your avatar broken in the editor you can switch to this build to see it fixed:
https://play.decentraland.zone/branch/fix/avatar-editor-culling/index.html?ALL_WEARABLES&ENV=zone&position=141%2C-1&realm=hermes-amber