### PR TITLE
feat: add animation state layers to play multiple animations at diffe…

### DIFF
--- a/kernel/packages/decentraland-ecs/src/decentraland/AnimationState.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/AnimationState.ts
@@ -102,16 +102,14 @@ export class AnimationState extends ObservableComponent {
    * Starts the animation
    */
   play(reset: boolean = false) {
-    this.owner?.pauseLayer(this.layer)
-    if (reset) this.reset()
-    this.playing = true
+    this.owner?.play(this, reset)
   }
 
   /**
    * Pauses the animation
    */
   pause() {
-    this.playing = false
+    this.owner?.pause(this)
   }
 
   /**
@@ -125,7 +123,6 @@ export class AnimationState extends ObservableComponent {
    * Resets and pauses the animation
    */
   stop() {
-    this.reset()
-    this.pause()
+    this.owner?.stop(this)
   }
 }

--- a/kernel/packages/decentraland-ecs/src/decentraland/AnimationState.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/AnimationState.ts
@@ -1,23 +1,27 @@
 import { ObservableComponent } from '../ecs/Component'
 import { newId } from '../ecs/helpers'
+import { Animator } from './Components'
 
 /** @public */
 export type AnimationParams = {
   looping?: boolean
   speed?: number
   weight?: number
+  layer?: number
 }
 
-const defaultParams: Required<Pick<AnimationParams, 'looping' | 'speed' | 'weight'>> = {
+const defaultParams: Required<Pick<AnimationParams, 'looping' | 'speed' | 'weight' | 'layer'>> = {
   looping: true,
   speed: 1.0,
-  weight: 1.0
+  weight: 1.0,
+  layer: 0
 }
 
 /**
  * @public
  */
 export class AnimationState extends ObservableComponent {
+
   // @internal
   public isAnimationClip: boolean = true
 
@@ -61,6 +65,14 @@ export class AnimationState extends ObservableComponent {
   @ObservableComponent.readonly
   readonly name: string = newId('AnimClip')
 
+  /**
+   * Layering allows you to have two or more levels of animation on an object's parameters at the same time
+   */
+  public layer: number = defaultParams.layer
+
+  // @internal
+  public owner?: Animator
+
   constructor(clip: string, params: AnimationParams = defaultParams) {
     super()
     this.clip = clip
@@ -73,6 +85,8 @@ export class AnimationState extends ObservableComponent {
   setParams(params: AnimationParams) {
     this.looping = params.looping !== undefined ? params.looping : this.looping
     this.speed = params.speed || this.speed
+    this.weight = params.weight || this.weight
+    this.layer = params.layer || this.layer
     return this
   }
 
@@ -87,7 +101,9 @@ export class AnimationState extends ObservableComponent {
   /**
    * Starts the animation
    */
-  play() {
+  play(reset: boolean = false) {
+    this.owner?.pauseLayer(this.layer)
+    if (reset) this.reset()
     this.playing = true
   }
 

--- a/kernel/packages/decentraland-ecs/src/decentraland/Components.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Components.ts
@@ -536,21 +536,45 @@ export class Animator extends Shape {
   }
 
   /**
-   * Adds an AnimationState to the animation lists.
+   * Resets and pauses the animation state, if the clip is null it will stop all animations on this animator
    */
-  stop() {
-    for (let i = 0; i < this.states.length; i++) {
-      const clip = this.states[i]
-      clip.stop()
+  stop(clip?: AnimationState) {
+    if (clip) {
+      clip.playing = false
+      clip.shouldReset = true
+    } else {
+      for (let i = 0; i < this.states.length; i++) {
+        const animationState = this.states[i]
+        this.stop(animationState)
+      }
     }
   }
 
-  // @internal
-  pauseLayer(layer: number) {
+  /**
+   * Starts the animation
+   */
+  play(clip: AnimationState, reset: boolean = false) {
     for (let i = 0; i < this.states.length; i++) {
-      const clip = this.states[i]
-      if (clip.layer === layer) {
-        clip.pause()
+      const animationState = this.states[i]
+      if (animationState.layer === clip.layer && clip !== animationState) {
+        this.pause(animationState)
+      }
+    }
+
+    if (reset) clip.shouldReset = true
+    clip.playing = true
+  }
+
+  /**
+   * Pauses the animation state, if the clip is null it will pause all animations on this animator
+   */
+  pause(clip?: AnimationState) {
+    if (clip) {
+      clip.playing = false
+    } else {
+      for (let i = 0; i < this.states.length; i++) {
+        const animationState = this.states[i]
+        this.pause(animationState)
       }
     }
   }

--- a/kernel/packages/decentraland-ecs/src/decentraland/Components.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Components.ts
@@ -513,6 +513,8 @@ export class Animator extends Shape {
     clip.onChange(() => {
       this.dirty = true
     })
+
+    clip.owner = this
     return this
   }
 
@@ -531,6 +533,26 @@ export class Animator extends Shape {
     const newClip = new AnimationState(clipName)
     this.addClip(newClip)
     return newClip
+  }
+
+  /**
+   * Adds an AnimationState to the animation lists.
+   */
+  stop() {
+    for (let i = 0; i < this.states.length; i++) {
+      const clip = this.states[i]
+      clip.stop()
+    }
+  }
+
+  // @internal
+  pauseLayer(layer: number) {
+    for (let i = 0; i < this.states.length; i++) {
+      const clip = this.states[i]
+      if (clip.layer === layer) {
+        clip.pause()
+      }
+    }
   }
 }
 

--- a/kernel/public/test-scenes/1.13.animator/BlockDog.glb
+++ b/kernel/public/test-scenes/1.13.animator/BlockDog.glb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e995348d1283dfa7ae9e9eab693f3c169ce42bbf9a1b999a43bf2588a1cc6a7
+size 168672

--- a/kernel/public/test-scenes/1.13.animator/game.ts
+++ b/kernel/public/test-scenes/1.13.animator/game.ts
@@ -1,0 +1,100 @@
+import { engine, BoxShape, Entity, Animator, ActionButton, OnPointerDown, Transform, Vector3, GLTFShape, AnimationState } from 'decentraland-ecs/src'
+
+const createButton = (pos : number, hoverText : string, onClick : Function) => {
+  // Create box shape
+  const boxShapeEntity = new Entity()
+
+  const box = new BoxShape()
+
+  boxShapeEntity.addComponent(
+    new OnPointerDown(
+      e => {
+        onClick()
+      },
+      { button: ActionButton.POINTER, hoverText: hoverText }
+    )
+  )
+
+  boxShapeEntity.addComponent(
+    new Transform({
+      position: new Vector3(6, 0.5, pos),
+      scale: new Vector3(0.2, 0.2, 0.2)
+    })
+  )
+  boxShapeEntity.addComponent(box)
+
+  engine.addEntity(boxShapeEntity)
+}
+
+// Dog
+const dog = new Entity()
+const dogAnimator = new Animator()
+dog.addComponent(new GLTFShape('BlockDog.glb'))
+dog.addComponent(dogAnimator)
+
+const sit = dog.getComponent(Animator).getClip('Sitting')
+const drinking = dog.getComponent(Animator).getClip('Drinking')
+const idle = dog.getComponent(Animator).getClip('Idle')
+const walking = dog.getComponent(Animator).getClip('Walking')
+
+sit.looping = false
+idle.play()
+
+dog.addComponent(
+  new Transform({
+    position: new Vector3(8, 0, 4)
+  })
+)
+
+engine.addEntity(dog)
+
+// Shark
+const shark = new Entity()
+const sharkAnimator = new Animator()
+shark.addComponent(new GLTFShape('shark.gltf'))
+shark.addComponent(sharkAnimator)
+
+const swim = new AnimationState('swim', { layer: 0 })
+const bite = new AnimationState('bite', { layer: 1 })
+
+sharkAnimator.addClip(swim)
+sharkAnimator.addClip(bite)
+
+shark.addComponent(
+  new Transform({
+    position: new Vector3(8, 3, 10)
+  })
+)
+
+engine.addEntity(shark)
+
+// Dog Buttons
+
+createButton(3, 'Stop all animations', () => {
+  dogAnimator.stop()
+})
+
+createButton(3.5, 'Play Sit', () => {
+  sit.play()
+})
+
+createButton(4, 'Play Idle', () => {
+  idle.play()
+})
+
+createButton(4.5, 'Play Drinking', () => {
+  drinking.play()
+})
+
+createButton(5, 'Play Walking', () => {
+  walking.play()
+})
+
+// Shark Buttons
+createButton(12, 'Toggle swim', () => {
+  swim.playing = !swim.playing
+})
+
+createButton(12.5, 'Toggle bite', () => {
+  bite.playing = !bite.playing
+})

--- a/kernel/public/test-scenes/1.13.animator/scene.json
+++ b/kernel/public/test-scenes/1.13.animator/scene.json
@@ -1,0 +1,30 @@
+{
+  "display": {
+    "title": "0.13.animator",
+    "favicon": "favicon_asset"
+  },
+  "contact": {
+    "name": "author-name",
+    "email": ""
+  },
+  "owner": "",
+  "scene": {
+    "parcels": [
+      "1,13"
+    ],
+    "base": "1,13"
+  },
+  "communications": {
+    "type": "webrtc",
+    "signalling": "https://signalling-01.decentraland.org"
+  },
+  "policy": {
+    "contentRating": "E",
+    "fly": true,
+    "voiceEnabled": true,
+    "blacklist": [],
+    "teleportPosition": ""
+  },
+  "main": "game.js",
+  "tags": []
+}

--- a/kernel/public/test-scenes/1.13.animator/shark.gltf
+++ b/kernel/public/test-scenes/1.13.animator/shark.gltf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:986e3a45371a333aeb1c22152bb25982074556472103e89c20ed6a5c62902810
+size 128885

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Components/Animator/DCLAnimator.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Components/Animator/DCLAnimator.cs
@@ -43,8 +43,7 @@ namespace DCL.Components
 
         [System.NonSerialized]
         public Animation animComponent = null;
-
-        Model.DCLAnimationState[] previousState;
+        
         Dictionary<string, AnimationClip> clipNameToClip = new Dictionary<string, AnimationClip>();
         Dictionary<AnimationClip, AnimationState> clipToState = new Dictionary<AnimationClip, AnimationState>();
 
@@ -96,7 +95,7 @@ namespace DCL.Components
             animComponent.Stop(); //NOTE(Brian): When the GLTF is created by GLTFSceneImporter a frame may be elapsed,
             //putting the component in play state if playAutomatically was true at that point.
             animComponent.clip?.SampleAnimation(animComponent.gameObject, 0);
-
+            
             foreach (AnimationState unityState in animComponent)
             {
                 clipNameToClip[unityState.clip.name] = unityState.clip;
@@ -135,23 +134,17 @@ namespace DCL.Components
                     state.clipReference = unityState.clip;
 
                     if (state.shouldReset)
-                    {
                         ResetAnimation(state);
-                    }
 
                     if (state.playing)
                     {
                         if (!animComponent.IsPlaying(state.clip))
-                        {
                             animComponent.Play(state.clip);
-                        }
                     }
                     else
                     {
                         if (animComponent.IsPlaying(state.clip))
-                        {
                             animComponent.Stop(state.clip);
-                        }
                     }
                 }
             }


### PR DESCRIPTION
...erent layers and add a new function on animator to stop all animation states

# What?
Fix decentraland/unity-renderer#107

Add layers to `AnimationState`, when you execute `play` you will pause all animation states from the same layer.

Add new `stop` function on `Animator` to stop all animations

Add new `reset` parameter in `play` function to decide if you want to reset the current clip animation.

New test scene:

https://user-images.githubusercontent.com/12563266/115482447-11bcaf00-a225-11eb-8c89-c59717a6516a.mp4

**Extra bugfix!:** `Weight` of an `AnimationState` was not being send to Unity when we called it by `setParams`.

# Why?
Details: decentraland/unity-renderer#107