### PR TITLE
fix: base64 images in kernel messages

### DIFF
--- a/kernel/packages/scene-system/sdk/SceneRuntime.ts
+++ b/kernel/packages/scene-system/sdk/SceneRuntime.ts
@@ -432,10 +432,10 @@ export abstract class SceneRuntime extends Script {
         },
 
         componentUpdated(id: string, json: string) {
-          if (json.length > 49000) {
+          /*if (json.length > 49000) {
             that.onError(new Error('Component payload cannot exceed 49.000 bytes'))
             return
-          }
+          }*/
 
           that.events.push({
             type: 'ComponentUpdated',

--- a/kernel/packages/scene-system/sdk/SceneRuntime.ts
+++ b/kernel/packages/scene-system/sdk/SceneRuntime.ts
@@ -432,11 +432,6 @@ export abstract class SceneRuntime extends Script {
         },
 
         componentUpdated(id: string, json: string) {
-          /*if (json.length > 49000) {
-            that.onError(new Error('Component payload cannot exceed 49.000 bytes'))
-            return
-          }*/
-
           that.events.push({
             type: 'ComponentUpdated',
             tag: id,

--- a/kernel/packages/unity-interface/UnityScene.ts
+++ b/kernel/packages/unity-interface/UnityScene.ts
@@ -59,6 +59,15 @@ export class UnityScene<T> implements ParcelSceneAPI {
     let messages = ''
     for (let i = 0; i < actions.length; i++) {
       const action = actions[i]
+
+      // Check moved from SceneRuntime.ts->DecentralandInterface.componentUpdate() here until we remove base64 support.
+      // This way we can still initialize problematic scenes in the Editor, otherwise the protobuf encoding explodes with such messages.
+      if (action.payload.json?.length > 49000) {
+        this.logger.error('Component payload cannot exceed 49.000 bytes. Skipping message.')
+
+        continue
+      }
+
       messages += protobufMsgBridge.encodeSceneMessage(sceneId, action.type, action.payload, action.tag)
       messages += '\n'
     }


### PR DESCRIPTION
### WHY
* Right now, we have a check to skip kernel->unity messages that have a bigger size than 49kb to avoid crashing the build. Apparently the 49kb limit has changed due to the latest unity 2020 build changes and it can support that size and more.

* 2 libraries widely used: [decentraland-ui-utils](https://github.com/decentraland/decentraland-ui-utils/commit/74a1d746225a09ed29e694472deebdcd56ffbc07) and [decentraland-npc-utils](https://github.com/decentraland/decentraland-npc-utils/commit/98cd2bb52c98d0e452fcd47c9175a7a10c3d4d24) have recently changed their used images to be base64 (to avoid referencing images from a centralized server). By doing that, now the kernel->unity messages, for several components used in those libraries, contain a payload bigger than 49kb, so those messages are being skipped and the images end up broken in the build. This can be observed in the npc speech dialogs in the current ZONE 0,0 scene.

### WHAT
* By removing update-component-payload check we fix the issue with broken images in the build
* Since we encode in protobuf every scene message when connecting through Websockets (that's the case when debugging from Unity Editor), when protobuff tries to encode those giant payloads it throws an exception and interrupts the flow and the scene is never initialized. So by moving the previously removed check to the part in which we send the WSS batched messages, we can now initialize these problematic scenes using the UnityEditor even though the images look broken.
* Eventually we will remove base64 support and move those library images somewhere else (probably IPFs or content servers), and could return the check to its original place

### TESTING
#### Bugged dialog background images:
master build: https://play.decentraland.zone/?ENV=zone

![Screen Shot 2021-04-14 at 16 23 31](https://user-images.githubusercontent.com/1031741/114767297-d4948080-9d3d-11eb-849e-33636f2af172.png)
![Screen Shot 2021-04-14 at 16 23 38](https://user-images.githubusercontent.com/1031741/114767308-d8c09e00-9d3d-11eb-8b86-2bd3e6abcfba.png)

#### Correct dialog background images:
this branch build: https://play.decentraland.zone/branch/fix/base64ImagesInKernelMessages/index.html?ENV=zone

![Screen Shot 2021-04-14 at 16 20 08](https://user-images.githubusercontent.com/1031741/114767657-4a98e780-9d3e-11eb-9849-ab269369a9bc.png)
![Screen Shot 2021-04-14 at 16 20 15](https://user-images.githubusercontent.com/1031741/114767668-4ec50500-9d3e-11eb-9eea-945c7cad80be.png)
