### PR TITLE
feat: add sdk event to subscribe to camera mode change and we can get…

### DIFF
--- a/kernel/packages/decentraland-ecs/src/decentraland/Camera.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Camera.ts
@@ -1,5 +1,5 @@
 import { Vector3, Quaternion, ReadOnlyVector3, ReadOnlyQuaternion } from './math'
-import { DecentralandInterface, IEvents } from './Types'
+import { DecentralandInterface, IEvents, CameraMode } from './Types'
 
 declare let dcl: DecentralandInterface | void
 
@@ -32,6 +32,11 @@ export class Camera {
     return this._playerHeight
   }
 
+  /** Get Camera Mode. */
+  get cameraMode(): CameraMode {
+    return this._cameraMode
+  }
+
   // @internal
   private lastEventPosition: ReadOnlyVector3 = { x: 0, y: 0, z: 0 }
   // @internal
@@ -43,10 +48,14 @@ export class Camera {
   // @internal
   private _playerHeight: number = 1.6
 
+  // @internal
+  private _cameraMode: CameraMode = CameraMode.FirstPerson
+
   constructor() {
     if (typeof dcl !== 'undefined') {
       dcl.subscribe('positionChanged')
       dcl.subscribe('rotationChanged')
+      dcl.subscribe('onCameraModeChanged')
 
       dcl.onEvent(event => {
         switch (event.type) {
@@ -55,6 +64,9 @@ export class Camera {
             break
           case 'rotationChanged':
             this.rotationChanged(event.data as any)
+            break
+          case 'onCameraModeChanged':
+            this.cameraModeChanged(event.data as any)
             break
         }
       })
@@ -123,5 +135,10 @@ export class Camera {
   // @internal
   private rotationChanged(e: IEvents['rotationChanged']) {
     this.lastEventRotation = e.quaternion
+  }
+
+  // @internal
+  private cameraModeChanged(e: IEvents['onCameraModeChanged']) {
+    this._cameraMode = e.cameraMode
   }
 }

--- a/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
@@ -1,6 +1,7 @@
 import { EventConstructor } from '../ecs/EventManager'
 import { Observable } from '../ecs/Observable'
-import { DecentralandInterface, IEvents, RaycastResponsePayload } from './Types'
+import { DecentralandInterface, IEvents, RaycastResponsePayload, CameraMode } from './Types'
+export { CameraMode }
 
 /**
  * @public

--- a/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
@@ -44,6 +44,12 @@ function createSubscriber(eventName: keyof IEvents) {
 }
 
 /**
+ * This event is triggered when you change your camera between 1st and 3rd person
+ * @public
+ */
+export const onCameraModeChanged = new Observable<IEvents['onCameraModeChanged']>(createSubscriber('onCameraModeChanged'))
+
+/**
  * These events are triggered after your character enters the scene.
  * @public
  */
@@ -73,6 +79,10 @@ export function _initEventObservables(dcl: DecentralandInterface) {
         }
         case 'onLeaveScene': {
           onLeaveScene.notifyObservers(event.data as IEvents['onLeaveScene'])
+          return
+        }
+        case 'onCameraModeChanged': {
+          onCameraModeChanged.notifyObservers(event.data as IEvents['onCameraModeChanged'])
           return
         }
       }

--- a/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
@@ -135,6 +135,13 @@ export type RaycastResponsePayload<T> = {
   payload: T
 }
 
+/** @public */
+export enum CameraMode {
+  FirstPerson,
+  ThirdPerson,
+  BuildingToolGodMode
+}
+
 /**
  * @public
  */
@@ -163,6 +170,13 @@ export interface IEvents {
     rotation: ReadOnlyVector3
     /** Rotation quaternion, useful in some scenarios. */
     quaternion: ReadOnlyQuaternion
+  }
+
+  /**
+   * `onCameraModeChanged` is triggered when the user changes the camera mode
+   */
+  onCameraModeChanged: {
+    cameraMode: CameraMode
   }
 
   /**

--- a/kernel/packages/scene-system/sdk/SceneRuntime.ts
+++ b/kernel/packages/scene-system/sdk/SceneRuntime.ts
@@ -82,6 +82,11 @@ export abstract class SceneRuntime extends Script {
 
   eventSubscriber!: EventSubscriber
 
+  // this dictionary contains the list of subscriptions.
+  // the boolean value indicates if the client is actively
+  // listenting to that event
+  subscribedEvents: { [event: string]: boolean } = {}
+
   onUpdateFunctions: Array<(dt: number) => void> = []
   onStartFunctions: Array<Function> = []
   onEventFunctions: Array<(event: any) => void> = []
@@ -393,19 +398,24 @@ export abstract class SceneRuntime extends Script {
 
         /** subscribe to specific events, events will be handled by the onEvent function */
         subscribe(eventName: string): void {
-          that.eventSubscriber.on(eventName, (event) => {
-            if (eventName === 'raycastResponse') {
-              let idAsNumber = parseInt(event.data.queryId, 10)
-              if (numberToIdStore[idAsNumber]) {
-                event.data.queryId = numberToIdStore[idAsNumber].toString()
+          if (!(eventName in that.subscribedEvents)) {
+            that.subscribedEvents[eventName] = true
+
+            that.eventSubscriber.on(eventName, (event) => {
+              if (eventName === 'raycastResponse') {
+                let idAsNumber = parseInt(event.data.queryId, 10)
+                if (numberToIdStore[idAsNumber]) {
+                  event.data.queryId = numberToIdStore[idAsNumber].toString()
+                }
               }
-            }
-            that.fireEvent({ type: eventName, data: event.data })
-          })
+              that.fireEvent({ type: eventName, data: event.data })
+            })
+          }
         },
 
         /** unsubscribe to specific event */
         unsubscribe(eventName: string): void {
+          delete that.subscribedEvents[eventName]
           that.eventSubscriber.off(eventName)
         },
 

--- a/kernel/packages/scene-system/sdk/SceneRuntime.ts
+++ b/kernel/packages/scene-system/sdk/SceneRuntime.ts
@@ -85,7 +85,7 @@ export abstract class SceneRuntime extends Script {
   // this dictionary contains the list of subscriptions.
   // the boolean value indicates if the client is actively
   // listenting to that event
-  subscribedEvents: { [event: string]: boolean } = {}
+  subscribedEvents: Map<string, boolean> = new Map<string, boolean>()
 
   onUpdateFunctions: Array<(dt: number) => void> = []
   onStartFunctions: Array<Function> = []
@@ -398,8 +398,8 @@ export abstract class SceneRuntime extends Script {
 
         /** subscribe to specific events, events will be handled by the onEvent function */
         subscribe(eventName: string): void {
-          if (!(eventName in that.subscribedEvents)) {
-            that.subscribedEvents[eventName] = true
+          if (!that.subscribedEvents.has(eventName)) {
+            that.subscribedEvents.set(eventName, true)
 
             that.eventSubscriber.on(eventName, (event) => {
               if (eventName === 'raycastResponse') {
@@ -415,7 +415,7 @@ export abstract class SceneRuntime extends Script {
 
         /** unsubscribe to specific event */
         unsubscribe(eventName: string): void {
-          delete that.subscribedEvents[eventName]
+          that.subscribedEvents.delete(eventName)
           that.eventSubscriber.off(eventName)
         },
 

--- a/kernel/packages/shared/world/SceneSystemWorker.ts
+++ b/kernel/packages/shared/world/SceneSystemWorker.ts
@@ -3,7 +3,7 @@ import { ScriptingTransport } from 'decentraland-rpc/lib/common/json-rpc/types'
 import { playerConfigurations } from 'config'
 import { SceneWorker } from './SceneWorker'
 import { Vector3, Quaternion } from 'decentraland-ecs/src/decentraland/math'
-import { PositionReport, positionObservable } from './positionThings'
+import { PositionReport, positionObservable, cameraModeObservable } from './positionThings'
 import { Observer } from 'decentraland-ecs/src'
 import { sceneLifeCycleObservable } from '../../decentraland-loader/lifecycle/controllers/scene'
 import { renderStateObservable, isRendererEnabled } from './worldState'
@@ -30,6 +30,7 @@ export class SceneSystemWorker extends SceneWorker {
   private sceneLifeCycleObserver: Observer<any> | null = null
   private renderStateObserver: Observer<any> | null = null
   private sceneChangeObserver: Observer<any> | null = null
+  private cameraModeChangedObserver: Observer<any> | null = null
 
   private sceneReady: boolean = false
 
@@ -44,6 +45,7 @@ export class SceneSystemWorker extends SceneWorker {
     this.subscribeToWorldRunningEvents()
     this.subscribeToPositionEvents()
     this.subscribeToSceneChangeEvents()
+    this.subscribeToCameraChangeEvents()
   }
 
   private static buildWebWorkerTransport(parcelScene: ParcelSceneAPI): ScriptingTransport {
@@ -85,6 +87,10 @@ export class SceneSystemWorker extends SceneWorker {
     if (this.sceneChangeObserver) {
       sceneObservable.remove(this.sceneChangeObserver)
       this.sceneChangeObserver = null
+    }
+    if (this.cameraModeChangedObserver) {
+      cameraModeObservable.remove(this.cameraModeChangedObserver)
+      this.cameraModeChangedObserver = null
     }
   }
 
@@ -152,6 +158,14 @@ export class SceneSystemWorker extends SceneWorker {
         this.sceneReady = true
         sceneLifeCycleObservable.remove(this.sceneLifeCycleObserver)
         this.sendSceneReadyIfNecessary()
+      }
+    })
+  }
+
+  private subscribeToCameraChangeEvents() {
+    this.cameraModeChangedObserver = cameraModeObservable.add((cameraMode) => {
+      if (this.engineAPI && 'onCameraModeChanged' in this.engineAPI.subscribedEvents) {
+        this.engineAPI.sendSubscriptionEvent('onCameraModeChanged', { cameraMode })
       }
     })
   }

--- a/kernel/packages/shared/world/positionThings.ts
+++ b/kernel/packages/shared/world/positionThings.ts
@@ -17,6 +17,7 @@ import {
 } from 'atomicHelpers/parcelScenePositions'
 import { DEBUG } from "../../config"
 import { isInsideWorldLimits } from '@dcl/schemas'
+import { CameraMode } from 'decentraland-ecs/src/decentraland/Types'
 
 declare var location: any
 declare var history: any
@@ -47,6 +48,8 @@ export const positionObservable = new Observable<Readonly<PositionReport>>()
 export const parcelObservable = new Observable<ParcelReport>()
 
 export const teleportObservable = new Observable<ReadOnlyVector2>()
+
+export const cameraModeObservable = new Observable<CameraMode>()
 
 export const lastPlayerPosition = new Vector3()
 export let lastPlayerParcel: Vector2

--- a/kernel/packages/unity-interface/BrowserInterface.ts
+++ b/kernel/packages/unity-interface/BrowserInterface.ts
@@ -7,7 +7,7 @@ import { TeleportController } from 'shared/world/TeleportController'
 import { reportScenesAroundParcel } from 'shared/atlas/actions'
 import { decentralandConfigurations, ethereumConfigurations, playerConfigurations, WORLD_EXPLORER } from 'config'
 import { Quaternion, ReadOnlyQuaternion, ReadOnlyVector3, Vector3 } from '../decentraland-ecs/src/decentraland/math'
-import { IEventNames } from '../decentraland-ecs/src/decentraland/Types'
+import { CameraMode, IEventNames } from '../decentraland-ecs/src/decentraland/Types'
 import { sceneLifeCycleObservable } from '../decentraland-loader/lifecycle/controllers/scene'
 import { identifyEmail, trackEvent } from 'shared/analytics'
 import { aborted } from 'shared/loading/ReportFatalError'
@@ -23,7 +23,7 @@ import {
 } from 'shared/types'
 import { getSceneWorkerBySceneID, setNewParcelScene, stopParcelSceneWorker } from 'shared/world/parcelSceneManager'
 import { getPerformanceInfo } from 'shared/session/getPerformanceInfo'
-import { positionObservable } from 'shared/world/positionThings'
+import { cameraModeObservable, positionObservable } from 'shared/world/positionThings'
 import { renderStateObservable } from 'shared/world/worldState'
 import { sendMessage } from 'shared/chat/actions'
 import { updateFriendship, updateUserData } from 'shared/friends/actions'
@@ -114,6 +114,10 @@ export class BrowserInterface {
     }
 
     positionObservable.notifyObservers(positionEvent)
+  }
+
+  public ReportCameraMode(data: { cameraMode: CameraMode }) {
+    cameraModeObservable.notifyObservers(data.cameraMode)
   }
 
   public ReportMousePosition(data: { id: string; mousePosition: ReadOnlyVector3 }) {

--- a/kernel/public/test-scenes/0.12.subscribeToEnterLeaveScene2/game.ts
+++ b/kernel/public/test-scenes/0.12.subscribeToEnterLeaveScene2/game.ts
@@ -1,29 +1,64 @@
-import { log, engine, Entity, BoxShape, Material, Color3, Transform, Vector3, onEnterScene, onLeaveScene } from 'decentraland-ecs/src'
+import { log, engine, Entity, BoxShape, Material, Color3, Transform, Vector3, onEnterScene, onLeaveScene, onCameraModeChanged, Camera, CameraMode } from 'decentraland-ecs/src'
 
+//Create entity and assign shape
+const floor = new Entity()
+floor.addComponent(new BoxShape())
+
+//Create material and configure its fields
+const floorMaterial = new Material()
+floorMaterial.albedoColor = Color3.Gray()
+
+//Assign the material to the entity
+floor.addComponent(floorMaterial)
+
+floor.addComponent(new Transform({
+  position: new Vector3(8, 0, 16),
+  scale: new Vector3(16, 0.1, 32),
+}))
+
+engine.addEntity(floor);
+
+onEnterScene.add(({ userId }) => {
+  floorMaterial.albedoColor = Color3.Red()
+  log("onEnterScene: ", userId, " - CameraMode: ", Camera.instance.cameraMode)
+})
+
+onLeaveScene.add(({ userId }) => {
+  floorMaterial.albedoColor = Color3.Gray()
+  log("onLeaveScene: ", userId)
+})
+
+
+// Camera Mode
 //Create entity and assign shape
 const box = new Entity()
 box.addComponent(new BoxShape())
 
 //Create material and configure its fields
-const material = new Material()
-material.albedoColor = Color3.Gray()
+const boxMaterial = new Material()
+boxMaterial.albedoColor = Color3.Gray()
 
 //Assign the material to the entity
-box.addComponent(material)
+box.addComponent(boxMaterial)
 
 box.addComponent(new Transform({
-  position: new Vector3(8, 0, 16),
-  scale: new Vector3(16, 0.1, 32),
+  position: new Vector3(8, 2, 8),
+  scale: new Vector3(1, 1, 1),
 }))
 
 engine.addEntity(box);
 
-onEnterScene.add(({ userId }) => {
-  material.albedoColor = Color3.Red()
-  log("onEnterScene: ", userId)
+const setFloorMaterial = (cameraMode: CameraMode) => {
+  if (cameraMode == CameraMode.FirstPerson)
+    boxMaterial.albedoColor = Color3.Red()
+  else if (cameraMode == CameraMode.ThirdPerson)
+    boxMaterial.albedoColor = Color3.Blue()
+}
+
+onCameraModeChanged.add(({ cameraMode }) => {
+  log("onCameraModeChanged", cameraMode)
+  setFloorMaterial(cameraMode)
 })
 
-onLeaveScene.add(({ userId }) => {
-  material.albedoColor = Color3.Gray()
-  log("onLeaveScene: ", userId)
-})
+// Init
+setFloorMaterial(Camera.instance.cameraMode)

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Camera.asmdef
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Camera/Camera.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "Camera",
+    "rootNamespace": "",
     "references": [
         "GUID:4720e174f2805c74bb7aa94cc8bb5bf8",
         "GUID:4307f53044263cf4b835bd812fc161a4",
@@ -7,7 +8,8 @@
         "GUID:b1087c5731ff68448a0a9c625bb7e52d",
         "GUID:e555144732b726c4cba5b0f6337fea75",
         "GUID:555c1f3c6d18648df910b7a1de75b424",
-        "GUID:99cea83ca76dcd846abed7e61a8c90bd"
+        "GUID:99cea83ca76dcd846abed7e61a8c90bd",
+        "GUID:4973650d2444c4561a15d50f24d91cd9"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/Controllers/Camera/CameraController.cs
@@ -2,6 +2,7 @@ using Cinemachine;
 using DCL.Helpers;
 using System.Collections.Generic;
 using System.Linq;
+using DCL;
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -107,6 +108,8 @@ public class CameraController : MonoBehaviour
         currentCameraState.OnUnselect();
         CommonScriptableObjects.cameraMode.Set(newMode);
         currentCameraState.OnSelect();
+        
+        DCL.Interface.WebInterface.ReportCameraChanged(newMode);
 
         onSetCameraMode.Invoke(newMode);
     }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -126,6 +126,12 @@ namespace DCL.Interface
         public class OnClickEvent : UUIDEvent<OnClickEventPayload> { };
 
         [System.Serializable]
+        public class CameraModePayload
+        {
+            public CameraMode.ModeId cameraMode;
+        };
+
+        [System.Serializable]
         public class OnPointerDownEvent : UUIDEvent<OnPointerEventPayload> { };
 
         [System.Serializable]
@@ -160,7 +166,6 @@ namespace DCL.Interface
         {
             public ACTION_BUTTON buttonId = ACTION_BUTTON.POINTER;
         }
-
         [System.Serializable]
         public class SendChatMessageEvent
         {
@@ -585,6 +590,7 @@ namespace DCL.Interface
         }
 
         private static ReportPositionPayload positionPayload = new ReportPositionPayload();
+        private static CameraModePayload cameraModePayload = new CameraModePayload();
         private static OnMetricsUpdate onMetricsUpdate = new OnMetricsUpdate();
         private static OnClickEvent onClickEvent = new OnClickEvent();
         private static OnPointerDownEvent onPointerDownEvent = new OnPointerDownEvent();
@@ -636,6 +642,12 @@ namespace DCL.Interface
             positionPayload.playerHeight = playerHeight;
 
             SendMessage("ReportPosition", positionPayload);
+        }
+        
+        public static void ReportCameraChanged(CameraMode.ModeId cameraMode)
+        {
+            cameraModePayload.cameraMode = cameraMode;
+            SendMessage("ReportCameraMode", cameraModePayload);
         }
 
         public static void ReportControlEvent<T>(T controlEvent) where T : ControlEvent { SendMessage("ControlEvent", controlEvent); }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/WebInterface/WebInterface.asmdef
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/WebInterface/WebInterface.asmdef
@@ -1,11 +1,13 @@
 {
     "name": "WebInterface",
+    "rootNamespace": "",
     "references": [
         "GUID:43315b150e1df4592868fc0fe58b3429",
         "GUID:6afcac5154f98e846bbd9f27e454b57a",
         "GUID:ba9b721ce33233c4da7ff4ef30d25b59",
         "GUID:a881b57670b1d2747a6d7f9e32b63230",
-        "GUID:b1087c5731ff68448a0a9c625bb7e52d"
+        "GUID:b1087c5731ff68448a0a9c625bb7e52d",
+        "GUID:4720e174f2805c74bb7aa94cc8bb5bf8"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
… the value of it too

# What? <!-- what is this PR? -->
Fix decentraland/unity-renderer#275

https://user-images.githubusercontent.com/12563266/115803183-c2a68380-a3b6-11eb-9d9d-1507f1691205.mp4

**New SDK code:**
```
onCameraModeChanged.add(({ cameraMode }) => {
  log("onCameraModeChanged:", cameraMode)
})

log("Current CameraMode:", Camera.instance.cameraMode)
```

**Test scene:**
Turns red the box on first person camera, and blue on third person camera.

@menduz I changed `SceneRuntime.subscribe` because if we call that function multiple times it subscribe more than once in each event.
Let me know if it correct.