### PR TITLE
feat: allow fake ownership of collections

### DIFF
--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -65,9 +65,8 @@ export namespace parcelLimits {
   ]
 
   export const descriptiveValidWorldRanges = validWorldRanges
-    .map(range => `(X from ${range.x.from} to ${range.x.to}, and Y from ${range.y.from} to ${range.y.to})`)
+    .map((range) => `(X from ${range.x.from} to ${range.x.to}, and Y from ${range.y.from} to ${range.y.to})`)
     .join(' or ')
-
 }
 export namespace playerConfigurations {
   export const gravity = -0.2
@@ -266,6 +265,7 @@ export function getExclusiveServer() {
 }
 
 export const ALL_WEARABLES = location.search.includes('ALL_WEARABLES') && getDefaultTLD() !== 'org'
+export const WITH_FIXED_COLLECTIONS = getDefaultTLD() !== 'org' ? qs.WITH_COLLECTIONS : undefined
 export const WEARABLE_API_DOMAIN = qs.WEARABLE_API_DOMAIN || 'wearable-api.decentraland.org'
 export const WEARABLE_API_PATH_PREFIX = qs.WEARABLE_API_PATH_PREFIX || 'v2'
 export const ENABLE_EMPTY_SCENES = !DEBUG || knownTLDs.includes(getTLD())

--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -265,7 +265,7 @@ export function getExclusiveServer() {
 }
 
 export const ALL_WEARABLES = location.search.includes('ALL_WEARABLES') && getDefaultTLD() !== 'org'
-export const WITH_FIXED_COLLECTIONS = getDefaultTLD() !== 'org' ? qs.WITH_COLLECTIONS : undefined
+export const WITH_FIXED_COLLECTIONS = qs.WITH_COLLECTIONS && getDefaultTLD() !== 'org' ? qs.WITH_COLLECTIONS : undefined
 export const WEARABLE_API_DOMAIN = qs.WEARABLE_API_DOMAIN || 'wearable-api.decentraland.org'
 export const WEARABLE_API_PATH_PREFIX = qs.WEARABLE_API_PATH_PREFIX || 'v2'
 export const ENABLE_EMPTY_SCENES = !DEBUG || knownTLDs.includes(getTLD())

--- a/kernel/packages/shared/catalogs/sagas.ts
+++ b/kernel/packages/shared/catalogs/sagas.ts
@@ -6,7 +6,8 @@ import {
   PIN_CATALYST,
   WSS_ENABLED,
   TEST_WEARABLES_OVERRIDE,
-  ALL_WEARABLES
+  ALL_WEARABLES,
+  WITH_FIXED_COLLECTIONS
 } from 'config'
 
 import defaultLogger from 'shared/logger'
@@ -159,12 +160,20 @@ function* fetchWearablesV2(filters: WearablesRequestFilters) {
 
   const result: any[] = []
   if (filters.ownedByUser) {
-    // TODO: What about ALL_WEARABLES?
-
-    const ownedWearables: OwnedWearablesWithDefinition[] = yield call(fetchOwnedWearables, filters.ownedByUser, client)
-    for (const { amount, definition } of ownedWearables) {
-      for (let i = 0; i < amount; i++) {
-        result.push(definition)
+    if (WITH_FIXED_COLLECTIONS) {
+      const collectionIds = WITH_FIXED_COLLECTIONS.split(',')
+      const wearables = yield call(fetchWearablesByFilters, { collectionIds }, client)
+      result.push(...wearables)
+    } else {
+      const ownedWearables: OwnedWearablesWithDefinition[] = yield call(
+        fetchOwnedWearables,
+        filters.ownedByUser,
+        client
+      )
+      for (const { amount, definition } of ownedWearables) {
+        for (let i = 0; i < amount; i++) {
+          result.push(definition)
+        }
       }
     }
   } else {


### PR DESCRIPTION
As of now, we have the `ALL_WEARABLES` flag that allows users to simulate as if the owned all existing wearables. 

With the changes made to support decentralized wearables, this is no longer an option. So the idea is to have a new query parameter called `WITH_COLLECTIONS` what would be used like this:
```
&WITH_COLLECTIONS=collectionId1,collectionId2,...
```
This parameter will only work for non-productive environments

### How to test it
Check this link to see how it looks like you own the wearables
https://play.decentraland.zone/branch/feat/allow-fake-ownership-of-collections/index.html?CATALYST=peer-testing.decentraland.org&ENABLE_WEARABLES_V2&WITH_COLLECTIONS=0x102daabd1e9d294d4436ec4c521dce7b1f15499e%2C0x30d3387ff3de2a21bef7032f82d00ff7739e403c

But in a prod environment, it doesn't work
https://play.decentraland.zone/branch/feat/allow-fake-ownership-of-collections/index.html?CATALYST=peer-testing.decentraland.org&ENABLE_WEARABLES_V2&WITH_COLLECTIONS=0x102daabd1e9d294d4436ec4c521dce7b1f15499e%2C0x30d3387ff3de2a21bef7032f82d00ff7739e403c&ENV=org