### PR TITLE
chore: add gitattribute to treat shell scripts as lf (line feed) a…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -70,3 +70,5 @@
 #*.RTF   diff=astextplain
 TestResources/Audio/Train.wav filter=lfs diff=lfs merge=lfs -text
 *.jspre linguist-language=JavaScript
+# Shell scripts require LF
+*.sh text eol=lf


### PR DESCRIPTION
…nd avoid conflicts in windows os with crlf (carriage return + line feed)

# What? 
After #2308 we started executing `updateRenderer.sh` when we use `make watch`.

Git in Windows were modifying the end line from `lf` (line feed) to `crlf` (carriage return + line feed) and that was breaking the script.

So I added in .gitattributes to considerer all `.sh` as `lf`.

More info about `lf` vs `crlf`: https://stackoverflow.com/a/1552770

Edit: When I merge I will rename the commit message from `refactor` to `chore`