### PR TITLE
refactor: change how profiles files are named

### DIFF
--- a/kernel/packages/shared/profiles/sagas.ts
+++ b/kernel/packages/shared/profiles/sagas.ts
@@ -468,7 +468,7 @@ async function buildSnapshotContent(selector: string, value: string): Promise<[s
   let hash: string
   let contentFile: ContentFile | undefined
 
-  const name = `./${selector}.png`
+  const name = `${selector}.png`
 
   if (isResizeServiceUrl(globalThis.globalStore.getState(), value)) {
     // value is coming in a resize service url => generate image & upload content


### PR DESCRIPTION
Profile files are normally names like this:
* `./face.png`
* `./face128.png`
* `./face256.png`
* `./body.png`

However, files used in scenes are relative to the project folder. In order to be consistent, be are removing `./` from the profile files