### PR TITLE
fix: avatar snapshots long URLs issue

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Texture/AssetPromise_Texture.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Texture/AssetPromise_Texture.cs
@@ -85,7 +85,7 @@ namespace DCL
             {
                 //For Base64 protocols we just take the bytes and create the texture
                 //to avoid Unity's web request issue with large URLs
-                byte[] decodedTexture = Convert.FromBase64String(url.Replace(PLAIN_BASE64_PROTOCOL, ""));
+                byte[] decodedTexture = Convert.FromBase64String(url.Substring(PLAIN_BASE64_PROTOCOL.Length));
                 asset.texture = new Texture2D(1,1);
                 asset.texture.LoadImage(decodedTexture);
                 OnSuccess?.Invoke();

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Texture/AssetPromise_Texture.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/AssetManager/Texture/AssetPromise_Texture.cs
@@ -9,6 +9,7 @@ namespace DCL
     {
         const TextureWrapMode DEFAULT_WRAP_MODE = TextureWrapMode.Clamp;
         const FilterMode DEFAULT_FILTER_MODE = FilterMode.Bilinear;
+        private const string PLAIN_BASE64_PROTOCOL = "data:text/plain;base64,";
 
         string url;
         string idWithTexSettings;
@@ -61,22 +62,34 @@ namespace DCL
                 return;
             }
 
-            webRequest = UnityWebRequestTexture.GetTexture(url);
-            webRequest.SendWebRequest().completed += (asyncOp) =>
+            if (!url.StartsWith(PLAIN_BASE64_PROTOCOL))
             {
-                bool success = webRequest != null && webRequest.WebRequestSucceded() && asset != null;
-                if (success)
+                webRequest = UnityWebRequestTexture.GetTexture(url);
+                webRequest.SendWebRequest().completed += (asyncOp) =>
                 {
-                    asset.texture = DownloadHandlerTexture.GetContent(webRequest);
-                    OnSuccess?.Invoke();
-                }
-                else
-                {
-                    OnFail?.Invoke();
-                }
-                webRequest?.Dispose();
-                webRequest = null;
-            };
+                    bool success = webRequest != null && webRequest.WebRequestSucceded() && asset != null;
+                    if (success)
+                    {
+                        asset.texture = DownloadHandlerTexture.GetContent(webRequest);
+                        OnSuccess?.Invoke();
+                    }
+                    else
+                    {
+                        OnFail?.Invoke();
+                    }
+                    webRequest?.Dispose();
+                    webRequest = null;
+                };
+            }
+            else
+            {
+                //For Base64 protocols we just take the bytes and create the texture
+                //to avoid Unity's web request issue with large URLs
+                byte[] decodedTexture = Convert.FromBase64String(url.Replace(PLAIN_BASE64_PROTOCOL, ""));
+                asset.texture = new Texture2D(1,1);
+                asset.texture.LoadImage(decodedTexture);
+                OnSuccess?.Invoke();
+            }
         }
 
         protected override bool AddToLibrary()

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUDView.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUDView.cs
@@ -129,6 +129,7 @@ internal class ProfileHUDView : MonoBehaviour
 
     internal void SetProfile(UserProfile userProfile)
     {
+        profile = userProfile;
         if (userProfile.hasClaimedName)
         {
             HandleClaimedProfileName(userProfile);
@@ -141,7 +142,6 @@ internal class ProfileHUDView : MonoBehaviour
         SetConnectedWalletSectionActive(userProfile.hasConnectedWeb3);
         HandleProfileAddress(userProfile);
         HandleProfileSnapshot(userProfile);
-        profile = userProfile;
     }
 
     internal void ToggleMenu()


### PR DESCRIPTION
#1921

We are sending the avatar snapshots as `data:text/plain;base64` protocol. This is translated into a HTTP GET request to retrieve the byte, but since we already have the `base64` data, we can just get the bytes from there.