### PR TITLE
fix: removed meaningless error message when preview is loading and ge…

### DIFF
--- a/kernel/static/preview.html
+++ b/kernel/static/preview.html
@@ -657,13 +657,15 @@
       const ws = new WebSocket(`${location.protocol === 'https:' ? 'wss' : 'ws'}://${document.location.host}`)
 
       ws.addEventListener('message', msg => {
-        console.log('Sending new message to engine.', msg.data)
-        if (msg.data === 'update') {
-          handleServerMessage({
-            type: 'update'
-          })
-        } else if (msg.data.startsWith('{')) {
-          handleServerMessage(JSON.parse(msg.data))
+        if (typeof handleServerMessage !== 'undefined') {
+          console.log('Sending new message to engine.', msg.data)
+          if (msg.data === 'update') {
+            handleServerMessage({
+              type: 'update'
+            })
+          } else if (msg.data.startsWith('{')) {
+            handleServerMessage(JSON.parse(msg.data))
+          }
         }
       })
       var RENDERER_ARTIFACTS_ROOT = '/@/artifacts/unity/Build/'


### PR DESCRIPTION
…t an update before totally loaded

# What? <!-- what is this PR? -->
Fix decentraland/unity-renderer#228

This was happening when we reload the preview site and in the beginning of the loading we make a change in the scene. So it was receiving a update message and getting that error because it wasn't completly loaded.

# Why? <!-- Explain the reason -->
...
