### PR TITLE
hotfix: Adapt the tutorial camera for the new Genesis Plaza

### DIFF
--- a/kernel/packages/entryPoints/unity.ts
+++ b/kernel/packages/entryPoints/unity.ts
@@ -100,10 +100,15 @@ initializeUnity(container)
       i.ConfigureHUDElement(HUDElementID.USERS_AROUND_LIST_HUD, { active: voiceChatEnabled, visible: false })
       i.ConfigureHUDElement(HUDElementID.FRIENDS, { active: identity.hasConnectedWeb3, visible: false })
 
+      const tutorialConfig = {
+        fromDeepLink: HAS_INITIAL_POSITION_MARK,
+        enableNewTutorialCamera: false,
+      }
+
       EnsureProfile(identity.address)
         .then((profile) => {
           i.ConfigureEmailPrompt(profile.tutorialStep)
-          i.ConfigureTutorial(profile.tutorialStep, HAS_INITIAL_POSITION_MARK)
+          i.ConfigureTutorial(profile.tutorialStep, tutorialConfig)
         })
         .catch((e) => logger.error(`error getting profile ${e}`))
     } catch (e) {

--- a/kernel/packages/entryPoints/website.ts
+++ b/kernel/packages/entryPoints/website.ts
@@ -93,6 +93,7 @@ namespace webApp {
     const i = unityInterface
     const worldConfig: WorldConfig | undefined = globalThis.globalStore.getState().meta.config.world
     const renderProfile = worldConfig ? worldConfig.renderProfile ?? RenderProfile.DEFAULT : RenderProfile.DEFAULT
+    const enableNewTutorialCamera = worldConfig ? worldConfig.enableNewTutorialCamera ?? false : false
 
     i.ConfigureHUDElement(HUDElementID.MINIMAP, { active: true, visible: true })
     i.ConfigureHUDElement(HUDElementID.NOTIFICATION, { active: true, visible: true })
@@ -143,10 +144,15 @@ namespace webApp {
           Html.switchGameContainer(true)
         }).catch(logger.error)
 
+        const tutorialConfig = {
+          fromDeepLink: HAS_INITIAL_POSITION_MARK,
+          enableNewTutorialCamera: enableNewTutorialCamera,
+        }
+
         EnsureProfile(identity.address)
           .then((profile) => {
             i.ConfigureEmailPrompt(profile.tutorialStep)
-            i.ConfigureTutorial(profile.tutorialStep, HAS_INITIAL_POSITION_MARK)
+            i.ConfigureTutorial(profile.tutorialStep, tutorialConfig)
             i.ConfigureHUDElement(HUDElementID.GRAPHIC_CARD_WARNING, { active: true, visible: true })
           })
           .catch((e) => logger.error(`error getting profile ${e}`))

--- a/kernel/packages/shared/meta/types.ts
+++ b/kernel/packages/shared/meta/types.ts
@@ -27,6 +27,7 @@ export type WorldConfig = {
   renderProfile?: RenderProfile
   messageOfTheDay?: MessageOfTheDayConfig | null
   messageOfTheDayInit?: boolean
+  enableNewTutorialCamera?: boolean
 }
 
 export type MessageOfTheDayConfig = {

--- a/kernel/packages/shared/types.ts
+++ b/kernel/packages/shared/types.ts
@@ -584,3 +584,8 @@ export type CurrentRealmInfoForRenderer = {
   domain: string
   contentServerUrl: string
 }
+
+export type TutorialInitializationMessage = {
+  fromDeepLink: boolean
+  enableNewTutorialCamera: boolean
+}

--- a/kernel/packages/unity-interface/UnityInterface.ts
+++ b/kernel/packages/unity-interface/UnityInterface.ts
@@ -19,7 +19,8 @@ import {
   KernelConfigForRenderer,
   RealmsInfoForRenderer,
   ContentMapping,
-  Profile
+  Profile,
+  TutorialInitializationMessage
 } from 'shared/types'
 import { nativeMsgBridge } from './nativeMessagesBridge'
 import { HotSceneInfo } from 'shared/social/hotScenes'
@@ -279,12 +280,12 @@ export class UnityInterface {
     }
   }
 
-  public SetTutorialEnabled(fromDeepLink: boolean) {
-    this.SendMessageToUnity('TutorialController', 'SetTutorialEnabled', JSON.stringify(fromDeepLink))
+  public SetTutorialEnabled(tutorialConfig: TutorialInitializationMessage) {
+    this.SendMessageToUnity('TutorialController', 'SetTutorialEnabled', JSON.stringify(tutorialConfig))
   }
 
-  public SetTutorialEnabledForUsersThatAlreadyDidTheTutorial() {
-    this.SendMessageToUnity('TutorialController', 'SetTutorialEnabledForUsersThatAlreadyDidTheTutorial')
+  public SetTutorialEnabledForUsersThatAlreadyDidTheTutorial(tutorialConfig: TutorialInitializationMessage) {
+    this.SendMessageToUnity('TutorialController', 'SetTutorialEnabledForUsersThatAlreadyDidTheTutorial', JSON.stringify(tutorialConfig))
   }
 
   public TriggerAirdropDisplay(data: AirdropInfo) {
@@ -344,14 +345,14 @@ export class UnityInterface {
     })
   }
 
-  public ConfigureTutorial(tutorialStep: number, fromDeepLink: boolean) {
+  public ConfigureTutorial(tutorialStep: number, tutorialConfig: TutorialInitializationMessage) {
     const tutorialCompletedFlag = 256
 
     if (WORLD_EXPLORER) {
       if (RESET_TUTORIAL || (tutorialStep & tutorialCompletedFlag) === 0) {
-        this.SetTutorialEnabled(fromDeepLink)
+        this.SetTutorialEnabled(tutorialConfig)
       } else {
-        this.SetTutorialEnabledForUsersThatAlreadyDidTheTutorial()
+        this.SetTutorialEnabledForUsersThatAlreadyDidTheTutorial(tutorialConfig)
         setDelightedSurveyEnabled(true)
       }
     }

--- a/unity-client/Assets/Scripts/MainScripts/Debugging/WSS/WSSController.cs
+++ b/unity-client/Assets/Scripts/MainScripts/Debugging/WSS/WSSController.cs
@@ -29,10 +29,7 @@ namespace DCL
             public string type;
             public string payload;
 
-            public override string ToString()
-            {
-                return string.Format("type = {0}... payload = {1}...", type, payload);
-            }
+            public override string ToString() { return string.Format("type = {0}... payload = {1}...", type, payload); }
         }
 
         protected override void OnMessage(MessageEventArgs e)
@@ -49,10 +46,7 @@ namespace DCL
             }
         }
 
-        protected override void OnError(ErrorEventArgs e)
-        {
-            base.OnError(e);
-        }
+        protected override void OnError(ErrorEventArgs e) { base.OnError(e); }
 
         protected override void OnClose(CloseEventArgs e)
         {
@@ -110,10 +104,7 @@ namespace DCL
         [System.NonSerialized]
         public static volatile bool queuedMessagesDirty;
 
-        public bool isServerReady
-        {
-            get { return ws.IsListening; }
-        }
+        public bool isServerReady { get { return ws.IsListening; } }
 
         public string wssServerUrl = "ws://localhost:5000/";
         public bool openBrowserWhenStart;
@@ -144,11 +135,7 @@ namespace DCL
         public bool questsEnabled = true;
         public DebugPanel debugPanelMode = DebugPanel.Off;
 
-
-        private void Awake()
-        {
-            i = this;
-        }
+        private void Awake() { i = this; }
 
         private void Start()
         {
@@ -438,7 +425,7 @@ namespace DCL
                                 DCL.Tutorial.TutorialController.i?.SetTutorialEnabled(msg.payload);
                                 break;
                             case "SetTutorialEnabledForUsersThatAlreadyDidTheTutorial":
-                                DCL.Tutorial.TutorialController.i?.SetTutorialEnabledForUsersThatAlreadyDidTheTutorial();
+                                DCL.Tutorial.TutorialController.i?.SetTutorialEnabledForUsersThatAlreadyDidTheTutorial(msg.payload);
                                 break;
                             case "TriggerSelfUserExpression":
                                 HUDController.i.TriggerSelfUserExpression(msg.payload);

--- a/unity-client/Assets/Tutorial/Scripts/TutorialController.cs
+++ b/unity-client/Assets/Tutorial/Scripts/TutorialController.cs
@@ -15,6 +15,13 @@ namespace DCL.Tutorial
     /// </summary>
     public class TutorialController : MonoBehaviour
     {
+        [System.Serializable]
+        public class TutorialInitializationMessage
+        {
+            public string fromDeepLink;
+            public string enableNewTutorialCamera;
+        }
+
         [Flags]
         public enum TutorialFinishStep
         {
@@ -41,10 +48,7 @@ namespace DCL.Tutorial
 
         public static TutorialController i { get; private set; }
 
-        public HUDController hudController
-        {
-            get => HUDController.i;
-        }
+        public HUDController hudController { get => HUDController.i; }
 
         public int currentStepIndex { get; private set; }
         public event Action OnTutorialEnabled;
@@ -160,7 +164,13 @@ namespace DCL.Tutorial
                 CommonScriptableObjects.isTaskbarHUDInitialized.OnChange += IsTaskbarHUDInitialized_OnChange;
 
             if (debugRunTutorial)
-                SetTutorialEnabled(debugOpenedFromDeepLink.ToString());
+            {
+                SetTutorialEnabled(JsonUtility.ToJson(new TutorialInitializationMessage
+                {
+                    fromDeepLink = debugOpenedFromDeepLink.ToString(),
+                    enableNewTutorialCamera = false.ToString()
+                }));
+            }
         }
 
         private void OnDestroy()
@@ -178,32 +188,39 @@ namespace DCL.Tutorial
             NotificationsController.disableWelcomeNotification = false;
         }
 
-        public void SetTutorialEnabled(string fromDeepLink)
+        public void SetTutorialEnabled(string json)
         {
-            SetupTutorial(fromDeepLink, TutorialType.Initial);
+            TutorialInitializationMessage msg = JsonUtility.FromJson<TutorialInitializationMessage>(json);
+            SetupTutorial(msg.fromDeepLink, msg.enableNewTutorialCamera, TutorialType.Initial);
         }
 
-        public void SetTutorialEnabledForUsersThatAlreadyDidTheTutorial()
+        public void SetTutorialEnabledForUsersThatAlreadyDidTheTutorial(string json)
         {
+            TutorialInitializationMessage msg = JsonUtility.FromJson<TutorialInitializationMessage>(json);
+
             // TODO (Santi): This a TEMPORAL fix. It will be removed when we refactorize the tutorial system in order to make it compatible with incremental features.
             if (PlayerPrefsUtils.GetInt(PLAYER_PREFS_VOICE_CHAT_FEATURE_SHOWED) == 1)
                 return;
 
-            SetupTutorial(false.ToString(), TutorialType.Initial, true);
+            SetupTutorial(false.ToString(), msg.enableNewTutorialCamera, TutorialType.Initial, true);
         }
 
-        public void SetBuilderInWorldTutorialEnabled()
-        {
-            SetupTutorial(false.ToString(), TutorialType.BuilderInWorld);
-        }
+        public void SetBuilderInWorldTutorialEnabled() { SetupTutorial(false.ToString(), false.ToString(), TutorialType.BuilderInWorld); }
 
         /// <summary>
         /// Enables the tutorial controller and waits for the RenderingState is enabled to start to execute the corresponding tutorial steps.
         /// </summary>
-        void SetupTutorial(string fromDeepLink, TutorialType tutorialType, bool userAlreadyDidTheTutorial = false)
+        void SetupTutorial(string fromDeepLink, string enableNewTutorialCamera, TutorialType tutorialType, bool userAlreadyDidTheTutorial = false)
         {
             if (isRunning)
                 return;
+
+            if (Convert.ToBoolean(enableNewTutorialCamera))
+            {
+                eagleCamInitPosition = new Vector3(15, 115, -30);
+                eagleCamInitLookAtPoint = new Vector3(16, 105, 6);
+                eagleCamRotationActived = false;
+            }
 
             isRunning = true;
             this.userAlreadyDidTheTutorial = userAlreadyDidTheTutorial;
@@ -352,19 +369,13 @@ namespace DCL.Tutorial
         /// Plays a specific animation on the tutorial teacher.
         /// </summary>
         /// <param name="animation">Animation to apply.</param>
-        public void PlayTeacherAnimation(TutorialTeacher.TeacherAnimation animation)
-        {
-            teacher.PlayAnimation(animation);
-        }
+        public void PlayTeacherAnimation(TutorialTeacher.TeacherAnimation animation) { teacher.PlayAnimation(animation); }
 
         /// <summary>
         /// Set sort order for canvas containing teacher RawImage
         /// </summary>
         /// <param name="sortOrder"></param>
-        public void SetTeacherCanvasSortingOrder(int sortOrder)
-        {
-            teacherCanvas.sortingOrder = sortOrder;
-        }
+        public void SetTeacherCanvasSortingOrder(int sortOrder) { teacherCanvas.sortingOrder = sortOrder; }
 
         /// <summary>
         /// Finishes the current running step, skips all the next ones and completes the tutorial.
@@ -402,7 +413,7 @@ namespace DCL.Tutorial
             if (isActive)
             {
                 eagleEyeCamera.transform.position = eagleCamInitPosition;
-                eagleEyeCamera.transform.LookAt(CommonScriptableObjects.playerUnityPosition.Get());
+                eagleEyeCamera.transform.LookAt(eagleCamInitLookAtPoint);
 
                 if (eagleCamRotationActived)
                     eagleEyeRotationCoroutine = StartCoroutine(EagleEyeCameraRotation(eagleCamRotationSpeed));
@@ -532,10 +543,7 @@ namespace DCL.Tutorial
             SetTutorialDisabled();
         }
 
-        private void SetUserTutorialStepAsCompleted(TutorialFinishStep finishStepType)
-        {
-            WebInterface.SaveUserTutorialStep(UserProfile.GetOwnUserProfile().tutorialStep | (int) finishStepType);
-        }
+        private void SetUserTutorialStepAsCompleted(TutorialFinishStep finishStepType) { WebInterface.SaveUserTutorialStep(UserProfile.GetOwnUserProfile().tutorialStep | (int) finishStepType); }
 
         private IEnumerator MoveTeacher(Vector2 fromPosition, Vector2 toPosition)
         {
@@ -568,7 +576,11 @@ namespace DCL.Tutorial
         {
             SetTutorialDisabled();
             tutorialReset = true;
-            SetTutorialEnabled(false.ToString());
+            SetTutorialEnabled(JsonUtility.ToJson(new TutorialInitializationMessage
+            {
+                fromDeepLink = false.ToString(),
+                enableNewTutorialCamera = false.ToString()
+            }));
         }
 
         private bool IsPlayerInsideGenesisPlaza()


### PR DESCRIPTION
We plan to release the new genesis plaza this Friday. With the new plaza, the tutorial camera has been misconfigured. It looks at you from a lower height than the player, and all you see are the clouds from below.

In order to keep the compatibility with the current plaza, we have added a new feature flag `enableNewTutorialCamera` (it is allocated in https://dcl.tools/ops/global-config/-/blob/release/public/explorer.json) to switch from the old configuration to the new one once the new plaza has been released.

### Testing
- **To see the tutorial camera configuration for the current plaza (ORG)**: https://explorer.decentraland.zone/branch/hotfix/Adapt-the-tutorial-camera-for-the-new-Genesis-Plaza/index.html?ENV=org&RESET_TUTORIAL

![image](https://user-images.githubusercontent.com/64659061/116575430-e9ad0a00-a90e-11eb-8487-9e1e7f41b8df.png)

- **To see the tutorial camera configuration for the new plaza (ZONE)**: https://explorer.decentraland.zone/branch/hotfix/Adapt-the-tutorial-camera-for-the-new-Genesis-Plaza/index.html?ENV=zone&RESET_TUTORIAL

![image](https://user-images.githubusercontent.com/64659061/116575567-0c3f2300-a90f-11eb-9eb6-d0b9ceedc0dd.png)

**NOTE**: The tutorial camera for the new Genesis Plaza, unlike the previous configuration, have the rotation deactivated. It has been decided in this way because, due to the new position of the camera (too high off the ground), we cannot see anything around us.