### PR TITLE
fix: Updating renderer to be able to run the client without using Unity

### DIFF
--- a/kernel/package-lock.json
+++ b/kernel/package-lock.json
@@ -3929,9 +3929,9 @@
       }
     },
     "decentraland-renderer": {
-      "version": "1.8.70353",
-      "resolved": "https://registry.npmjs.org/decentraland-renderer/-/decentraland-renderer-1.8.70353.tgz",
-      "integrity": "sha512-SmDANVN0j9K3jtzww6Csi5iAq1wpM05b+wbQsMn8F5eqOTu4kBXvqmf9IvVWpsIwKqTnN13nEZLkeRbXkCxUXg=="
+      "version": "1.0.72527",
+      "resolved": "https://registry.npmjs.org/decentraland-renderer/-/decentraland-renderer-1.0.72527.tgz",
+      "integrity": "sha512-rv3hzeYxiT5+Jo8TgXUr6FBjYsEqebAtHxYIgt6yL/SMvEoUB+ZqrFcjON4m/UligYm0WpoNgsKL1w+ctCRcQQ=="
     },
     "decentraland-rpc": {
       "version": "3.1.8",

--- a/kernel/package.json
+++ b/kernel/package.json
@@ -107,7 +107,7 @@
     "dcl-social-client": "^1.3.13",
     "decentraland-connect": "^2.13.2",
     "decentraland-katalyst-peer": "0.2.20",
-    "decentraland-renderer": "^1.8.70353",
+    "decentraland-renderer": "^1.0.72527",
     "decentraland-rpc": "^3.1.8",
     "devtools-protocol": "0.0.615714",
     "eth-connect": "^4.0.1",


### PR DESCRIPTION
Seems that the latest update of Unity changed the required files for the renderer to work.

CI works as expected. But running locally, it won't work because it cannot find the file corresponding to the URL: http://localhost:3000/unity/Build/unity.framework.js.unityweb

Updating the renderer with `make update-renderer` seems to fix the issue.
