### PR TITLE
fix: disable world camera on navmap open

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/HUD/NavMap/NavmapView.cs
@@ -111,6 +111,8 @@ namespace DCL
                 MapRenderer.i.usersPositionMarkerController?.SetUpdateMode(MapGlobalUsersPositionMarkerController.UpdateMode.FOREGROUND);
 
                 AudioScriptableObjects.dialogOpen.Play(true);
+
+                CommonScriptableObjects.isFullscreenHUDOpen.Set(true);
             }
             else
             {
@@ -131,9 +133,10 @@ namespace DCL
                 MapRenderer.i.UpdateRendering(Utils.WorldToGridPositionUnclamped(CommonScriptableObjects.playerWorldPosition.Get()));
 
                 // Set longer interval of time for populated scenes markers fetch
-                MapRenderer.i.usersPositionMarkerController?.SetUpdateMode(MapGlobalUsersPositionMarkerController.UpdateMode.BACKGROUND); 
+                MapRenderer.i.usersPositionMarkerController?.SetUpdateMode(MapGlobalUsersPositionMarkerController.UpdateMode.BACKGROUND);
 
                 AudioScriptableObjects.dialogClose.Play(true);
+                CommonScriptableObjects.isFullscreenHUDOpen.Set(false);
             }
 
             OnToggle?.Invoke(isOpen);

--- a/unity-client/Assets/Scripts/MainScripts/DCL/ScriptableObject/CommonScriptableObjects.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/ScriptableObject/CommonScriptableObjects.cs
@@ -147,8 +147,8 @@ public static class CommonScriptableObjects
     private static BooleanVariable isProfileHUDOpenValue;
     public static BooleanVariable isProfileHUDOpen => GetOrLoad(ref isProfileHUDOpenValue, "ScriptableObjects/IsProfileHUDOpen");
 
-    private static BooleanVariable isAvatarHUDOpenValue;
-    public static BooleanVariable isFullscreenHUDOpen => GetOrLoad(ref isProfileHUDOpenValue, "ScriptableObjects/IsAvatarHUDOpen");
+    private static BooleanVariable isFullscreenHUDOpenValue;
+    public static BooleanVariable isFullscreenHUDOpen => GetOrLoad(ref isFullscreenHUDOpenValue, "ScriptableObjects/IsAvatarHUDOpen");
 
 
     private static BooleanVariable isTaskbarHUDInitializedValue;


### PR DESCRIPTION
World camera was active when the navmap was open. Disabling it should improve the navmap performance by a mile.