### PR TITLE
refactor: Rename 'onLeftScene' event to 'onLeaveScene'

### DIFF
--- a/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
@@ -53,7 +53,7 @@ export const onEnterScene = new Observable<IEvents['onEnterScene']>(createSubscr
  * These events are triggered after your character leaves the scene.
  * @public
  */
-export const onLeftScene = new Observable<IEvents['onLeftScene']>(createSubscriber('onLeftScene'))
+export const onLeaveScene = new Observable<IEvents['onLeaveScene']>(createSubscriber('onLeaveScene'))
 
 /**
  * @internal
@@ -71,8 +71,8 @@ export function _initEventObservables(dcl: DecentralandInterface) {
           onEnterScene.notifyObservers(event.data as IEvents['onEnterScene'])
           return
         }
-        case 'onLeftScene': {
-          onLeftScene.notifyObservers(event.data as IEvents['onLeftScene'])
+        case 'onLeaveScene': {
+          onLeaveScene.notifyObservers(event.data as IEvents['onLeaveScene'])
           return
         }
       }

--- a/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
@@ -286,7 +286,7 @@ export interface IEvents {
   /**
    * This event gets triggered when the user leaves the scene
    */
-  onLeftScene: {
+  onLeaveScene: {
     userId: string
   }
 

--- a/kernel/packages/shared/world/SceneSystemWorker.ts
+++ b/kernel/packages/shared/world/SceneSystemWorker.ts
@@ -130,7 +130,7 @@ export class SceneSystemWorker extends SceneWorker {
           if (report.newScene.sceneId === this.getSceneId()) {
             this.engineAPI!.sendSubscriptionEvent('onEnterScene', { userId })
           } else if (report.previousScene?.sceneId === this.getSceneId()) {
-            this.engineAPI!.sendSubscriptionEvent('onLeftScene', { userId })
+            this.engineAPI!.sendSubscriptionEvent('onLeaveScene', { userId })
           }
         })
       })

--- a/kernel/public/test-scenes/0.11.subscribeToEnterLeaveScene1/game.ts
+++ b/kernel/public/test-scenes/0.11.subscribeToEnterLeaveScene1/game.ts
@@ -1,4 +1,4 @@
-import { log, engine, Entity, BoxShape, Material, Color3, Transform, Vector3, onEnterScene, onLeftScene } from 'decentraland-ecs/src'
+import { log, engine, Entity, BoxShape, Material, Color3, Transform, Vector3, onEnterScene, onLeaveScene } from 'decentraland-ecs/src'
 
 //Create entity and assign shape
 const box = new Entity()
@@ -23,7 +23,7 @@ onEnterScene.add(({ userId }) => {
   log("onEnterScene: ", userId)
 })
 
-onLeftScene.add(({ userId }) => {
+onLeaveScene.add(({ userId }) => {
   material.albedoColor = Color3.Gray()
-  log("onLeftScene: ", userId)
+  log("onLeaveScene: ", userId)
 })

--- a/kernel/public/test-scenes/0.12.subscribeToEnterLeaveScene2/game.ts
+++ b/kernel/public/test-scenes/0.12.subscribeToEnterLeaveScene2/game.ts
@@ -1,4 +1,4 @@
-import { log, engine, Entity, BoxShape, Material, Color3, Transform, Vector3, onEnterScene, onLeftScene } from 'decentraland-ecs/src'
+import { log, engine, Entity, BoxShape, Material, Color3, Transform, Vector3, onEnterScene, onLeaveScene } from 'decentraland-ecs/src'
 
 //Create entity and assign shape
 const box = new Entity()
@@ -23,7 +23,7 @@ onEnterScene.add(({ userId }) => {
   log("onEnterScene: ", userId)
 })
 
-onLeftScene.add(({ userId }) => {
+onLeaveScene.add(({ userId }) => {
   material.albedoColor = Color3.Gray()
-  log("onLeftScene: ", userId)
+  log("onLeaveScene: ", userId)
 })


### PR DESCRIPTION
# What?
Fix the incorrect event name introduced in #2259

# Why?
We're using the simple present form of the verb