### PR TITLE
fix: avoid typo breaking change

### DIFF
--- a/kernel/packages/decentraland-ecs/src/decentraland/Components.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Components.ts
@@ -6,6 +6,9 @@ import { IEvents } from './Types'
 import { ActionButton } from './Input'
 
 /** @public */
+export type TranformConstructorArgs = TransformConstructorArgs
+
+/** @public */
 export type TransformConstructorArgs = {
   position?: Vector3
   rotation?: Quaternion


### PR DESCRIPTION
We recently fixed a typo, but since it was being exposed, it would be a breaking change. We are adding support for both the typo and the correct way to spell it