### PR TITLE
Custom library support: allow to customize 'main' and 'typings' 

### DIFF
--- a/kernel/packages/build-ecs/index.ts
+++ b/kernel/packages/build-ecs/index.ts
@@ -471,14 +471,19 @@ function getConfiguration(packageJson: PackageJson | null, sceneJson: SceneJson 
     if (resolved) {
       try {
         const libPackageJson = JSON.parse(ts.sys.readFile(resolved)!)
+        const decentralandLibrary = libPackageJson.decentralandLibrary;
 
         let main: string | null = null
         let typings: string | null = null
 
+        if (!decentralandLibrary) {
+          throw new Error(`field "decentralandLibrary" is missing in package.json`)
+        }
+
         if (!libPackageJson.main) {
           throw new Error(`field "main" is missing in package.json`)
         } else {
-          main = resolve(dirname(resolved), libPackageJson.main)
+          main = resolve(dirname(resolved), decentralandLibrary.main || libPackageJson.main)
           if (!ts.sys.fileExists(main)) {
             throw new Error(`main file ${main} not found`)
           }
@@ -487,14 +492,10 @@ function getConfiguration(packageJson: PackageJson | null, sceneJson: SceneJson 
         if (!libPackageJson.typings) {
           throw new Error(`field "typings" is missing in package.json`)
         } else {
-          typings = resolve(dirname(resolved), libPackageJson.typings)
+          typings = resolve(dirname(resolved), decentralandLibrary.typings || libPackageJson.typings)
           if (!ts.sys.fileExists(typings)) {
             throw new Error(`typings file ${typings} not found`)
           }
-        }
-
-        if (!libPackageJson.decentralandLibrary) {
-          throw new Error(`field "decentralandLibrary" is missing in package.json`)
         }
 
         libs.push({ main, typings, name: libPackageJson.name })


### PR DESCRIPTION
Hi guys 👋

# What? <!-- what is this PR? -->
This PR adds the possibility to provide a custom `"main"` and/or `"typings"` through the `"decentralandLibrary"` property on `package.json`.

Example: https://github.com/colyseus/colyseus.js/commit/fe1f4da44211fe0bccbf898b75f970c7a6a2619f

# Why? <!-- Explain the reason -->
As a library author, I'd like to customize the `main` and `typings` fields specifically for Decentraland support on a module. The [`colyseus.js` module](https://www.npmjs.com/package/colyseus.js), for example, currently uses the `"main"` root property for Node.js/ReactNative target, and `"browser"` property for browsers.

Additionally, the default typings provided by `colyseus.js` module have references to other third-party typings/modules, making it difficult to integrate seamlessly with Decentraland. Luckily, some work has been done in the past to generate a "standalone" .d.ts file for Colyseus that is meant for copying and pasting on a standalone project - which is perfect to be used on Decentraland!

--- 

Let me know what you think about this change. I haven't found if `"decentralandLibrary": {}` is being used for another specific purpose, otherwise I'm happy to make any changes requested to land this PR.

(I'm starting to work on a demo scene using Colyseus + Decentraland 🎉)