### PR TITLE
feat: Redirect Buy More MANA button to Accounts

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUDController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/ProfileHUD/ProfileHUDController.cs
@@ -14,7 +14,7 @@ public class ProfileHUDController : IHUD
 
     private const string URL_CLAIM_NAME = "https://builder.decentraland.org/claim-name";
     private const string URL_MANA_INFO = "https://docs.decentraland.org/examples/get-a-wallet";
-    private const string URL_MANA_PURCHASE = "https://market.decentraland.org/settings";
+    private const string URL_MANA_PURCHASE = "https://account.decentraland.org";
     private const string URL_TERMS_OF_USE = "https://decentraland.org/terms";
     private const string URL_PRIVACY_POLICY = "https://decentraland.org/privacy";
     private const float FETCH_MANA_INTERVAL = 60;
@@ -49,13 +49,17 @@ public class ProfileHUDController : IHUD
         view.buttonBackpack.onClick.AddListener(OpenBackpackWindow);
         view.buttonLogOut.onClick.AddListener(WebInterface.LogOut);
         view.buttonSignUp.onClick.AddListener(WebInterface.RedirectToSignUp);
-        view.buttonClaimName.onClick.AddListener(()=> WebInterface.OpenURL(URL_CLAIM_NAME));
+        view.buttonClaimName.onClick.AddListener(() => WebInterface.OpenURL(URL_CLAIM_NAME));
         view.buttonTermsOfServiceForConnectedWallets.onPointerDown += () => WebInterface.OpenURL(URL_TERMS_OF_USE);
         view.buttonPrivacyPolicyForConnectedWallets.onPointerDown += () => WebInterface.OpenURL(URL_PRIVACY_POLICY);
         view.buttonTermsOfServiceForNonConnectedWallets.onPointerDown += () => WebInterface.OpenURL(URL_TERMS_OF_USE);
         view.buttonPrivacyPolicyForNonConnectedWallets.onPointerDown += () => WebInterface.OpenURL(URL_PRIVACY_POLICY);
         view.inputName.onSubmit.AddListener(UpdateProfileName);
-        view.OnOpen += () => { WebInterface.RequestOwnProfileUpdate(); OnOpen?.Invoke(); };
+        view.OnOpen += () =>
+        {
+            WebInterface.RequestOwnProfileUpdate();
+            OnOpen?.Invoke();
+        };
         view.OnClose += () => OnClose?.Invoke();
 
         manaCounterView = view.GetComponentInChildren<ManaCounterView>(true);
@@ -66,7 +70,8 @@ public class ProfileHUDController : IHUD
         }
 
         ownUserProfile.OnUpdate += OnProfileUpdated;
-        if (mouseCatcher != null) mouseCatcher.OnMouseLock += OnMouseLocked;
+        if (mouseCatcher != null)
+            mouseCatcher.OnMouseLock += OnMouseLocked;
 
         if (!DCL.Configuration.EnvironmentSettings.RUNNING_TESTS)
         {
@@ -75,10 +80,7 @@ public class ProfileHUDController : IHUD
         }
     }
 
-    public void ChangeVisibilityForBuilderInWorld(bool current, bool previus)
-    {
-        SetVisibility(current);
-    }
+    public void ChangeVisibilityForBuilderInWorld(bool current, bool previus) { SetVisibility(current); }
     public void SetVisibility(bool visible)
     {
         view?.SetVisibility(visible);
@@ -108,7 +110,8 @@ public class ProfileHUDController : IHUD
         }
         ownUserProfile.OnUpdate -= OnProfileUpdated;
         CommonScriptableObjects.builderInWorldNotNecessaryUIVisibilityStatus.OnChange -= ChangeVisibilityForBuilderInWorld;
-        if (mouseCatcher != null) mouseCatcher.OnMouseLock -= OnMouseLocked;
+        if (mouseCatcher != null)
+            mouseCatcher.OnMouseLock -= OnMouseLocked;
 
         if (!DCL.Configuration.EnvironmentSettings.RUNNING_TESTS)
         {
@@ -116,15 +119,9 @@ public class ProfileHUDController : IHUD
         }
     }
 
-    void OnProfileUpdated(UserProfile profile)
-    {
-        view?.SetProfile(profile);
-    }
+    void OnProfileUpdated(UserProfile profile) { view?.SetProfile(profile); }
 
-    void OnMouseLocked()
-    {
-        HideProfileMenu();
-    }
+    void OnMouseLocked() { HideProfileMenu(); }
 
     IEnumerator ManaIntervalRoutine()
     {
@@ -139,10 +136,7 @@ public class ProfileHUDController : IHUD
     /// Set an amount of MANA on the HUD.
     /// </summary>
     /// <param name="balance">Amount of MANA.</param>
-    public void SetManaBalance(string balance)
-    {
-        manaCounterView?.SetBalance(balance);
-    }
+    public void SetManaBalance(string balance) { manaCounterView?.SetBalance(balance); }
 
     /// <summary>
     /// Configure an AvatarEditorHUDController for the Backpack button.
@@ -164,10 +158,7 @@ public class ProfileHUDController : IHUD
     /// Show/Hide the Backpack button.
     /// </summary>
     /// <param name="visible">True for showing the button.</param>
-    public void SetBackpackButtonVisibility(bool visible)
-    {
-        view?.SetBackpackButtonVisibility(avatarEditorHud != null && visible);
-    }
+    public void SetBackpackButtonVisibility(bool visible) { view?.SetBackpackButtonVisibility(avatarEditorHud != null && visible); }
 
     private void OpenBackpackWindow()
     {
@@ -181,10 +172,7 @@ public class ProfileHUDController : IHUD
     /// <summary>
     /// Close the Profile menu.
     /// </summary>
-    public void HideProfileMenu()
-    {
-        view?.HideMenu();
-    }
+    public void HideProfileMenu() { view?.HideMenu(); }
 
     private void UpdateProfileName(string newName)
     {
@@ -206,8 +194,5 @@ public class ProfileHUDController : IHUD
         WebInterface.SendSaveUserUnverifiedName(newName);
     }
 
-    private void OnKernelConfigChanged(KernelConfigModel current, KernelConfigModel previous)
-    {
-        view?.SetNameRegex(current.profiles.nameValidRegex);
-    }
+    private void OnKernelConfigChanged(KernelConfigModel current, KernelConfigModel previous) { view?.SetNameRegex(current.profiles.nameValidRegex); }
 }


### PR DESCRIPTION
The new accounts section is now ready to operate buying mana either in Etherum or in the Polygon L2 network. We need to redirect the players to https://account.decentraland.org while clicking on the + button on the profile popup, instead ot the https://market.decentraland.org

**Test link:** https://explorer.decentraland.zone/branch/feat/Redirect-Buy-More-MANA-button-to-Accounts/index.html?ENV=org