### PR TITLE
fix: remove need for yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Make sure you have the following dependencies:
 - Latest version of GNU make, install it using `brew install make`
 - If you are using Windows 10, you must enable the Linux subsystem and install a Linux distro from Windows Store like Ubuntu. Then install all tools and dependecies like nodejs, npm, typescript, make, et cetera.
 - Node v10 or compatible installed via `sudo apt install nodejs` or [nvm](https://github.com/nvm-sh/nvm)
-- yarn installed globally via `npm install yarn -g`
 
 ---
 **IMPORTANT:** If your path has spaces the build process will fail. Make sure to clone this repo in a properly named path.

--- a/kernel/package-lock.json
+++ b/kernel/package-lock.json
@@ -1017,9 +1017,9 @@
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
     "@types/matrix-js-sdk": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/matrix-js-sdk/-/matrix-js-sdk-5.1.0.tgz",
-      "integrity": "sha512-u3zWul7ENUnWko8GsTnM20HKO1tDhyRiVsQha8aOSOxd3DbNAcXceIKw3XaMLqCRaH60L6yZVrJai9K2b6iIwg=="
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@types/matrix-js-sdk/-/matrix-js-sdk-5.1.3.tgz",
+      "integrity": "sha512-u4ofG4C8mRLcG/rH6fCSBVh1wpIINNEFVAY2kK70xEX2kpOuONHA7wrQ1iqaaSYh5zVuAs12Pf4Tzf89mwwsGQ=="
     },
     "@types/mime": {
       "version": "2.0.1",
@@ -3043,6 +3043,15 @@
         "write-file-atomic": "^2.4.2"
       }
     },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
     "caller-callsite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
@@ -3857,20 +3866,20 @@
       "integrity": "sha512-1GrnacmjHSNxhHwjbnAc3MzN8xZG3tFSFEZ9Tb/njHPuxKEmoYaawfVnlUcUehHaKsQsJdpRMGdOvH/QILNDlw=="
     },
     "dcl-social-client": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.3.10.tgz",
-      "integrity": "sha512-o8ac+Yv+AMfPRcbOxgkj9wqDoy7+JBeZAwWrSFge4KFRvERL9DZgIA9SLSEBq5n5dHxm5Ho01NNQ5sB6EjYb1g==",
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.3.12.tgz",
+      "integrity": "sha512-5H//Tywd7ggzD6WM5VuqsaA10vGS8xc+L6idFFmW/WRpDjM61Z9gBJAZnIWS/PSRgWHHi+dKVeeOmdFCTS7xPQ==",
       "requires": {
-        "@types/matrix-js-sdk": "^5.1.0",
+        "@types/matrix-js-sdk": "^5.1.2",
         "@types/node": "^13.11.1",
         "dcl-crypto": "^2.2.0",
-        "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#7b7356192337341b7f346fc17c6b4e5679f4454f"
+        "matrix-js-sdk": "^7.1.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.9.tgz",
-          "integrity": "sha512-EPZBIGed5gNnfWCiwEIwTE2Jdg4813odnG8iNPMQGrqVxrI+wL68SPtPeCX+ZxGBaA6pKAVc6jaKgP/Q0QzfdQ=="
+          "version": "13.13.47",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.47.tgz",
+          "integrity": "sha512-R6851wTjN1YJza8ZIeX6puNBSi/ZULHVh4WVleA7q256l+cP2EtXnKbO455fTs2ytQk3dL9qkU+Wh8l/uROdKg=="
         }
       }
     },
@@ -7066,6 +7075,16 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
@@ -7314,6 +7333,11 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
       "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+    },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
     },
     "has-to-string-tag-x": {
       "version": "1.4.1",
@@ -8825,9 +8849,9 @@
       }
     },
     "loglevel": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
-      "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA=="
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
+      "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw=="
     },
     "lolex": {
       "version": "2.7.5",
@@ -9012,8 +9036,9 @@
       }
     },
     "matrix-js-sdk": {
-      "version": "github:matrix-org/matrix-js-sdk#7b7356192337341b7f346fc17c6b4e5679f4454f",
-      "from": "github:matrix-org/matrix-js-sdk#7b7356192337341b7f346fc17c6b4e5679f4454f",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-7.1.0.tgz",
+      "integrity": "sha512-Y+MdOfsVQRGx0KcwSdNtwsFNGWUF7Zi7wPxUSa050J8eBlbkXUNFAyuSWviLJ5pUwzmp9XMEKD9Cdv+tGZG1ww==",
       "requires": {
         "@babel/runtime": "^7.8.3",
         "another-json": "^0.2.0",
@@ -10007,6 +10032,11 @@
         }
       }
     },
+    "object-inspect": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+    },
     "object-keys": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.5.0.tgz",
@@ -10990,9 +11020,12 @@
       }
     },
     "qs": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
     },
     "query-string": {
       "version": "5.1.1",
@@ -11776,6 +11809,16 @@
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
         "rechoir": "^0.6.2"
+      }
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
       }
     },
     "signal-exit": {

--- a/kernel/package.json
+++ b/kernel/package.json
@@ -103,7 +103,7 @@
     "dcl-ecs-quests": "^1.0.0",
     "dcl-quests-client": "^2.0.0",
     "dcl-scene-writer": "^1.1.2",
-    "dcl-social-client": "^1.3.10",
+    "dcl-social-client": "^1.3.12",
     "decentraland-connect": "^2.13.2",
     "decentraland-katalyst-peer": "0.2.20",
     "decentraland-renderer": "^1.8.64775",


### PR DESCRIPTION
By updating the `dcl-social-client` library to the latest version, we can now remove the need for yarn