### PR TITLE
fix: null check for currentShape in SceneBoundariesChecker

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneBoundariesController/SceneBoundsFeedbackStyle_Simple.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Scene/SceneBoundariesController/SceneBoundsFeedbackStyle_Simple.cs
@@ -6,17 +6,14 @@ namespace DCL.Controllers
 {
     public class SceneBoundsFeedbackStyle_Simple : ISceneBoundsFeedbackStyle
     {
-        public void OnRendererExitBounds(Renderer renderer)
-        {
-            renderer.enabled = false;
-        }
+        public void OnRendererExitBounds(Renderer renderer) { renderer.enabled = false; }
 
         public void ApplyFeedback(MeshesInfo meshesInfo, bool isInsideBoundaries)
         {
             if (meshesInfo?.renderers == null || meshesInfo.renderers.Length == 0)
                 return;
 
-            if (!meshesInfo.currentShape.IsVisible())
+            if (meshesInfo?.currentShape != null && !meshesInfo.currentShape.IsVisible())
                 return;
 
             for (int i = 0; i < meshesInfo.renderers.Length; i++)
@@ -30,7 +27,6 @@ namespace DCL.Controllers
                 meshesInfo.renderers[i].enabled = isInsideBoundaries;
             }
         }
-
 
         public List<Material> GetOriginalMaterials(MeshesInfo meshesInfo)
         {


### PR DESCRIPTION
With the addition of TextMeshPro meshes to the SceneBoundariesChecker we were missing an edge case where an entity doesn't have a `currentShape` set but it triggers the SceneBoundariesChecker due to the renderers.