### PR TITLE
fix: avoid npe when querying the graph

### DIFF
--- a/kernel/packages/shared/types.ts
+++ b/kernel/packages/shared/types.ts
@@ -460,13 +460,11 @@ export type CatalystNode = {
 }
 
 export type GraphResponse = {
-  data: {
-    nfts: {
-      ens: {
-        subdomain: string
-      }
-    }[]
-  }
+  nfts: {
+    ens: {
+      subdomain: string
+    }
+  }[]
 }
 
 export type AnalyticsContainer = { analytics: SegmentAnalytics.AnalyticsJS }

--- a/kernel/packages/shared/web3.ts
+++ b/kernel/packages/shared/web3.ts
@@ -110,7 +110,7 @@ query GetNameByBeneficiary($beneficiary: String) {
 
   try {
     const jsonResponse: GraphResponse = await queryGraph(theGraphBaseUrl, query, variables)
-    return jsonResponse.data.nfts.map((nft) => nft.ens.subdomain)
+    return jsonResponse.nfts.map((nft) => nft.ens.subdomain)
   } catch (e) {
     // do nothing
   }

--- a/kernel/packages/shared/web3.ts
+++ b/kernel/packages/shared/web3.ts
@@ -131,7 +131,7 @@ export async function fetchOwner(url: string, name: string) {
 
   try {
     const resp = await queryGraph(url, query, variables)
-    return resp.data.nfts.length === 1 ? (resp.data.nfts[0].owner.address as string) : null
+    return resp.nfts.length === 1 ? (resp.nfts[0].owner.address as string) : null
   } catch (error) {
     defaultLogger.error(`Error querying graph`, error)
     throw error


### PR DESCRIPTION
We were getting some reports of errors like these:
```
Cannot read property 'nfts' of undefined
```


It looks like https://github.com/decentraland/explorer/pull/1962, we replaced the query to subgraph, with the use of the `Fetcher`. The problem is that the fetcher internally does `return response.data`. So when using the fetcher, we don't have to read the `.data` property. When we did, it would be `undefined`