### PR TITLE
feat: adding support for feature flags

### DIFF
--- a/kernel/packages/config/contracts.ts
+++ b/kernel/packages/config/contracts.ts
@@ -112,7 +112,9 @@ export const contracts = {
     'MemeDontBuyThis': '0x1a57f6afc902d25792c53b8f19b7e17ef84222d5',
     'ReleaseTheKraken': '0xffc5043d9a00865d089d5eefa5b3d1625aec6763',
     '3LAUBasics': '0xe1ecb4e5130f493551c7d6df96ad19e5b431a0a9',
-    'XmashUp2020': '0xdd9c7bc159dacb19c9f6b9d7e23948c87aa2397f'
+    'XmashUp2020': '0xdd9c7bc159dacb19c9f6b9d7e23948c87aa2397f',
+    'MLLiondance': '0x0b1c6c75d511fae05e7dc696f4cf14129a9c43c9',
+    'AtariLaunch': '0x4c290f486bae507719c562b6b524bdb71a2570c9'
   },
   'kovan': {
     'MANAToken': '0x230fc362413d9e862326c2c7084610a5a2fdf78a',

--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -274,12 +274,14 @@ export function getServerConfigurations() {
   const synapseUrl = TLDDefault === 'zone' ? `https://matrix.decentraland.zone` : `https://decentraland.modular.im`
 
   const metaConfigBaseUrl = META_CONFIG_URL || `https://config.decentraland.${notToday}/explorer.json`
+  const metaFeatureFlagsBaseUrl = `https://feature-flags.decentraland.${notToday}/explorer.json`
   const ASSET_BUNDLES_DOMAIN = qs.ASSET_BUNDLES_DOMAIN || `content-assets-as-bundle.decentraland.${TLDDefault}`
 
   return {
     contentAsBundle: `https://${ASSET_BUNDLES_DOMAIN}`,
     wearablesApi: `https://${WEARABLE_API_DOMAIN}/${WEARABLE_API_PATH_PREFIX}`,
     explorerConfiguration: `${metaConfigBaseUrl}?t=${new Date().getTime()}`,
+    explorerFeatureFlags: `${metaFeatureFlagsBaseUrl}?t=${new Date().getTime()}`,
     synapseUrl,
     questsUrl: QUESTS_SERVER_URL,
     fallbackResizeServiceUrl: `${PIN_CATALYST ?? 'https://peer.decentraland.' + notToday}/lambdas/images`,

--- a/kernel/packages/shared/meta/selectors.ts
+++ b/kernel/packages/shared/meta/selectors.ts
@@ -50,7 +50,7 @@ export const isFeatureEnabled = (store: RootMetaState, featureName: FeatureFlags
 
 /** Convert camel case to upper snake case */
 function toUrlFlag(key: string) {
-  var result = key.replace(/([A-Z])/g, ' $1')
+  const result = key.replace(/([A-Z])/g, ' $1')
   return result.split(' ').join('_').toUpperCase()
 }
 

--- a/kernel/packages/shared/meta/selectors.ts
+++ b/kernel/packages/shared/meta/selectors.ts
@@ -1,4 +1,4 @@
-import { CommsConfig, MessageOfTheDayConfig, RootMetaState } from './types'
+import { CommsConfig, FeatureFlags, MessageOfTheDayConfig, RootMetaState } from './types'
 import { Vector2Component } from 'atomicHelpers/landHelpers'
 import { getCatalystNodesDefaultURL, VOICE_CHAT_DISABLED_FLAG, WORLD_EXPLORER } from 'config'
 
@@ -35,6 +35,24 @@ export const getMessageOfTheDay = (store: RootMetaState): MessageOfTheDayConfig 
 
 export const isVoiceChatEnabledFor = (store: RootMetaState, userId: string): boolean =>
   WORLD_EXPLORER && !VOICE_CHAT_DISABLED_FLAG
+
+export const isFeatureEnabled = (store: RootMetaState, featureName: FeatureFlags, ifNotSet: boolean): boolean => {
+  const queryParamFlag = toUrlFlag(featureName)
+  if (location.search.includes(`DISABLE_${queryParamFlag}`)) {
+    return false
+  } else if (location.search.includes(`ENABLE_${queryParamFlag}`)) {
+    return true
+  } else {
+    const featureFlag = store.meta.config?.featureFlags?.[`explorer-${featureName}`]
+    return featureFlag ?? ifNotSet
+  }
+}
+
+/** Convert camel case to upper snake case */
+function toUrlFlag(key: string) {
+  var result = key.replace(/([A-Z])/g, ' $1')
+  return result.split(' ').join('_').toUpperCase()
+}
 
 export const getCatalystNodesEndpoint = (store: RootMetaState): string =>
   store.meta.config.servers?.catalystsNodesEndpoint ?? getCatalystNodesDefaultURL()

--- a/kernel/packages/shared/meta/types.ts
+++ b/kernel/packages/shared/meta/types.ts
@@ -18,6 +18,7 @@ export type MetaConfiguration = {
   }
   world: WorldConfig
   comms: CommsConfig
+  featureFlags?: Record<string, boolean>
 }
 
 export type WorldConfig = {
@@ -56,4 +57,8 @@ export type CommsConfig = {
   relaySuspensionDisabled?: boolean
   relaySuspensionInterval?: number
   relaySuspensionDuration?: number
+}
+
+export enum FeatureFlags {
+  WEARABLES_V2 = 'wearables_v2'
 }


### PR DESCRIPTION
We are now adding support for feature flags inside the explorer. 

We also added a selector called `isFeatureEnabled(featureName: string, ifNotSet: boolean)` that accepts url overrides. To explain how it works, let's go with the feature flag called `wearables_v2`. 
1. If the url has the following on the query `DISABLE_WEARABLES_V2`, then the flag is considered as off, regardless of what the server says
1. If the url has the following on the query `ENABLE_WEARABLES_V2`, then the flag is considered as on, regardless of what the server says
1. If the flag is configured on the server, then that is the value that stands
1. If it wasn't present on the server, then `ifNotSet` is used as default

This will allow us to easily add new flags with little to no effort