### PR TITLE
fix: disabled skeleton importing

### DIFF
--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/Tests/GLTFImporterTests.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/LoadableShapes/Tests/GLTFImporterTests.cs
@@ -34,6 +34,13 @@ public class GLTFImporterTests : IntegrationTestSuite_Legacy
         }
     }
 
+    [Test]
+    public void ImporterCanLoadSkeletonsByDefault()
+    {
+        var importer = new GLTFSceneImporter("", "", null, null);
+        Assert.IsTrue( importer.importSkeleton, "Skeleton importing should be true by default or avatars won't load correctly!" );
+    }
+
     [UnityTest]
     [Explicit("Test takes too long")]
     [Category("Explicit")]

--- a/unity-client/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/unity-client/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -115,7 +115,8 @@ namespace UnityGLTF
 
         private bool useMaterialTransitionValue = true;
 
-        public bool importSkeleton = false;
+        public bool importSkeleton = true;
+
         public bool useMaterialTransition
         {
             get => useMaterialTransitionValue && !renderingIsDisabled;


### PR DESCRIPTION
Skeleton importing was disabled BY DEFAULT for all our assets. This completely broken the avatars loading.

How to validate? Two ways:

1) No avatars should be visible (or at least most of them, this should happen randomly). 

2) In master build, go to backpack, and:
- Select female body shape
- Select male body shape
- Male body shape should never finish loading or should be invisible

Do the same in this branch and it should be fixed.