### PR TITLE
fix: disabled camera on avatar profile

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/ScriptableObject/CommonScriptableObjects.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/ScriptableObject/CommonScriptableObjects.cs
@@ -147,8 +147,8 @@ public static class CommonScriptableObjects
     private static BooleanVariable isProfileHUDOpenValue;
     public static BooleanVariable isProfileHUDOpen => GetOrLoad(ref isProfileHUDOpenValue, "ScriptableObjects/IsProfileHUDOpen");
 
-    private static BooleanVariable isAvatarHUDOpenValue;
-    public static BooleanVariable isFullscreenHUDOpen => GetOrLoad(ref isProfileHUDOpenValue, "ScriptableObjects/IsAvatarHUDOpen");
+    private static BooleanVariable isFullscreenHUDOpenValue;
+    public static BooleanVariable isFullscreenHUDOpen => GetOrLoad(ref isFullscreenHUDOpenValue, "ScriptableObjects/IsAvatarHUDOpen");
 
 
     private static BooleanVariable isTaskbarHUDInitializedValue;


### PR DESCRIPTION
Camera was being disabled when avatar profile was open. This was caused due to a bad copy-paste in the `CommonScriptableObjects` code