### PR TITLE
fix: change url to use builder download endpoint

### DIFF
--- a/kernel/packages/shared/apis/SceneStateStorageController/AssetManager.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/AssetManager.ts
@@ -9,7 +9,7 @@ export type Asset = {
   baseUrl: string
 }
 
-const BASE_DOWNLOAD_URL = 'https://content.decentraland.org/contents'
+const BASE_DOWNLOAD_URL = 'http://builder-api.decentraland.org/v1/storage/contents/'
 const BASE_ASSET_URL = 'https://builder-api.decentraland.org/v1/assets'
 
 export class AssetManager {

--- a/kernel/packages/shared/apis/SceneStateStorageController/AssetManager.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/AssetManager.ts
@@ -9,7 +9,7 @@ export type Asset = {
   baseUrl: string
 }
 
-const BASE_DOWNLOAD_URL = 'https://builder-api.decentraland.org/v1/storage/contents/'
+const BASE_DOWNLOAD_URL = 'https://builder-api.decentraland.org/v1/storage/contents'
 const BASE_ASSET_URL = 'https://builder-api.decentraland.org/v1/assets'
 
 export class AssetManager {

--- a/kernel/packages/shared/apis/SceneStateStorageController/AssetManager.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/AssetManager.ts
@@ -9,7 +9,7 @@ export type Asset = {
   baseUrl: string
 }
 
-const BASE_DOWNLOAD_URL = 'http://builder-api.decentraland.org/v1/storage/contents/'
+const BASE_DOWNLOAD_URL = 'https://builder-api.decentraland.org/v1/storage/contents/'
 const BASE_ASSET_URL = 'https://builder-api.decentraland.org/v1/assets'
 
 export class AssetManager {


### PR DESCRIPTION
We are now using the builder url, so we can kill the old content server domain