### PR TITLE
fix: nftshapes error retry

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShapeLoaderController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/NFTShape/NFTShapeLoaderController.cs
@@ -87,19 +87,17 @@ public class NFTShapeLoaderController : MonoBehaviour
         InitializePerlinNoise();
     }
 
-    void Update()
-    {
-        hqTextureHandler?.Update();
-    }
+    void Update() { hqTextureHandler?.Update(); }
 
     public void LoadAsset(string url, bool loadEvenIfAlreadyLoaded = false)
     {
-        if (string.IsNullOrEmpty(url) || (!loadEvenIfAlreadyLoaded && alreadyLoadedAsset)) return;
+        if (string.IsNullOrEmpty(url) || (!loadEvenIfAlreadyLoaded && alreadyLoadedAsset))
+            return;
 
         UpdateBackgroundColor(backgroundColor);
 
         // Check the src follows the needed format e.g.: 'ethereum://0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/558536'
-        var regexMatches = Regex.Matches(url, "(?<protocol>[^:]+)://(?<registry>[^/]+)(?:/(?<asset>.+))?");
+        var regexMatches = Regex.Matches(url, "(?<protocol>[^:]+)://(?<registry>0x([A-Fa-f0-9])+)(?:/(?<asset>.+))?");
         if (regexMatches.Count == 0)
         {
             Debug.LogError($"Couldn't fetch DAR url '{url}' for NFTShape. The accepted format is 'ethereum://ContractAddress/TokenID'");
@@ -233,7 +231,8 @@ public class NFTShapeLoaderController : MonoBehaviour
 
     void SetFrameImage(ITexture newAsset, bool resizeFrameMesh = false)
     {
-        if (newAsset == null) return;
+        if (newAsset == null)
+            return;
 
         UpdateTexture(newAsset.texture);
 
@@ -241,8 +240,10 @@ public class NFTShapeLoaderController : MonoBehaviour
         {
             float w, h;
             w = h = 0.5f;
-            if (newAsset.width > newAsset.height) h *= newAsset.height / (float)newAsset.width;
-            else if (newAsset.width < newAsset.height) w *= newAsset.width / (float)newAsset.height;
+            if (newAsset.width > newAsset.height)
+                h *= newAsset.height / (float)newAsset.width;
+            else if (newAsset.width < newAsset.height)
+                w *= newAsset.width / (float)newAsset.height;
             Vector3 newScale = new Vector3(w, h, 1f);
 
             meshRenderer.transform.localScale = newScale;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/NFTHelper/NFTMarkets/OpenSea_Internal/Request.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/NFTHelper/NFTMarkets/OpenSea_Internal/Request.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.Networking;
 
@@ -28,6 +29,7 @@ namespace DCL.Helpers.NFT.Markets.OpenSea_Internal
                     break;
                 }
             }
+
             if (group == null)
             {
                 group = CreateNewGroup();
@@ -40,13 +42,15 @@ namespace DCL.Helpers.NFT.Markets.OpenSea_Internal
             float delayRequest = IncrementApiRequestDelay();
             OpenSeaRequestGroup group = new OpenSeaRequestGroup(delayRequest, OnGroupClosed, IncrementApiRequestDelay);
             requestGroup.Add(group);
-            if (VERBOSE) Debug.Log($"RequestController: RequestGroup created to request at {lastApiRequestTime}");
+            if (VERBOSE)
+                Debug.Log($"RequestController: RequestGroup created to request at {lastApiRequestTime}");
             return group;
         }
 
         void OnGroupClosed(OpenSeaRequestGroup group)
         {
-            if (VERBOSE) Debug.Log("RequestController: RequestGroup closed");
+            if (VERBOSE)
+                Debug.Log("RequestController: RequestGroup closed");
             if (requestGroup.Contains(group))
             {
                 requestGroup.Remove(group);
@@ -91,6 +95,18 @@ namespace DCL.Helpers.NFT.Markets.OpenSea_Internal
             fetchRoutine = CoroutineStarter.Start(Fetch(delayRequest));
         }
 
+        public OpenSeaRequestGroup(float delayRequest, IEnumerable<KeyValuePair<string, OpenSeaRequest>> existentRequests, Func<float> getRetryDelay)
+        {
+            isOpen = false;
+            foreach ((string key, OpenSeaRequest value) in existentRequests)
+            {
+                requests.Add(key, value);
+                requestUrl += value.ToString() + "&";
+            }
+            this.getRetryDelay = getRetryDelay;
+            fetchRoutine = CoroutineStarter.Start(Fetch(delayRequest));
+        }
+
         public OpenSeaRequest AddRequest(string assetContractAddress, string tokenId)
         {
             string nftId = $"{assetContractAddress}/{tokenId}";
@@ -127,28 +143,39 @@ namespace DCL.Helpers.NFT.Markets.OpenSea_Internal
             {
                 using (UnityWebRequest request = UnityWebRequest.Get(url))
                 {
-                    if (OpenSeaRequestController.VERBOSE) Debug.Log($"RequestGroup: Request to OpenSea {url}");
+                    if (OpenSeaRequestController.VERBOSE)
+                        Debug.Log($"RequestGroup: Request to OpenSea {url}");
                     yield return request.SendWebRequest();
 
                     AssetsResponse response = null;
 
                     if (!request.isNetworkError && !request.isHttpError)
                     {
+                        Debug.Log(request.downloadHandler.text);
                         response = Utils.FromJsonWithNulls<AssetsResponse>(request.downloadHandler.text);
                     }
 
-                    if (OpenSeaRequestController.VERBOSE) Debug.Log($"RequestGroup: Request resolving {response != null} {request.error} {url}");
+                    if (OpenSeaRequestController.VERBOSE)
+                        Debug.Log($"RequestGroup: Request resolving {response != null} {request.error} {url}");
                     if (response != null)
                     {
                         shouldRetry = false;
-                        using (var iterator = requests.GetEnumerator())
+                        //if we have one element in the group, is the one failing and we dont group it again
+                        if (response.assets.Length != 0 || requests.Count <= 1)
                         {
-                            while (iterator.MoveNext())
+                            using (var iterator = requests.GetEnumerator())
                             {
-                                iterator.Current.Value.Resolve(response);
+                                while (iterator.MoveNext())
+                                {
+                                    iterator.Current.Value.Resolve(response);
+                                }
                             }
                         }
-
+                        else
+                        {
+                            //There are invalids NFTs to fetch, we split the request into 2 smaller groups to find the ofender
+                            SplitGroup();
+                        }
                     }
                     else
                     {
@@ -166,12 +193,23 @@ namespace DCL.Helpers.NFT.Markets.OpenSea_Internal
                         else
                         {
                             retryCount++;
-                            if (OpenSeaRequestController.VERBOSE) Debug.Log($"RequestGroup: Request retrying {url}");
+                            if (OpenSeaRequestController.VERBOSE)
+                                Debug.Log($"RequestGroup: Request retrying {url}");
                             yield return new WaitForSeconds(GetRetryDelay());
                         }
                     }
                 }
             } while (shouldRetry);
+        }
+
+        void SplitGroup()
+        {
+            int counter = 0;
+            var groups = requests.GroupBy(x => counter++ % 2);
+            foreach (var group in groups)
+            {
+                new OpenSeaRequestGroup(getRetryDelay(), group, getRetryDelay );
+            }
         }
 
         void CloseGroup()
@@ -190,7 +228,8 @@ namespace DCL.Helpers.NFT.Markets.OpenSea_Internal
 
         public void Dispose()
         {
-            if (fetchRoutine != null) CoroutineStarter.Stop(fetchRoutine);
+            if (fetchRoutine != null)
+                CoroutineStarter.Stop(fetchRoutine);
             fetchRoutine = null;
             CloseGroup();
         }
@@ -211,12 +250,14 @@ namespace DCL.Helpers.NFT.Markets.OpenSea_Internal
         public OpenSeaRequestAllNFTs(string assetContractAddress, Action<AssetsResponse> OnSuccess, Action<string> OnError)
         {
             this.assetContractAddress = assetContractAddress;
-            if (OpenSeaRequestController.VERBOSE) Debug.Log($"Request: created {this.ToString()}");
+            if (OpenSeaRequestController.VERBOSE)
+                Debug.Log($"Request: created {this.ToString()}");
 
             this.OnSuccess = OnSuccess;
             this.OnError = OnError;
 
-            if (fetchRoutine != null) CoroutineStarter.Stop(fetchRoutine);
+            if (fetchRoutine != null)
+                CoroutineStarter.Stop(fetchRoutine);
             fetchRoutine = CoroutineStarter.Start(Fetch());
         }
 
@@ -231,7 +272,8 @@ namespace DCL.Helpers.NFT.Markets.OpenSea_Internal
             {
                 using (UnityWebRequest request = UnityWebRequest.Get(url))
                 {
-                    if (OpenSeaRequestController.VERBOSE) Debug.Log($"RequestGroup: Request to OpenSea {url}");
+                    if (OpenSeaRequestController.VERBOSE)
+                        Debug.Log($"RequestGroup: Request to OpenSea {url}");
                     yield return request.SendWebRequest();
 
                     AssetsResponse response = null;
@@ -241,7 +283,8 @@ namespace DCL.Helpers.NFT.Markets.OpenSea_Internal
                         response = Utils.FromJsonWithNulls<AssetsResponse>(request.downloadHandler.text);
                     }
 
-                    if (OpenSeaRequestController.VERBOSE) Debug.Log($"RequestGroup: Request resolving {response != null} {request.error} {url}");
+                    if (OpenSeaRequestController.VERBOSE)
+                        Debug.Log($"RequestGroup: Request resolving {response != null} {request.error} {url}");
                     if (response != null)
                     {
                         shouldRetry = false;
@@ -257,7 +300,8 @@ namespace DCL.Helpers.NFT.Markets.OpenSea_Internal
                         else
                         {
                             retryCount++;
-                            if (OpenSeaRequestController.VERBOSE) Debug.Log($"RequestGroup: Request retrying {url}");
+                            if (OpenSeaRequestController.VERBOSE)
+                                Debug.Log($"RequestGroup: Request retrying {url}");
                             yield return new WaitForSeconds(GetRetryDelay());
                         }
                     }
@@ -265,15 +309,9 @@ namespace DCL.Helpers.NFT.Markets.OpenSea_Internal
             } while (shouldRetry);
         }
 
-        float GetRetryDelay()
-        {
-            return OpenSeaRequestController.MIN_REQUEST_DELAY;
-        }
+        float GetRetryDelay() { return OpenSeaRequestController.MIN_REQUEST_DELAY; }
 
-        public override string ToString()
-        {
-            return $"asset_contract_addresses={assetContractAddress}";
-        }
+        public override string ToString() { return $"asset_contract_addresses={assetContractAddress}"; }
     }
 
     internal class OpenSeaRequest
@@ -289,7 +327,8 @@ namespace DCL.Helpers.NFT.Markets.OpenSea_Internal
         {
             this.assetContractAddress = assetContractAddress;
             this.tokenId = tokenId;
-            if (OpenSeaRequestController.VERBOSE) Debug.Log($"Request: created {this.ToString()}");
+            if (OpenSeaRequestController.VERBOSE)
+                Debug.Log($"Request: created {this.ToString()}");
         }
 
         public void Resolve(AssetsResponse response)
@@ -300,7 +339,8 @@ namespace DCL.Helpers.NFT.Markets.OpenSea_Internal
                 asset = response.assets[i];
                 if (asset.token_id == tokenId && String.Equals(asset.asset_contract.address, assetContractAddress, StringComparison.OrdinalIgnoreCase))
                 {
-                    if (OpenSeaRequestController.VERBOSE) Debug.Log($"Request: resolved {this.ToString()}");
+                    if (OpenSeaRequestController.VERBOSE)
+                        Debug.Log($"Request: resolved {this.ToString()}");
                     assetResponse = asset;
                     break;
                 }
@@ -308,7 +348,8 @@ namespace DCL.Helpers.NFT.Markets.OpenSea_Internal
             if (assetResponse == null)
             {
                 error = $"asset {assetContractAddress}/{tokenId} not found in api response";
-                if (OpenSeaRequestController.VERBOSE) Debug.Log($"Request: for {assetContractAddress}/{tokenId} not found {JsonUtility.ToJson(response)}");
+                if (OpenSeaRequestController.VERBOSE)
+                    Debug.Log($"Request: for {assetContractAddress}/{tokenId} not found {JsonUtility.ToJson(response)}");
             }
             resolved = true;
         }
@@ -333,10 +374,7 @@ namespace DCL.Helpers.NFT.Markets.OpenSea_Internal
             }
         }
 
-        public override string ToString()
-        {
-            return $"asset_contract_addresses={assetContractAddress}&token_ids={tokenId}";
-        }
+        public override string ToString() { return $"asset_contract_addresses={assetContractAddress}&token_ids={tokenId}"; }
     }
 
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/NFTHelper/NFTMarkets/OpenSea_Internal/Request.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Helpers/NFTHelper/NFTMarkets/OpenSea_Internal/Request.cs
@@ -95,7 +95,7 @@ namespace DCL.Helpers.NFT.Markets.OpenSea_Internal
             fetchRoutine = CoroutineStarter.Start(Fetch(delayRequest));
         }
 
-        public OpenSeaRequestGroup(float delayRequest, IEnumerable<KeyValuePair<string, OpenSeaRequest>> existentRequests, Func<float> getRetryDelay)
+        private OpenSeaRequestGroup(float delayRequest, IEnumerable<KeyValuePair<string, OpenSeaRequest>> existentRequests, Func<float> getRetryDelay)
         {
             isOpen = false;
             foreach ((string key, OpenSeaRequest value) in existentRequests)
@@ -151,7 +151,6 @@ namespace DCL.Helpers.NFT.Markets.OpenSea_Internal
 
                     if (!request.isNetworkError && !request.isHttpError)
                     {
-                        Debug.Log(request.downloadHandler.text);
                         response = Utils.FromJsonWithNulls<AssetsResponse>(request.downloadHandler.text);
                     }
 


### PR DESCRIPTION
#1968

The OpenSea API requests allow us to fetch the info of multiple NFTs in a single request. The downside is that if any of the NFTs is invalid the whole request wont return anything (not even an error). So when dealing with that situation, we split the failed request into 2 smaller requests to narrow down the ofender NFT.