### PR TITLE
fix: always show wallet selector

### DIFF
--- a/website/src/components/auth/EthLogin.tsx
+++ b/website/src/components/auth/EthLogin.tsx
@@ -18,11 +18,7 @@ export const EthLogin: React.FC<EthLoginProps> = (props) => {
   const isLoading = props.loading || showWalletSelector;
 
   function handlePlay() {
-    if (props.onLogin && hasWallet) {
-      return props.onLogin(ProviderType.INJECTED);
-    } else {
-      setShowWalletSelector(true);
-    }
+    setShowWalletSelector(true);
   }
 
   function handlePlayAsGuest() {


### PR DESCRIPTION
# What? 

changes the login behaviour: always shows the wallet selector

# Why?

to have the same behaviour in all apps