### PR TITLE
chore: update dcl-social-client

### DIFF
--- a/kernel/package-lock.json
+++ b/kernel/package-lock.json
@@ -2742,7 +2742,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -3630,7 +3630,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
@@ -3642,7 +3642,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
@@ -3862,9 +3862,9 @@
       "integrity": "sha512-1GrnacmjHSNxhHwjbnAc3MzN8xZG3tFSFEZ9Tb/njHPuxKEmoYaawfVnlUcUehHaKsQsJdpRMGdOvH/QILNDlw=="
     },
     "dcl-social-client": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.3.12.tgz",
-      "integrity": "sha512-5H//Tywd7ggzD6WM5VuqsaA10vGS8xc+L6idFFmW/WRpDjM61Z9gBJAZnIWS/PSRgWHHi+dKVeeOmdFCTS7xPQ==",
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/dcl-social-client/-/dcl-social-client-1.3.13.tgz",
+      "integrity": "sha512-tKNk6/lMxlr5zci6In8sDmesEFvdwg9InMPjonbgJzRXVEECRBjrTknmS0vgKeK/s750d8d+D1hpHT41rd3QDA==",
       "requires": {
         "@types/matrix-js-sdk": "^5.1.2",
         "@types/node": "^13.11.1",
@@ -3873,9 +3873,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.47",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.47.tgz",
-          "integrity": "sha512-R6851wTjN1YJza8ZIeX6puNBSi/ZULHVh4WVleA7q256l+cP2EtXnKbO455fTs2ytQk3dL9qkU+Wh8l/uROdKg=="
+          "version": "13.13.48",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.48.tgz",
+          "integrity": "sha512-z8wvSsgWQzkr4sVuMEEOvwMdOQjiRY2Y/ZW4fDfjfe3+TfQrZqFKOthBgk2RnVEmtOKrkwdZ7uTvsxTBLjKGDQ=="
         }
       }
     },
@@ -6757,7 +6757,7 @@
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         }
@@ -11513,7 +11513,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -13692,7 +13692,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/kernel/package.json
+++ b/kernel/package.json
@@ -103,7 +103,7 @@
     "dcl-ecs-quests": "^1.0.0",
     "dcl-quests-client": "^2.0.0",
     "dcl-scene-writer": "^1.1.2",
-    "dcl-social-client": "^1.3.12",
+    "dcl-social-client": "^1.3.13",
     "decentraland-connect": "^2.13.2",
     "decentraland-katalyst-peer": "0.2.20",
     "decentraland-renderer": "^1.8.70353",


### PR DESCRIPTION
We are now updating `dcl-social-client` to `1.3.13`