### PR TITLE
fix: Patched error handling to not explode on unhandled promises with no stack trace

### DIFF
--- a/kernel/packages/config/contracts.ts
+++ b/kernel/packages/config/contracts.ts
@@ -140,10 +140,12 @@ export const contracts = {
     'RootChainManagerProxy': '0xbbd7cbfa79faee899eaf900f13c9065bf03b1a74'
   },
   'matic': {
-    'MANAToken': '0xA1c57f48F0Deb89f569dFbE6E2B7f46D33606fD4'
+    'MANAToken': '0xA1c57f48F0Deb89f569dFbE6E2B7f46D33606fD4',
+    'ChildChainManagerProxy': '0xA6FA4fB5f76172d178d61B04b0ecd319C5d1C0aa'
   },
   'mumbai': {
     'MetaTxForwarder': '0xBF6755A83C0dCDBB2933A96EA778E00b717d7004',
-    'MANAToken': '0x882Da5967c435eA5cC6b09150d55E8304B838f45'
+    'MANAToken': '0x882Da5967c435eA5cC6b09150d55E8304B838f45',
+    'ChildChainManagerProxy': '0xb5505a6d998549090530911180f38aC5130101c6'
   }
 }

--- a/kernel/packages/entryPoints/website.ts
+++ b/kernel/packages/entryPoints/website.ts
@@ -92,7 +92,7 @@ namespace webApp {
   export async function loadUnity({ instancedJS }: InitializeUnityResult) {
     const i = (await instancedJS).unityInterface
     const worldConfig: WorldConfig | undefined = globalThis.globalStore.getState().meta.config.world
-    const renderProfile = worldConfig ? (worldConfig.renderProfile ?? RenderProfile.DEFAULT) : RenderProfile.DEFAULT
+    const renderProfile = worldConfig ? worldConfig.renderProfile ?? RenderProfile.DEFAULT : RenderProfile.DEFAULT
 
     i.ConfigureHUDElement(HUDElementID.MINIMAP, { active: true, visible: true })
     i.ConfigureHUDElement(HUDElementID.NOTIFICATION, { active: true, visible: true })
@@ -206,6 +206,12 @@ namespace webApp {
       }
 
       console['error'](error)
+      if (error.message && error.message.includes('The error you provided does not contain a stack trace')) {
+        // This error is something that react causes only on development, with unhandled promises and strange errors with no stack trace (i.e, matrix errors).
+        // Some libraries (i.e, matrix client) don't handle promises well and we shouldn't crash the explorer because of that
+        return
+      }
+
       ReportFatalError(error.message)
     }
     return true


### PR DESCRIPTION
React includes an "error overlay" which is use to shown errors in development.

It seems that overlay can throw an exception when the error received doesn't have an stacktrace: https://github.com/facebook/create-react-app/blob/7e4949a20fc828577fb7626a3262832422f3ae3b/packages/react-error-overlay/src/utils/parser.js#L88

This, combined with Matrix and our error handling, produces an explosive combo, in which Explorer would crash with an exception that should be handled by our sagas.

This PR ignores the error caused by this combination, because we have already a particular handler for when private messages and friends fails to load.
