### PR TITLE
refactor: rename sdk events and alias for events in production as dep…

### DIFF
--- a/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
@@ -48,19 +48,25 @@ function createSubscriber(eventName: keyof IEvents) {
  * This event is triggered when you change your camera between 1st and 3rd person
  * @public
  */
-export const onCameraModeChanged = new Observable<IEvents['cameraModeChanged']>(createSubscriber('cameraModeChanged'))
+export const onCameraModeChangedObservable = new Observable<IEvents['cameraModeChanged']>(createSubscriber('cameraModeChanged'))
 
 /**
  * These events are triggered after your character enters the scene.
  * @public
  */
-export const onEnterScene = new Observable<IEvents['onEnterScene']>(createSubscriber('onEnterScene'))
+export const onEnterSceneObservable = new Observable<IEvents['onEnterScene']>(createSubscriber('onEnterScene'))
+
+/* @deprecated Use onEnterSceneObservable instead. */
+export const onEnterScene = onEnterSceneObservable
 
 /**
  * These events are triggered after your character leaves the scene.
  * @public
  */
-export const onLeaveScene = new Observable<IEvents['onLeaveScene']>(createSubscriber('onLeaveScene'))
+export const onLeaveSceneObservable = new Observable<IEvents['onLeaveScene']>(createSubscriber('onLeaveScene'))
+
+/* @deprecated Use onLeaveSceneObservable instead. */
+export const onLeaveScene = onLeaveSceneObservable
 
 /**
  * @internal
@@ -75,15 +81,15 @@ export function _initEventObservables(dcl: DecentralandInterface) {
     internalDcl.onEvent((event) => {
       switch (event.type) {
         case 'onEnterScene': {
-          onEnterScene.notifyObservers(event.data as IEvents['onEnterScene'])
+          onEnterSceneObservable.notifyObservers(event.data as IEvents['onEnterScene'])
           return
         }
         case 'onLeaveScene': {
-          onLeaveScene.notifyObservers(event.data as IEvents['onLeaveScene'])
+          onLeaveSceneObservable.notifyObservers(event.data as IEvents['onLeaveScene'])
           return
         }
         case 'cameraModeChanged': {
-          onCameraModeChanged.notifyObservers(event.data as IEvents['cameraModeChanged'])
+          onCameraModeChangedObservable.notifyObservers(event.data as IEvents['cameraModeChanged'])
           return
         }
       }

--- a/kernel/public/test-scenes/0.11.subscribeToEnterLeaveScene1/game.ts
+++ b/kernel/public/test-scenes/0.11.subscribeToEnterLeaveScene1/game.ts
@@ -1,4 +1,4 @@
-import { log, engine, Entity, BoxShape, Material, Color3, Transform, Vector3, onEnterScene, onLeaveScene } from 'decentraland-ecs/src'
+import { log, engine, Entity, BoxShape, Material, Color3, Transform, Vector3, onEnterSceneObservable, onLeaveSceneObservable } from 'decentraland-ecs/src'
 
 //Create entity and assign shape
 const box = new Entity()
@@ -18,12 +18,12 @@ box.addComponent(new Transform({
 
 engine.addEntity(box);
 
-onEnterScene.add(({ userId }) => {
+onEnterSceneObservable.add(({ userId }) => {
   material.albedoColor = Color3.Red()
-  log("onEnterScene: ", userId)
+  log("onEnterSceneObservable: ", userId)
 })
 
-onLeaveScene.add(({ userId }) => {
+onLeaveSceneObservable.add(({ userId }) => {
   material.albedoColor = Color3.Gray()
-  log("onLeaveScene: ", userId)
+  log("onLeaveSceneObservable: ", userId)
 })

--- a/kernel/public/test-scenes/0.12.subscribeToEnterLeaveScene2/game.ts
+++ b/kernel/public/test-scenes/0.12.subscribeToEnterLeaveScene2/game.ts
@@ -1,4 +1,4 @@
-import { log, engine, Entity, BoxShape, Material, Color3, Transform, Vector3, onEnterScene, onLeaveScene, onCameraModeChanged, Camera, CameraMode } from 'decentraland-ecs/src'
+import { log, engine, Entity, BoxShape, Material, Color3, Transform, Vector3, onEnterSceneObservable, onLeaveSceneObservable, onCameraModeChangedObservable, Camera, CameraMode } from 'decentraland-ecs/src'
 
 //Create entity and assign shape
 const floor = new Entity()
@@ -18,14 +18,14 @@ floor.addComponent(new Transform({
 
 engine.addEntity(floor);
 
-onEnterScene.add(({ userId }) => {
+onEnterSceneObservable.add(({ userId }) => {
   floorMaterial.albedoColor = Color3.Red()
-  log("onEnterScene: ", userId, " - CameraMode: ", Camera.instance.cameraMode)
+  log("onEnterSceneObservable: ", userId, " - CameraMode: ", Camera.instance.cameraMode)
 })
 
-onLeaveScene.add(({ userId }) => {
+onLeaveSceneObservable.add(({ userId }) => {
   floorMaterial.albedoColor = Color3.Gray()
-  log("onLeaveScene: ", userId)
+  log("onLeaveSceneObservable: ", userId)
 })
 
 
@@ -55,8 +55,8 @@ const setFloorMaterial = (cameraMode: CameraMode) => {
     boxMaterial.albedoColor = Color3.Blue()
 }
 
-onCameraModeChanged.add(({ cameraMode }) => {
-  log("onCameraModeChanged", cameraMode)
+onCameraModeChangedObservable.add(({ cameraMode }) => {
+  log("onCameraModeChangedObservable", cameraMode)
   setFloorMaterial(cameraMode)
 })
 


### PR DESCRIPTION
…recated

# What?
Fix decentraland/unity-renderer#295

Rename events to `on{EventName}Observable` pattern.

For the events that are in production we put an alias as `deprecated`.

Events in production: `onEnterScene`, `onLeaveScene`

# Why?

@menduz words:
Predictability and consistency over all things
More details: https://menduz.com/posts/2018.03.15