### PR TITLE
chore: update base avatars collection id

### DIFF
--- a/kernel/package-lock.json
+++ b/kernel/package-lock.json
@@ -435,9 +435,9 @@
       }
     },
     "@dcl/urn-resolver": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@dcl/urn-resolver/-/urn-resolver-1.0.2.tgz",
-      "integrity": "sha512-84N9Gd5wWZQUhi2S3HE5Wano4QrJhkysIlT+pQhRP3lKXHEe0COONJfdCDgo3ca9GKS6KaSrDEFNnELcgkafqg=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/urn-resolver/-/urn-resolver-1.1.0.tgz",
+      "integrity": "sha512-Msc1ALU5pSwtq7O/mN3S3S0UinrWZbHd96osP1fLU2R4gUi/VBv16i4EBOZfCvf1RQ4Cr/fI4H6B1C/QZzeTIA=="
     },
     "@eslint/eslintrc": {
       "version": "0.4.0",
@@ -6567,12 +6567,12 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -6580,7 +6580,7 @@
         },
         "readable-stream": {
           "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "resolved": false,
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -6594,7 +6594,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"

--- a/kernel/package.json
+++ b/kernel/package.json
@@ -93,7 +93,7 @@
     "web3x-codegen": "^4.0.6"
   },
   "dependencies": {
-    "@dcl/urn-resolver": "^1.0.2",
+    "@dcl/urn-resolver": "^1.1.0",
     "bignumber.js": "^9.0.0",
     "blob-to-buffer": "^1.2.8",
     "body-scroll-lock": "^2.5.10",

--- a/kernel/packages/shared/catalogs/sagas.ts
+++ b/kernel/packages/shared/catalogs/sagas.ts
@@ -40,8 +40,8 @@ import { parseUrn } from '@dcl/urn-resolver'
 import { getCatalystServer, getFetchContentServer } from 'shared/dao/selectors'
 
 declare const globalThis: Window & UnityInterfaceContainer & StoreContainer
-export const WRONG_FILTERS_ERROR =
-  'You must set one and only one filter for V1. Also, the only collection name allowed is base-avatars'
+const BASE_AVATARS_COLLECTION_ID = 'urn:decentraland:off-chain:base-avatars'
+export const WRONG_FILTERS_ERROR = `You must set one and only one filter for V1. Also, the only collection id allowed is '${BASE_AVATARS_COLLECTION_ID}'`
 
 /**
  * This saga handles wearable definition fetching.
@@ -344,7 +344,7 @@ function areFiltersValid(filters: WearablesRequestFilters) {
   let ok = true
   if (filters.collectionIds) {
     filtersSet += 1
-    if (filters.collectionIds.some((name) => name !== 'base-avatars')) {
+    if (filters.collectionIds.some((id) => id !== BASE_AVATARS_COLLECTION_ID)) {
       ok = false
     }
   }

--- a/kernel/packages/shared/catalogs/sagas.ts
+++ b/kernel/packages/shared/catalogs/sagas.ts
@@ -40,7 +40,7 @@ import { parseUrn } from '@dcl/urn-resolver'
 import { getCatalystServer, getFetchContentServer } from 'shared/dao/selectors'
 
 declare const globalThis: Window & UnityInterfaceContainer & StoreContainer
-const BASE_AVATARS_COLLECTION_ID = 'urn:decentraland:off-chain:base-avatars'
+export const BASE_AVATARS_COLLECTION_ID = 'urn:decentraland:off-chain:base-avatars'
 export const WRONG_FILTERS_ERROR = `You must set one and only one filter for V1. Also, the only collection id allowed is '${BASE_AVATARS_COLLECTION_ID}'`
 
 /**

--- a/kernel/packages/shared/catalogs/sagas.ts
+++ b/kernel/packages/shared/catalogs/sagas.ts
@@ -258,7 +258,7 @@ async function mapLegacyIdToUrn(wearableId: WearableId): Promise<WearableId | un
   }
   try {
     const result = await parseUrn(wearableId)
-    if (result?.type === 'off-chain' || result?.type === 'blockchain-collection-v1') {
+    if (result?.type === 'off-chain' || result?.type === 'blockchain-collection-v1-asset') {
       return result.uri.toString()
     }
   } catch {
@@ -281,7 +281,7 @@ export async function mapUrnToLegacyId(wearableId: WearableId): Promise<Wearable
     const result = await parseUrn(wearableId)
     if (result?.type === 'off-chain') {
       return `dcl://${result.registry}/${result.id}`
-    } else if (result?.type === 'blockchain-collection-v1') {
+    } else if (result?.type === 'blockchain-collection-v1-asset') {
       return `dcl://${result.collectionName}/${result.id}`
     }
   } catch {

--- a/kernel/test/unit/catalog.saga.test.tsx
+++ b/kernel/test/unit/catalog.saga.test.tsx
@@ -1,6 +1,6 @@
 import { expectSaga } from 'redux-saga-test-plan'
 import { call, select } from 'redux-saga/effects'
-import { fetchInventoryItemsByAddress, handleWearablesFailure, handleWearablesRequest, handleWearablesSuccess, informRequestFailure, sendWearablesCatalog, WRONG_FILTERS_ERROR } from 'shared/catalogs/sagas'
+import { BASE_AVATARS_COLLECTION_ID, fetchInventoryItemsByAddress, handleWearablesFailure, handleWearablesRequest, handleWearablesSuccess, informRequestFailure, sendWearablesCatalog, WRONG_FILTERS_ERROR } from 'shared/catalogs/sagas'
 import { wearablesFailure, wearablesRequest, wearablesSuccess } from 'shared/catalogs/actions'
 import { baseCatalogsLoaded, getExclusiveCatalog, getPlatformCatalog } from 'shared/catalogs/selectors'
 import { ensureRenderer } from 'shared/renderer/sagas'
@@ -39,7 +39,7 @@ describe('Wearables Saga', () => {
 
   it('When base avatars are requested, then they are returned successfully', () => {
     const baseWearables = [wearable1]
-    return expectSaga(handleWearablesRequest, wearablesRequest({ collectionIds: ['base-avatars'] }, context))
+    return expectSaga(handleWearablesRequest, wearablesRequest({ collectionIds: [BASE_AVATARS_COLLECTION_ID] }, context))
       .put(wearablesSuccess(baseWearables, context))
       .provide([
         [select(baseCatalogsLoaded), true],

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/CatalogController/CatalogController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/CatalogController/CatalogController.cs
@@ -27,7 +27,7 @@ public class CatalogController : MonoBehaviour
     private static List<string> pendingRequestsToSend = new List<string>();
     private float timeSinceLastUnusedWearablesCheck = 0f;
 
-    
+
 
     public void Awake()
     {
@@ -208,7 +208,7 @@ public class CatalogController : MonoBehaviour
             WebInterface.RequestWearables(
                 ownedByUser: null,
                 wearableIds: null,
-                collectionIds: new string[] { "base-avatars" },
+                collectionIds: new string[] { "urn:decentraland:off-chain:base-avatars" },
                 context: BASE_WEARABLES_CONTEXT
             );
         }


### PR DESCRIPTION
We are doing 2 changes in this PR:
* We are now moving collection ids to urns. So what used to be the id `base-avatars` will now be `urn:decentraland:off-chain:base-avatars`.
* We are updating the `urn-resolver` library, and now types that used to be `blockchain-collection-v1` are `blockchain-collection-v1-asset`