### PR TITLE
fix: avatarModifierArea now remove modifiers when destroyed

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AssemblyInfo.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AssemblyInfo.cs
@@ -3,3 +3,4 @@
 [assembly: InternalsVisibleTo("AvatarEditorHUDTests")]
 [assembly: InternalsVisibleTo("AvatarShapeVisualTests")]
 [assembly: InternalsVisibleTo("AvatarShapeTests")]
+[assembly: InternalsVisibleTo("AvatarModifiersTest")]

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/Tests.meta
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 349ca281d9a310a428ee100146dc3802
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/Tests/AvatarModifierAreaShould.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/Tests/AvatarModifierAreaShould.cs
@@ -1,0 +1,61 @@
+﻿using DCL.Helpers;
+using DCL.Models;
+using System.Collections;
+using UnityEngine;
+using NSubstitute;
+using UnityEngine.TestTools;
+
+public class AvatarModifierAreaShould : IntegrationTestSuite_Legacy
+{
+    private const string MOCK_MODIFIER_KEY = "MockModifier";
+    private AvatarModifierArea avatarModifierArea;
+    private AvatarModifier mockAvatarModifier;
+    protected override IEnumerator SetUp()
+    {
+        yield return base.SetUp();
+
+        DecentralandEntity entity = TestHelpers.CreateSceneEntity(scene);
+        AvatarModifierArea.Model model = new AvatarModifierArea.Model
+        {
+            area = new BoxTriggerArea { box = new Vector3(10, 10, 10) },
+        };
+        avatarModifierArea = TestHelpers.EntityComponentCreate<AvatarModifierArea, AvatarModifierArea.Model>(scene, entity, model, CLASS_ID_COMPONENT.AVATAR_MODIFIER_AREA);
+        yield return avatarModifierArea.routine;
+
+        model.modifiers = new [] { MOCK_MODIFIER_KEY };
+        mockAvatarModifier = Substitute.For<AvatarModifier>();
+        avatarModifierArea.modifiers.Add(MOCK_MODIFIER_KEY, mockAvatarModifier);
+
+        //now that the modifier has been added we trigger the Update again so it gets taken into account
+        yield return TestHelpers.EntityComponentUpdate(avatarModifierArea, model);
+    }
+
+    [UnityTest]
+    public IEnumerator DisableModifiersOnTeleportedAvatars()
+    {
+        var fakeObject = PrepareGameObjectForModifierArea();
+        yield return null;
+
+        mockAvatarModifier.Received().ApplyModifier(fakeObject);
+        fakeObject.SetActive(false);
+        Object.Destroy(avatarModifierArea.gameObject);
+        yield return null;
+        mockAvatarModifier.Received().RemoveModifier(fakeObject);
+    }
+
+    private GameObject PrepareGameObjectForModifierArea()
+    {
+        GameObject fakeObject = CreateTestGameObject("_FakeObject");
+
+        // ModifierArea presumes the object has a parent
+        GameObject fakeParent = CreateTestGameObject("_FakeParent");
+        fakeObject.transform.parent = fakeParent.transform;
+
+        var boxCollider = fakeObject.AddComponent<BoxCollider>();
+        boxCollider.size = new Vector3(3, 3, 3);
+        fakeObject.layer = LayerMask.NameToLayer(BoxTriggerArea.AVATAR_TRIGGER_LAYER);
+        fakeObject.transform.position = avatarModifierArea.transform.position;
+
+        return fakeParent;
+    }
+}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/Tests/AvatarModifierAreaShould.cs.meta
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/Tests/AvatarModifierAreaShould.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 34e5beaf793917a48bd71196d527c29b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/Tests/AvatarModifiersTest.asmdef
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/Tests/AvatarModifiersTest.asmdef
@@ -1,0 +1,25 @@
+{
+    "name": "AvatarModifiersTest",
+    "references": [
+        "GUID:ef84d7ce90ba34f07be26ace428e9bc8",
+        "GUID:e555144732b726c4cba5b0f6337fea75",
+        "GUID:9fad297e585ef204c9c2c497d77099f0",
+        "GUID:a881b57670b1d2747a6d7f9e32b63230",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll",
+        "NSubstitute.dll",
+        "System.Threading.Tasks.Extensions.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/Tests/AvatarModifiersTest.asmdef.meta
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/Tests/AvatarModifiersTest.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7e6302ff8d50bab44a7b6e6d2dde02c2
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/TriggerArea.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Avatar/AvatarModifiers/TriggerArea.cs
@@ -11,11 +11,12 @@ public abstract class TriggerArea
 [System.Serializable]
 public class BoxTriggerArea : TriggerArea
 {
+    internal const string AVATAR_TRIGGER_LAYER = "AvatarTriggerDetection";
     public Vector3 box;
 
     public override HashSet<GameObject> DetectAvatars(Vector3 center, Quaternion rotation)
     {
-        Collider[] colliders = Physics.OverlapBox(center, box * 0.5f, rotation, LayerMask.GetMask("AvatarTriggerDetection"), QueryTriggerInteraction.Collide);
+        Collider[] colliders = Physics.OverlapBox(center, box * 0.5f, rotation, LayerMask.GetMask(AVATAR_TRIGGER_LAYER), QueryTriggerInteraction.Collide);
         if (colliders.Length == 0)
         {
             return null;


### PR DESCRIPTION
#1917 

When performing a `/goto` operation the avatar is teleported and the entity that holds the `AvatarModifierArea` will be destroyed. 

`AvatarModifierArea.OnDestroy` was removing effects of the Avatars in the zone but since the player's avatar has been teleported, is no longer there and the removal of the modifiers are not applied to him.

Also I just realized we dont have a single test for the `AvatarModifierArea`, I created an unit test to cover this issue but a whole suite will be needed.  This will be tackled down in another ticket #1921.