### PR TITLE
feat: biw correct error handling while working with shapes

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadableShape.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/LoadableShape.cs
@@ -79,7 +79,7 @@ namespace DCL.Components
     {
         private bool isLoaded = false;
         private bool failed = false;
-        private event Action<BaseDisposable> OnReadyCallbacks;
+        private event Action<BaseDisposable> OnFinishCallbacks;
         public System.Action<DecentralandEntity> OnEntityShapeUpdated;
 
         new public LoadWrapperModelType model
@@ -199,8 +199,8 @@ namespace DCL.Components
             CleanFailedWrapper(loadWrapper);
 
             failed = true;
-            OnReadyCallbacks?.Invoke(this);
-            OnReadyCallbacks = null;
+            OnFinishCallbacks?.Invoke(this);
+            OnFinishCallbacks = null;
         }
 
         void CleanFailedWrapper(LoadWrapper loadWrapper)
@@ -247,8 +247,8 @@ namespace DCL.Components
 
             entity.OnShapeUpdated?.Invoke(entity);
 
-            OnReadyCallbacks?.Invoke(this);
-            OnReadyCallbacks = null;
+            OnFinishCallbacks?.Invoke(this);
+            OnFinishCallbacks = null;
         }
 
         protected virtual void DetachShape(DecentralandEntity entity)
@@ -271,7 +271,7 @@ namespace DCL.Components
             }
             else
             {
-                OnReadyCallbacks += callback;
+                OnFinishCallbacks += callback;
             }
         }
     }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderEntity/DCLBuilderInWorldEntity.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/BuilderEntity/DCLBuilderInWorldEntity.cs
@@ -12,7 +12,8 @@ public class DCLBuilderInWorldEntity : EditableEntity
 {
     public string entityUniqueId;
 
-    public event System.Action<DCLBuilderInWorldEntity> onStatusUpdate;
+    public event System.Action<DCLBuilderInWorldEntity> OnShapeFinishLoading;
+    public event System.Action<DCLBuilderInWorldEntity> OnStatusUpdate;
     public event System.Action<DCLBuilderInWorldEntity> OnDelete;
 
     private bool isLockedValue = false;
@@ -23,7 +24,7 @@ public class DCLBuilderInWorldEntity : EditableEntity
         set
         {
             SetIsLockedValue(value);
-            onStatusUpdate?.Invoke(this);
+            OnStatusUpdate?.Invoke(this);
         }
     }
 
@@ -35,7 +36,7 @@ public class DCLBuilderInWorldEntity : EditableEntity
         set
         {
             isSelectedValue = value;
-            onStatusUpdate?.Invoke(this);
+            OnStatusUpdate?.Invoke(this);
         }
     }
 
@@ -47,7 +48,7 @@ public class DCLBuilderInWorldEntity : EditableEntity
         set
         {
             isNewValue = value;
-            onStatusUpdate?.Invoke(this);
+            OnStatusUpdate?.Invoke(this);
         }
     }
 
@@ -59,7 +60,7 @@ public class DCLBuilderInWorldEntity : EditableEntity
         set
         {
             isVisibleValue = value;
-            onStatusUpdate?.Invoke(this);
+            OnStatusUpdate?.Invoke(this);
         }
     }
 
@@ -147,10 +148,12 @@ public class DCLBuilderInWorldEntity : EditableEntity
     {
         rootEntity.gameObject.SetActive(!gameObject.activeSelf);
         IsVisible = gameObject.activeSelf;
-        onStatusUpdate?.Invoke(this);
+        OnStatusUpdate?.Invoke(this);
     }
 
     public void ToggleLockStatus() { IsLocked = !IsLocked; }
+
+    public void ShapeLoadFinish(ISharedComponent component) { OnShapeFinishLoading?.Invoke(this); }
 
     public void Delete()
     {
@@ -266,7 +269,7 @@ public class DCLBuilderInWorldEntity : EditableEntity
             scene.SharedComponentAttach(rootEntity.entityId, name.id);
         }
 
-        onStatusUpdate?.Invoke(this);
+        OnStatusUpdate?.Invoke(this);
     }
 
     public string GetDescriptiveName()
@@ -455,7 +458,7 @@ public class DCLBuilderInWorldEntity : EditableEntity
         }
     }
 
-    void OnNameUpdate(DCLName.Model model) { onStatusUpdate?.Invoke(this); }
+    void OnNameUpdate(DCLName.Model model) { OnStatusUpdate?.Invoke(this); }
 
     void OnShapeUpdate(DecentralandEntity decentralandEntity)
     {

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWCreatorController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWCreatorController.cs
@@ -185,7 +185,7 @@ public class BIWCreatorController : BIWController
         }
     }
 
-    private void RemoveLoadingObject(string entityId)
+    public void RemoveLoadingObject(string entityId)
     {
         if (!loadingGameObjects.ContainsKey(entityId))
             return;
@@ -237,10 +237,9 @@ public class BIWCreatorController : BIWController
             nftShape.model.color = new Color(0.6404918f, 0.611472f, 0.8584906f);
             nftShape.model.src = catalogItem.model;
             nftShape.model.assetId = catalogItem.id;
-            nftShape.CallWhenReady(OnShapeLoadFinish);
-
             sceneToEdit.SharedComponentAttach(entity.rootEntity.entityId, nftShape.id);
 
+            nftShape.CallWhenReady(OnShapeLoadFinish);
         }
         else
         {
@@ -248,8 +247,9 @@ public class BIWCreatorController : BIWController
             gltfComponent.model = new LoadableShape.Model();
             gltfComponent.model.src = catalogItem.model;
             gltfComponent.model.assetId = catalogItem.id;
-            gltfComponent.CallWhenReady(OnShapeLoadFinish);
             sceneToEdit.SharedComponentAttach(entity.rootEntity.entityId, gltfComponent.id);
+
+            gltfComponent.CallWhenReady(OnShapeLoadFinish);
 
         }
 

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWFloorHandler.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Controllers/BIWFloorHandler.cs
@@ -96,12 +96,18 @@ public class BIWFloorHandler : BIWController
 
             GameObject floorPlaceHolder = GameObject.Instantiate(floorPrefab, decentralandEntity.rootEntity.gameObject.transform.position, Quaternion.identity);
             floorPlaceHolderDict.Add(decentralandEntity.rootEntity.entityId, floorPlaceHolder);
+            decentralandEntity.OnShapeFinishLoading += OnShapeLoadFinish;
             builderInWorldBridge?.EntityTransformReport(decentralandEntity.rootEntity, sceneToEdit);
-            CoroutineStarter.Start(FloorTimeOut(decentralandEntity.rootEntity.entityId));
         }
 
         builderInWorldEntityHandler.DeselectEntities();
         lastFloorCalalogItemUsed = floorSceneObject;
+    }
+
+    private void OnShapeLoadFinish(DCLBuilderInWorldEntity entity)
+    {
+        entity.OnShapeFinishLoading -= OnShapeLoadFinish;
+        RemovePlaceHolder(entity.rootEntity.entityId);
     }
 
     private void OnFloorLoaded(DecentralandEntity entity)
@@ -119,12 +125,5 @@ public class BIWFloorHandler : BIWController
         floorPlaceHolderDict.Remove(entityId);
         GameObject.Destroy(floorPlaceHolder);
         dclBuilderMeshLoadIndicatorController.HideIndicator(entityId);
-    }
-
-    private IEnumerator FloorTimeOut(string entityId)
-    {
-        yield return new WaitForSeconds(secondsToTimeOut);
-        RemovePlaceHolder(entityId);
-        Debug.LogError("Floor loading timeout " + entityId);
     }
 }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Tests/BIWCreatorShould.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/BuilderMode/Tests/BIWCreatorShould.cs
@@ -2,10 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using DCL;
+using DCL.Components;
 using DCL.Helpers;
 using DCL.Models;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 public class BIWCreatorShould : IntegrationTestSuite_Legacy
 {
@@ -94,7 +96,7 @@ public class BIWCreatorShould : IntegrationTestSuite_Legacy
         //Act
         biwCreatorController.CreateCatalogItem(item);
         DCLBuilderInWorldEntity entity = entityHandler.GetAllEntitiesFromCurrentScene().FirstOrDefault();
-        entity.rootEntity.OnShapeUpdated?.Invoke(entity.rootEntity);
+        biwCreatorController.RemoveLoadingObject(entity.rootEntity.entityId);
 
         //Assert
         Assert.IsFalse(biwCreatorController.ExistsLoadingGameObjectForEntity(entity.rootEntity.entityId));

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/Common/EntityInformationController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/Common/EntityInformationController.cs
@@ -107,8 +107,8 @@ public class EntityInformationController : IEntityInformationController
 
         if (entityInformationView.currentEntity != null)
         {
-            entity.onStatusUpdate -= UpdateEntityName;
-            entityInformationView.currentEntity.onStatusUpdate += UpdateEntityName;
+            entity.OnStatusUpdate -= UpdateEntityName;
+            entityInformationView.currentEntity.OnStatusUpdate += UpdateEntityName;
         }
 
         parcelScene = currentScene;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/GodMode/Inspector/EntityListAdapter.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/BuildModeHUD/Scripts/GodMode/Inspector/EntityListAdapter.cs
@@ -24,7 +24,7 @@ public class EntityListAdapter : MonoBehaviour
     {
         if (currentEntity != null)
         {
-            currentEntity.onStatusUpdate -= SetInfo;
+            currentEntity.OnStatusUpdate -= SetInfo;
             currentEntity.OnDelete -= DeleteAdapter;
             DCL.Environment.i.world.sceneBoundsChecker.OnEntityBoundsCheckerStatusChanged -= ChangeEntityBoundsCheckerStatus;
         }
@@ -34,12 +34,12 @@ public class EntityListAdapter : MonoBehaviour
     {
         if (currentEntity != null)
         {
-            currentEntity.onStatusUpdate -= SetInfo;
+            currentEntity.OnStatusUpdate -= SetInfo;
             currentEntity.OnDelete -= DeleteAdapter;
             DCL.Environment.i.world.sceneBoundsChecker.OnEntityBoundsCheckerStatusChanged -= ChangeEntityBoundsCheckerStatus;
         }
         currentEntity = decentrelandEntity;
-        currentEntity.onStatusUpdate += SetInfo;
+        currentEntity.OnStatusUpdate += SetInfo;
         currentEntity.OnDelete += DeleteAdapter;
         DCL.Environment.i.world.sceneBoundsChecker.OnEntityBoundsCheckerStatusChanged += ChangeEntityBoundsCheckerStatus;
 


### PR DESCRIPTION
# What? 
This PR makes the loading objects of builder in world to correctly handle errors and removing loading items when necessary

# Why? 
Currently, we had a timeout of 10 seconds to delete the loading objects in case they didn't load, now it is related to the shape component so the loading object will be destroyed when loaded/error