### PR TITLE
feat: New event when a user enters or leaves the scene

### DIFF
--- a/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
@@ -1,11 +1,13 @@
 import { EventConstructor } from '../ecs/EventManager'
+import { Observable } from '../ecs/Observable'
+import { DecentralandInterface, IEvents } from './Types'
 
 /**
  * @public
  */
 @EventConstructor()
 export class UUIDEvent<T = any> {
-  constructor(public readonly uuid: string, public readonly payload: T) {}
+  constructor(public readonly uuid: string, public readonly payload: T) { }
 }
 
 /**
@@ -19,7 +21,7 @@ export class RaycastResponse<T> {
       queryType: string
       payload: T
     }
-  ) {}
+  ) { }
 }
 
 /**
@@ -27,5 +29,57 @@ export class RaycastResponse<T> {
  */
 @EventConstructor()
 export class PointerEvent<GlobalInputEventResult> {
-  constructor(public readonly payload: GlobalInputEventResult) {}
+  constructor(public readonly payload: GlobalInputEventResult) { }
+}
+
+let internalDcl: DecentralandInterface | void
+
+/**
+ * @internal
+ * This function generates a callback that is passed to the Observable
+ * constructor to subscribe to the events of the DecentralandInterface
+ */
+function createSubscriber(eventName: keyof IEvents) {
+  return () => {
+    if (internalDcl) {
+      internalDcl.subscribe(eventName)
+    }
+  }
+}
+
+/**
+ * These events are triggered after your character enters the scene.
+ * @public
+ */
+export const onEnterScene = new Observable<IEvents['onEnterScene']>(createSubscriber('onEnterScene'))
+
+/**
+ * These events are triggered after your character leaves the scene.
+ * @public
+ */
+export const onLeftScene = new Observable<IEvents['onLeftScene']>(createSubscriber('onLeftScene'))
+
+/**
+ * @internal
+ * This function adds _one_ listener to the onEvent event of dcl interface.
+ * Leveraging a switch to route events to the Observable handlers.
+ */
+export function _initEventObservables(dcl: DecentralandInterface) {
+  // store internal reference to dcl, it is going to be used to subscribe to the events
+  internalDcl = dcl
+
+  if (internalDcl) {
+    internalDcl.onEvent((event) => {
+      switch (event.type) {
+        case 'onEnterScene': {
+          onEnterScene.notifyObservers(event.data)
+          return
+        }
+        case 'onLeftScene': {
+          onLeftScene.notifyObservers(event.data)
+          return
+        }
+      }
+    })
+  }
 }

--- a/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
@@ -1,6 +1,6 @@
 import { EventConstructor } from '../ecs/EventManager'
 import { Observable } from '../ecs/Observable'
-import { DecentralandInterface, IEvents } from './Types'
+import { DecentralandInterface, IEvents, RaycastResponsePayload } from './Types'
 
 /**
  * @public
@@ -16,11 +16,7 @@ export class UUIDEvent<T = any> {
 @EventConstructor()
 export class RaycastResponse<T> {
   constructor(
-    public readonly payload: {
-      queryId: string
-      queryType: string
-      payload: T
-    }
+    public readonly payload: RaycastResponsePayload<T>
   ) { }
 }
 
@@ -72,11 +68,11 @@ export function _initEventObservables(dcl: DecentralandInterface) {
     internalDcl.onEvent((event) => {
       switch (event.type) {
         case 'onEnterScene': {
-          onEnterScene.notifyObservers(event.data)
+          onEnterScene.notifyObservers(event.data as IEvents['onEnterScene'])
           return
         }
         case 'onLeftScene': {
-          onLeftScene.notifyObservers(event.data)
+          onLeftScene.notifyObservers(event.data as IEvents['onLeftScene'])
           return
         }
       }

--- a/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
@@ -1,5 +1,4 @@
 import { ReadOnlyVector3, ReadOnlyQuaternion, ReadOnlyColor4 } from './math'
-import { RaycastResponse } from './Events'
 
 /** @public */
 export type ModuleDescriptor = {
@@ -129,6 +128,13 @@ export type GlobalInputEventResult = InputEventResult & {
   type: InputEventType
 }
 
+/** @public */
+export type RaycastResponsePayload<T> = {
+  queryId: string
+  queryType: string
+  payload: T
+}
+
 /**
  * @public
  */
@@ -180,7 +186,7 @@ export interface IEvents {
   /**
    * `raycastResponse` is triggered in response to a raycast query
    */
-  raycastResponse: RaycastResponse<any>
+  raycastResponse: RaycastResponsePayload<any>
 
   /**
    * `chatMessage` is triggered when the user sends a message through chat entity.

--- a/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
@@ -271,6 +271,20 @@ export interface IEvents {
   }
 
   /**
+   * This event gets triggered when the user enters the scene
+   */
+  onEnterScene: {
+    userId: string
+  }
+
+  /**
+   * This event gets triggered when the user leaves the scene
+   */
+  onLeftScene: {
+    userId: string
+  }
+
+  /**
    * This event gets triggered after receiving a comms message.
    */
   comms: {

--- a/kernel/packages/decentraland-ecs/src/index.ts
+++ b/kernel/packages/decentraland-ecs/src/index.ts
@@ -12,6 +12,7 @@ export * from './ecs/UIValue'
 export * from './ecs/EventManager'
 export * from './ecs/UserActions'
 
+import { _initEventObservables } from './decentraland/Events'
 import { DecentralandSynchronizationSystem } from './decentraland/Implementation'
 
 // ECS INITIALIZATION
@@ -19,7 +20,7 @@ import { Engine } from './ecs/Engine'
 import { Entity } from './ecs/Entity'
 
 const entity = new Entity('scene')
-;(entity as any).uuid = '0'
+; (entity as any).uuid = '0'
 
 // Initialize engine
 /** @public */
@@ -36,6 +37,7 @@ import { DecentralandInterface } from './decentraland/Types'
 declare let dcl: DecentralandInterface | void
 if (typeof dcl !== 'undefined') {
   engine.addSystem(new DecentralandSynchronizationSystem(dcl), Infinity)
+  _initEventObservables(dcl)
 }
 
 import { uuidEventSystem, pointerEventSystem, raycastEventSystem } from './decentraland/Systems'

--- a/kernel/public/test-scenes/0.11.subscribeToEnterLeaveScene1/game.ts
+++ b/kernel/public/test-scenes/0.11.subscribeToEnterLeaveScene1/game.ts
@@ -1,0 +1,29 @@
+import { log, engine, Entity, BoxShape, Material, Color3, Transform, Vector3, onEnterScene, onLeftScene } from 'decentraland-ecs/src'
+
+//Create entity and assign shape
+const box = new Entity()
+box.addComponent(new BoxShape())
+
+//Create material and configure its fields
+const material = new Material()
+material.albedoColor = Color3.Gray()
+
+//Assign the material to the entity
+box.addComponent(material)
+
+box.addComponent(new Transform({
+  position: new Vector3(8, 0, 8),
+  scale: new Vector3(16, 0.1, 16),
+}))
+
+engine.addEntity(box);
+
+onEnterScene.add(({ userId }) => {
+  material.albedoColor = Color3.Red()
+  log("onEnterScene: ", userId)
+})
+
+onLeftScene.add(({ userId }) => {
+  material.albedoColor = Color3.Gray()
+  log("onLeftScene: ", userId)
+})

--- a/kernel/public/test-scenes/0.11.subscribeToEnterLeaveScene1/scene.json
+++ b/kernel/public/test-scenes/0.11.subscribeToEnterLeaveScene1/scene.json
@@ -1,0 +1,30 @@
+{
+  "display": {
+    "title": "0.11.subscribeToEnterLeaveScene1",
+    "favicon": "favicon_asset"
+  },
+  "contact": {
+    "name": "author-name",
+    "email": ""
+  },
+  "owner": "",
+  "scene": {
+    "parcels": [
+      "0,11"
+    ],
+    "base": "0,11"
+  },
+  "communications": {
+    "type": "webrtc",
+    "signalling": "https://signalling-01.decentraland.org"
+  },
+  "policy": {
+    "contentRating": "E",
+    "fly": true,
+    "voiceEnabled": true,
+    "blacklist": [],
+    "teleportPosition": ""
+  },
+  "main": "game.js",
+  "tags": []
+}

--- a/kernel/public/test-scenes/0.12.subscribeToEnterLeaveScene2/game.ts
+++ b/kernel/public/test-scenes/0.12.subscribeToEnterLeaveScene2/game.ts
@@ -1,0 +1,29 @@
+import { log, engine, Entity, BoxShape, Material, Color3, Transform, Vector3, onEnterScene, onLeftScene } from 'decentraland-ecs/src'
+
+//Create entity and assign shape
+const box = new Entity()
+box.addComponent(new BoxShape())
+
+//Create material and configure its fields
+const material = new Material()
+material.albedoColor = Color3.Gray()
+
+//Assign the material to the entity
+box.addComponent(material)
+
+box.addComponent(new Transform({
+  position: new Vector3(8, 0, 16),
+  scale: new Vector3(16, 0.1, 32),
+}))
+
+engine.addEntity(box);
+
+onEnterScene.add(({ userId }) => {
+  material.albedoColor = Color3.Red()
+  log("onEnterScene: ", userId)
+})
+
+onLeftScene.add(({ userId }) => {
+  material.albedoColor = Color3.Gray()
+  log("onLeftScene: ", userId)
+})

--- a/kernel/public/test-scenes/0.12.subscribeToEnterLeaveScene2/scene.json
+++ b/kernel/public/test-scenes/0.12.subscribeToEnterLeaveScene2/scene.json
@@ -1,0 +1,31 @@
+{
+  "display": {
+    "title": "0.12.subscribeToEnterLeaveScene2",
+    "favicon": "favicon_asset"
+  },
+  "contact": {
+    "name": "author-name",
+    "email": ""
+  },
+  "owner": "",
+  "scene": {
+    "parcels": [
+      "0,12",
+      "0,13"
+    ],
+    "base": "0,12"
+  },
+  "communications": {
+    "type": "webrtc",
+    "signalling": "https://signalling-01.decentraland.org"
+  },
+  "policy": {
+    "contentRating": "E",
+    "fly": true,
+    "voiceEnabled": true,
+    "blacklist": [],
+    "teleportPosition": ""
+  },
+  "main": "game.js",
+  "tags": []
+}


### PR DESCRIPTION
# What?
Since https://github.com/decentraland/explorer/pull/1768, there is now an event that is emitted every time the user changes scene. So in this PR we hook that event to the SDK to have access to the event of enter or left the scene.

And also I added two new scenes to the test-scenes, to test this. Those scenes have a floor in gray, and when you enter those the floor turns red, and when you left turns gray again.

Video:
https://user-images.githubusercontent.com/12563266/113425077-a01cde00-93a7-11eb-91ff-2134576bb145.mp4

When we left one scene, to a parcel without scene, the event is not triggered, but this only happens with the test-scenes, because in Decentraland World there are not parcels without scenes assigned.
I chated with @nchamo and this is the desired behavior.

# Why?
Allow the user use the SDK to get the event of enter/left scenes.

# How to test
Follow this guide (`Running Test Scenes` section):
https://github.com/decentraland/explorer/blob/master/docs/how-to-test-parcels-and-preview-scenes.md

And go to position 0,11 (quick link: http://localhost:3000/?DEBUG_MODE&position=0,11)