### PR TITLE
fix: genesis plaza alpha issue

### DIFF
--- a/unity-client/Assets/Rendering/Shaders/URP/LitInput.hlsl
+++ b/unity-client/Assets/Rendering/Shaders/URP/LitInput.hlsl
@@ -225,7 +225,7 @@ inline void InitializeStandardLitSurfaceDataWithUV2(float2 uvAlbedo, float2 uvNo
     half4 albedoAlpha = SampleAlbedoAlpha(uvAlbedo, TEXTURE2D_ARGS(_BaseMap, sampler_BaseMap));
     half4 alphaTexture = SampleAlbedoAlpha(uvAlbedo, TEXTURE2D_ARGS(_AlphaTexture, sampler_AlphaTexture));
 
-    outSurfaceData.alpha = Alpha(albedoAlpha.a, _BaseColor, _Cutoff) * length(alphaTexture.rgb);
+    outSurfaceData.alpha = Alpha(albedoAlpha.a, _BaseColor, _Cutoff) * saturate(length(alphaTexture.rgb));
 
     half4 specGloss = SampleMetallicSpecGloss(uvMetallic, albedoAlpha.a);
     outSurfaceData.albedo = albedoAlpha.rgb * _BaseColor.rgb;


### PR DESCRIPTION
Calculating greyness using `length` didn't take into account that it could go above one due to how distance formula works. 

This caused transparency issues on genesis plaza.

Before:
![image](https://user-images.githubusercontent.com/6875814/116277066-80d16080-a75b-11eb-971f-355ef579bd62.png)

After:
![image](https://user-images.githubusercontent.com/6875814/116277151-95155d80-a75b-11eb-871c-dc5823e48314.png)
