### PR TITLE
refactor: new way to send events from unity to the sdk

### DIFF
--- a/kernel/packages/decentraland-ecs/src/decentraland/Camera.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Camera.ts
@@ -47,7 +47,6 @@ export class Camera {
 
   // @internal
   private _playerHeight: number = 1.6
-
   // @internal
   private _cameraMode: CameraMode = CameraMode.FirstPerson
 
@@ -55,7 +54,7 @@ export class Camera {
     if (typeof dcl !== 'undefined') {
       dcl.subscribe('positionChanged')
       dcl.subscribe('rotationChanged')
-      dcl.subscribe('onCameraModeChanged')
+      dcl.subscribe('cameraModeChanged')
 
       dcl.onEvent(event => {
         switch (event.type) {
@@ -65,7 +64,7 @@ export class Camera {
           case 'rotationChanged':
             this.rotationChanged(event.data as any)
             break
-          case 'onCameraModeChanged':
+          case 'cameraModeChanged':
             this.cameraModeChanged(event.data as any)
             break
         }
@@ -138,7 +137,7 @@ export class Camera {
   }
 
   // @internal
-  private cameraModeChanged(e: IEvents['onCameraModeChanged']) {
+  private cameraModeChanged(e: IEvents['cameraModeChanged']) {
     this._cameraMode = e.cameraMode
   }
 }

--- a/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
@@ -48,7 +48,7 @@ function createSubscriber(eventName: keyof IEvents) {
  * This event is triggered when you change your camera between 1st and 3rd person
  * @public
  */
-export const onCameraModeChanged = new Observable<IEvents['onCameraModeChanged']>(createSubscriber('onCameraModeChanged'))
+export const onCameraModeChanged = new Observable<IEvents['cameraModeChanged']>(createSubscriber('cameraModeChanged'))
 
 /**
  * These events are triggered after your character enters the scene.
@@ -82,8 +82,8 @@ export function _initEventObservables(dcl: DecentralandInterface) {
           onLeaveScene.notifyObservers(event.data as IEvents['onLeaveScene'])
           return
         }
-        case 'onCameraModeChanged': {
-          onCameraModeChanged.notifyObservers(event.data as IEvents['onCameraModeChanged'])
+        case 'cameraModeChanged': {
+          onCameraModeChanged.notifyObservers(event.data as IEvents['cameraModeChanged'])
           return
         }
       }

--- a/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
@@ -144,6 +144,7 @@ export enum CameraMode {
 
 /**
  * @public
+ * Note: Don't use `on` prefix for IEvents to avoid redundancy with `event.on("onEventName")` syntax.
  */
 export interface IEvents {
   /**
@@ -173,9 +174,9 @@ export interface IEvents {
   }
 
   /**
-   * `onCameraModeChanged` is triggered when the user changes the camera mode
+   * `cameraModeChanged` is triggered when the user changes the camera mode
    */
-  onCameraModeChanged: {
+  cameraModeChanged: {
     cameraMode: CameraMode
   }
 

--- a/kernel/packages/shared/apis/EngineAPI.ts
+++ b/kernel/packages/shared/apis/EngineAPI.ts
@@ -1,5 +1,6 @@
 import { IEventNames, IEvents } from 'decentraland-ecs/src/decentraland/Types'
 import { APIOptions, exposeMethod, registerAPI } from 'decentraland-rpc/lib/host'
+import { ParcelSceneAPI } from '../../shared/world/ParcelSceneAPI'
 import { EntityAction } from '../types'
 import { ExposableAPI } from './ExposableAPI'
 import { IEngineAPI } from './IEngineAPI'
@@ -7,7 +8,7 @@ import { IEngineAPI } from './IEngineAPI'
 @registerAPI('EngineAPI')
 export class EngineAPI extends ExposableAPI implements IEngineAPI {
   didStart: boolean = false
-  parcelSceneAPI!: any
+  parcelSceneAPI!: ParcelSceneAPI
 
   // this dictionary contains the list of subscriptions.
   // the boolean value indicates if the client is actively

--- a/kernel/packages/shared/world/SceneSystemWorker.ts
+++ b/kernel/packages/shared/world/SceneSystemWorker.ts
@@ -3,7 +3,7 @@ import { ScriptingTransport } from 'decentraland-rpc/lib/common/json-rpc/types'
 import { playerConfigurations } from 'config'
 import { SceneWorker } from './SceneWorker'
 import { Vector3, Quaternion } from 'decentraland-ecs/src/decentraland/math'
-import { PositionReport, positionObservable, cameraModeObservable } from './positionThings'
+import { PositionReport, positionObservable } from './positionThings'
 import { Observer } from 'decentraland-ecs/src'
 import { sceneLifeCycleObservable } from '../../decentraland-loader/lifecycle/controllers/scene'
 import { renderStateObservable, isRendererEnabled } from './worldState'
@@ -30,7 +30,6 @@ export class SceneSystemWorker extends SceneWorker {
   private sceneLifeCycleObserver: Observer<any> | null = null
   private renderStateObserver: Observer<any> | null = null
   private sceneChangeObserver: Observer<any> | null = null
-  private cameraModeChangedObserver: Observer<any> | null = null
 
   private sceneReady: boolean = false
 
@@ -45,7 +44,6 @@ export class SceneSystemWorker extends SceneWorker {
     this.subscribeToWorldRunningEvents()
     this.subscribeToPositionEvents()
     this.subscribeToSceneChangeEvents()
-    this.subscribeToCameraChangeEvents()
   }
 
   private static buildWebWorkerTransport(parcelScene: ParcelSceneAPI): ScriptingTransport {
@@ -87,10 +85,6 @@ export class SceneSystemWorker extends SceneWorker {
     if (this.sceneChangeObserver) {
       sceneObservable.remove(this.sceneChangeObserver)
       this.sceneChangeObserver = null
-    }
-    if (this.cameraModeChangedObserver) {
-      cameraModeObservable.remove(this.cameraModeChangedObserver)
-      this.cameraModeChangedObserver = null
     }
   }
 
@@ -158,14 +152,6 @@ export class SceneSystemWorker extends SceneWorker {
         this.sceneReady = true
         sceneLifeCycleObservable.remove(this.sceneLifeCycleObserver)
         this.sendSceneReadyIfNecessary()
-      }
-    })
-  }
-
-  private subscribeToCameraChangeEvents() {
-    this.cameraModeChangedObserver = cameraModeObservable.add((cameraMode) => {
-      if (this.engineAPI && 'onCameraModeChanged' in this.engineAPI.subscribedEvents) {
-        this.engineAPI.sendSubscriptionEvent('onCameraModeChanged', { cameraMode })
       }
     })
   }

--- a/kernel/packages/shared/world/positionThings.ts
+++ b/kernel/packages/shared/world/positionThings.ts
@@ -17,7 +17,6 @@ import {
 } from 'atomicHelpers/parcelScenePositions'
 import { DEBUG } from "../../config"
 import { isInsideWorldLimits } from '@dcl/schemas'
-import { CameraMode } from 'decentraland-ecs/src/decentraland/Types'
 
 declare var location: any
 declare var history: any
@@ -48,8 +47,6 @@ export const positionObservable = new Observable<Readonly<PositionReport>>()
 export const parcelObservable = new Observable<ParcelReport>()
 
 export const teleportObservable = new Observable<ReadOnlyVector2>()
-
-export const cameraModeObservable = new Observable<CameraMode>()
 
 export const lastPlayerPosition = new Vector3()
 export let lastPlayerParcel: Vector2

--- a/unity-client/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -105,12 +105,6 @@ namespace DCL.Interface
             public string eventType;
             public T payload;
         }
-        [System.Serializable]
-        public class AllScenesEvent<T>
-        {
-            public string eventType;
-            public T payload;
-        }
 
         [System.Serializable]
         public class UUIDEvent<TPayload>
@@ -631,14 +625,6 @@ namespace DCL.Interface
         private static RequestWearablesPayload requestWearablesPayload = new RequestWearablesPayload();
         private static SearchENSOwnerPayload searchEnsOwnerPayload = new SearchENSOwnerPayload();
 
-        private static void SendAllScenesEvent<T>(string eventType, T payload)
-        {
-            AllScenesEvent<T> allScenesEvent = new AllScenesEvent<T>();
-            allScenesEvent.eventType = eventType;
-            allScenesEvent.payload = payload;
-
-            SendMessage("AllScenesEvent", allScenesEvent);
-        }
         public static void SendSceneEvent<T>(string sceneId, string eventType, T payload)
         {
             SceneEvent<T> sceneEvent = new SceneEvent<T>();
@@ -661,7 +647,7 @@ namespace DCL.Interface
         public static void ReportCameraChanged(CameraMode.ModeId cameraMode)
         {
             cameraModePayload.cameraMode = cameraMode;
-            SendAllScenesEvent("cameraModeChanged", cameraModePayload);
+            SendMessage("ReportCameraMode", cameraModePayload);
         }
 
         public static void ReportControlEvent<T>(T controlEvent) where T : ControlEvent { SendMessage("ControlEvent", controlEvent); }

--- a/unity-client/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -631,7 +631,7 @@ namespace DCL.Interface
         private static RequestWearablesPayload requestWearablesPayload = new RequestWearablesPayload();
         private static SearchENSOwnerPayload searchEnsOwnerPayload = new SearchENSOwnerPayload();
 
-        public static void SendAllScenesEvent<T>(string eventType, T payload)
+        private static void SendAllScenesEvent<T>(string eventType, T payload)
         {
             AllScenesEvent<T> allScenesEvent = new AllScenesEvent<T>();
             allScenesEvent.eventType = eventType;

--- a/unity-client/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
+++ b/unity-client/Assets/Scripts/MainScripts/DCL/WebInterface/Interface.cs
@@ -105,6 +105,12 @@ namespace DCL.Interface
             public string eventType;
             public T payload;
         }
+        [System.Serializable]
+        public class AllScenesEvent<T>
+        {
+            public string eventType;
+            public T payload;
+        }
 
         [System.Serializable]
         public class UUIDEvent<TPayload>
@@ -625,6 +631,14 @@ namespace DCL.Interface
         private static RequestWearablesPayload requestWearablesPayload = new RequestWearablesPayload();
         private static SearchENSOwnerPayload searchEnsOwnerPayload = new SearchENSOwnerPayload();
 
+        public static void SendAllScenesEvent<T>(string eventType, T payload)
+        {
+            AllScenesEvent<T> allScenesEvent = new AllScenesEvent<T>();
+            allScenesEvent.eventType = eventType;
+            allScenesEvent.payload = payload;
+
+            SendMessage("AllScenesEvent", allScenesEvent);
+        }
         public static void SendSceneEvent<T>(string sceneId, string eventType, T payload)
         {
             SceneEvent<T> sceneEvent = new SceneEvent<T>();
@@ -647,7 +661,7 @@ namespace DCL.Interface
         public static void ReportCameraChanged(CameraMode.ModeId cameraMode)
         {
             cameraModePayload.cameraMode = cameraMode;
-            SendMessage("ReportCameraMode", cameraModePayload);
+            SendAllScenesEvent("cameraModeChanged", cameraModePayload);
         }
 
         public static void ReportControlEvent<T>(T controlEvent) where T : ControlEvent { SendMessage("ControlEvent", controlEvent); }


### PR DESCRIPTION
# What? <!-- what is this PR? -->
Fix decentraland/unity-renderer#293
Related to #2316

Now we can send the event without going throght SceneWorkerSystem

# Why? <!-- Explain the reason -->
To avoid repeating code for each event, now we can send an event from Unity to SDK directly.

We discussed with @menduz to remove all "`on`" prefix in `IEvents` to avoid redundancy to avoid code like:
```events.on('onCameraModeChanged')```