### PR TITLE
refactor: instanced data store

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Bridges/RealmsInfoBridge/RealmsInfoHandler.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Bridges/RealmsInfoBridge/RealmsInfoHandler.cs
@@ -8,8 +8,8 @@ namespace DCL
     {
         private RealmsInfoModel model = new RealmsInfoModel();
 
-        public CurrentRealmVariable playerRealm => DataStore.playerRealm;
-        public RealmsVariable realmsInfo => DataStore.realmsInfo;
+        public CurrentRealmVariable playerRealm => DataStore.i.playerRealm;
+        public RealmsVariable realmsInfo => DataStore.i.realmsInfo;
 
         public void Set(string json)
         {
@@ -20,8 +20,8 @@ namespace DCL
         public void Set(RealmsInfoModel newModel)
         {
             model = newModel;
-            DataStore.playerRealm.Set(model.current?.Clone());
-            DataStore.realmsInfo.Set(model.realms);
+            DataStore.i.playerRealm.Set(model.current?.Clone());
+            DataStore.i.realmsInfo.Set(model.realms);
         }
     }
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BlockerController/WorldBlockersController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BlockerController/WorldBlockersController.cs
@@ -61,7 +61,7 @@ namespace DCL.Controllers
 
         void OnRendererStateChange(bool newValue, bool oldValue)
         {
-            if (newValue && DataStore.debugConfig.isDebugMode)
+            if (newValue && DataStore.i.debugConfig.isDebugMode)
                 SetEnabled(false);
         }
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/DebugController/DebugController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/DebugController/DebugController.cs
@@ -17,7 +17,7 @@ namespace DCL
 
     public class DebugController : IDebugController
     {
-        private DebugConfig debugConfig => DataStore.debugConfig;
+        private DebugConfig debugConfig => DataStore.i.debugConfig;
 
         public DebugView debugView;
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/AvatarEditorHUD/Scripts/AvatarEditorHUDController.cs
@@ -436,7 +436,7 @@ public class AvatarEditorHUDController : IHUD
         }
         else if (visible && !view.isOpen)
         {
-            DCL.Environment.i.messaging.manager.paused = DataStore.isSignUpFlow.Get();
+            DCL.Environment.i.messaging.manager.paused = DataStore.i.isSignUpFlow.Get();
             currentRenderProfile.avatarProfile.currentProfile = currentRenderProfile.avatarProfile.avatarEditor;
             currentRenderProfile.avatarProfile.Apply();
 
@@ -477,16 +477,16 @@ public class AvatarEditorHUDController : IHUD
     public void SaveAvatar(Texture2D faceSnapshot, Texture2D face128Snapshot, Texture2D face256Snapshot, Texture2D bodySnapshot)
     {
         var avatarModel = model.ToAvatarModel();
-        WebInterface.SendSaveAvatar(avatarModel, faceSnapshot, face128Snapshot, face256Snapshot, bodySnapshot, DataStore.isSignUpFlow.Get());
+        WebInterface.SendSaveAvatar(avatarModel, faceSnapshot, face128Snapshot, face256Snapshot, bodySnapshot, DataStore.i.isSignUpFlow.Get());
         userProfile.OverrideAvatar(avatarModel, face256Snapshot);
 
         SetVisibility(false);
-        DataStore.isSignUpFlow.Set(false);
+        DataStore.i.isSignUpFlow.Set(false);
     }
 
     public void DiscardAndClose()
     {
-        if (!DataStore.isSignUpFlow.Get())
+        if (!DataStore.i.isSignUpFlow.Get())
             LoadUserProfile(userProfile);
         else
             WebInterface.SendCloseUserAvatar(true);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/HUDController.cs
@@ -307,7 +307,7 @@ public class HUDController : MonoBehaviour
                         taskbarHud.OnAnyTaskbarButtonClicked -= TaskbarHud_onAnyTaskbarButtonClicked;
                         taskbarHud.OnAnyTaskbarButtonClicked += TaskbarHud_onAnyTaskbarButtonClicked;
                         taskbarHud.AddBuilderInWorldWindow(builderInWorldInititalHud);
-                        
+
 
                         if (!string.IsNullOrEmpty(extraPayload))
                         {
@@ -486,7 +486,7 @@ public class HUDController : MonoBehaviour
     {
         if (avatarEditorHud != null)
         {
-            DataStore.isSignUpFlow.Set(true);
+            DataStore.i.isSignUpFlow.Set(true);
             ShowAvatarEditor();
         }
     }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputController.cs
@@ -180,7 +180,7 @@ public class InputController : MonoBehaviour
                     InputProcessor.FromKey(action, KeyCode.U, modifiers: InputProcessor.Modifier.None);
                     break;
                 case DCLAction_Trigger.CloseWindow:
-                    if (allUIHidden || DataStore.isSignUpFlow.Get()) break;
+                    if (allUIHidden || DataStore.i.isSignUpFlow.Get()) break;
                     InputProcessor.FromKey(action, KeyCode.Escape, modifiers: InputProcessor.Modifier.None);
                     break;
                 case DCLAction_Trigger.OpenExpressions:

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/InputController/InputController.cs
@@ -180,7 +180,8 @@ public class InputController : MonoBehaviour
                     InputProcessor.FromKey(action, KeyCode.U, modifiers: InputProcessor.Modifier.None);
                     break;
                 case DCLAction_Trigger.CloseWindow:
-                    if (allUIHidden || DataStore.i.isSignUpFlow.Get()) break;
+                    if (allUIHidden || DataStore.i.isSignUpFlow.Get())
+                        break;
                     InputProcessor.FromKey(action, KeyCode.Escape, modifiers: InputProcessor.Modifier.None);
                     break;
                 case DCLAction_Trigger.OpenExpressions:

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/GlobalUsersPositionMarker/Utils/UserPositionMarker.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/MapRenderer/GlobalUsersPositionMarker/Utils/UserPositionMarker.cs
@@ -35,13 +35,13 @@ namespace DCL
         {
             if (active)
             {
-                OnRealmChanged(DataStore.playerRealm.Get(), null);
-                DataStore.playerRealm.OnChange -= OnRealmChanged;
-                DataStore.playerRealm.OnChange += OnRealmChanged;
+                OnRealmChanged(DataStore.i.playerRealm.Get(), null);
+                DataStore.i.playerRealm.OnChange -= OnRealmChanged;
+                DataStore.i.playerRealm.OnChange += OnRealmChanged;
             }
             else
             {
-                DataStore.playerRealm.OnChange -= OnRealmChanged;
+                DataStore.i.playerRealm.OnChange -= OnRealmChanged;
             }
 
             markerObject.gameObject.SetActive(active);
@@ -49,7 +49,7 @@ namespace DCL
 
         public void Dispose()
         {
-            DataStore.playerRealm.OnChange -= OnRealmChanged;
+            DataStore.i.playerRealm.OnChange -= OnRealmChanged;
             GameObject.Destroy(markerObject.gameObject);
         }
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/Main.cs
@@ -32,10 +32,10 @@ namespace DCL
 
             i = this;
 
-            DataStore.debugConfig.soloScene = debugConfig.soloScene;
-            DataStore.debugConfig.soloSceneCoords = debugConfig.soloSceneCoords;
-            DataStore.debugConfig.ignoreGlobalScenes = debugConfig.ignoreGlobalScenes;
-            DataStore.debugConfig.msgStepByStep = debugConfig.msgStepByStep;
+            DataStore.i.debugConfig.soloScene = debugConfig.soloScene;
+            DataStore.i.debugConfig.soloSceneCoords = debugConfig.soloSceneCoords;
+            DataStore.i.debugConfig.ignoreGlobalScenes = debugConfig.ignoreGlobalScenes;
+            DataStore.i.debugConfig.msgStepByStep = debugConfig.msgStepByStep;
 
             if (!Configuration.EnvironmentSettings.RUNNING_TESTS)
             {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingBus.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/MessagingBus.cs
@@ -211,7 +211,7 @@ namespace DCL
                         if (handler.ProcessMessage(sceneMessage, out msgYieldInstruction))
                         {
 #if UNITY_EDITOR
-                            if (DataStore.debugConfig.msgStepByStep)
+                            if (DataStore.i.debugConfig.msgStepByStep)
                             {
                                 if (VERBOSE)
                                 {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneController.cs
@@ -203,7 +203,7 @@ namespace DCL
             ParcelScene scene;
             bool res = false;
             IWorldState worldState = Environment.i.world.state;
-            DebugConfig debugConfig = DataStore.debugConfig;
+            DebugConfig debugConfig = DataStore.i.debugConfig;
 
             if (worldState.loadedScenes.TryGetValue(sceneId, out scene))
             {
@@ -593,7 +593,7 @@ namespace DCL
                 }
             }
 
-            if (!DataStore.debugConfig.isDebugMode && string.IsNullOrEmpty(worldState.currentSceneId))
+            if (!DataStore.i.debugConfig.isDebugMode && string.IsNullOrEmpty(worldState.currentSceneId))
             {
                 // When we don't know the current scene yet, we must lock the rendering from enabling until it is set
                 CommonScriptableObjects.rendererState.AddLock(this);
@@ -644,7 +644,7 @@ namespace DCL
             var sceneToLoad = scene;
 
 
-            DebugConfig debugConfig = DataStore.debugConfig;
+            DebugConfig debugConfig = DataStore.i.debugConfig;
 #if UNITY_EDITOR
             if (debugConfig.soloScene && sceneToLoad.basePosition.ToString() != debugConfig.soloSceneCoords.ToString())
             {
@@ -819,7 +819,7 @@ namespace DCL
         public void CreateUIScene(string json)
         {
 #if UNITY_EDITOR
-            DebugConfig debugConfig = DataStore.debugConfig;
+            DebugConfig debugConfig = DataStore.i.debugConfig;
 
             if (debugConfig.soloScene && debugConfig.ignoreGlobalScenes)
                 return;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneLifecycleHandler.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneLifecycleHandler.cs
@@ -64,7 +64,7 @@ namespace DCL.Controllers
             owner.RefreshName();
 
 #if UNITY_EDITOR
-            DebugConfig debugConfig = DataStore.debugConfig;
+            DebugConfig debugConfig = DataStore.i.debugConfig;
             //NOTE(Brian): Don't generate parcel blockers if debugScenes is active and is not the desired scene.
             if (debugConfig.soloScene && debugConfig.soloSceneCoords != data.basePosition)
             {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/DataStore/DataStore.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/DataStore/DataStore.cs
@@ -2,11 +2,15 @@
 
 namespace DCL
 {
-    public static class DataStore
+    public class DataStore
     {
-        static public readonly CurrentRealmVariable playerRealm = new CurrentRealmVariable();
-        static public readonly RealmsVariable realmsInfo = new RealmsVariable();
-        static public readonly DebugConfig debugConfig = new DebugConfig();
-        static public readonly BaseVariable<bool> isSignUpFlow = new BaseVariable<bool>();
+        private static DataStore instance = new DataStore();
+        public static DataStore i { get => instance; }
+        public static void Clear() => instance = new DataStore();
+
+        public readonly CurrentRealmVariable playerRealm = new CurrentRealmVariable();
+        public readonly RealmsVariable realmsInfo = new RealmsVariable();
+        public readonly DebugConfig debugConfig = new DebugConfig();
+        public readonly BaseVariable<bool> isSignUpFlow = new BaseVariable<bool>();
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/MouseCatcher/MouseCatcher.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/MouseCatcher/MouseCatcher.cs
@@ -41,7 +41,7 @@ namespace DCL
 
         public void LockCursor()
         {
-            if (!renderingEnabled || DataStore.isSignUpFlow.Get()) return;
+            if (!renderingEnabled || DataStore.i.isSignUpFlow.Get()) return;
 
             Utils.LockCursor();
 #if !WEB_PLATFORM

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/MouseCatcher/MouseCatcher.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/MouseCatcher/MouseCatcher.cs
@@ -41,7 +41,8 @@ namespace DCL
 
         public void LockCursor()
         {
-            if (!renderingEnabled || DataStore.i.isSignUpFlow.Get()) return;
+            if (!renderingEnabled || DataStore.i.isSignUpFlow.Get())
+                return;
 
             Utils.LockCursor();
 #if !WEB_PLATFORM

--- a/unity-client/Assets/Scripts/MainScripts/Debugging/WSS/WSSController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/Debugging/WSS/WSSController.cs
@@ -156,7 +156,7 @@ namespace DCL
             }
 
 #if UNITY_EDITOR
-            DCL.DataStore.debugConfig.isWssDebugMode = true;
+            DCL.DataStore.i.debugConfig.isWssDebugMode = true;
 
             ws = new WebSocketServer("ws://localhost:5000");
             ws.AddWebSocketService<DCLWebSocketService>("/dcl");


### PR DESCRIPTION
The static approach for the `DataStore` makes mocking and testing difficult. The static instance is not being cleaned-up between tests and this lead to errors, leaks from variables not unsubscribing to events, etc...

Ideally we would want this `DataStore` to be in the `Environment` class, and certainly we are aiming for that, but currently is not doable. `Environment` is still in the `MainScripts` assembly and putting the `DataStore` on it would force every class that uses it to reference it. This goes against our current goal of decoupling that humongous assembly from the rest and leads to annoying circular references.

So until `Environment` is on its own assembly we are going to have the `DataStore` as an auto-instanced singleton with a `Clear()` method. I know we are trying to avoid them, but it's temporary and it's the only solution I came up with to keep the system decoupled.