### PR TITLE
feat: add idle state change event to sdk

### DIFF
--- a/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
@@ -51,6 +51,12 @@ function createSubscriber(eventName: keyof IEvents) {
 export const onCameraModeChanged = new Observable<IEvents['cameraModeChanged']>(createSubscriber('cameraModeChanged'))
 
 /**
+ * This event is triggered when you change your camera between 1st and 3rd person
+ * @public
+ */
+export const onIdleStateChangedObservable = new Observable<IEvents['idleStateChanged']>(createSubscriber('idleStateChanged'))
+
+/**
  * These events are triggered after your character enters the scene.
  * @public
  */
@@ -84,6 +90,10 @@ export function _initEventObservables(dcl: DecentralandInterface) {
         }
         case 'cameraModeChanged': {
           onCameraModeChanged.notifyObservers(event.data as IEvents['cameraModeChanged'])
+          return
+        }
+        case 'idleStateChanged': {
+          onIdleStateChangedObservable.notifyObservers(event.data as IEvents['idleStateChanged'])
           return
         }
       }

--- a/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
@@ -181,6 +181,13 @@ export interface IEvents {
   }
 
   /**
+   * `idleStateChanged` is triggered when the user not moves for a defined period of time
+   */
+  idleStateChanged: {
+    isIdle: boolean
+  }
+
+  /**
    * `pointerUp` is triggered when the user releases an input pointer.
    * It could be a VR controller, a touch screen or the mouse.
    */

--- a/kernel/public/test-scenes/0.14.idleStateChanged/game.ts
+++ b/kernel/public/test-scenes/0.14.idleStateChanged/game.ts
@@ -1,0 +1,22 @@
+import { log, engine, Entity, Transform, Vector3, onIdleStateChangedObservable, TextShape } from 'decentraland-ecs/src'
+
+// AFK Mode Changed
+//Create entity and assign shape
+const text = new Entity()
+const shape = new TextShape("You're not AFK")
+text.addComponent(shape)
+
+text.addComponent(new Transform({
+  position: new Vector3(8, 2, 8),
+  scale: new Vector3(1, 1, 1),
+}))
+
+engine.addEntity(text);
+
+onIdleStateChangedObservable.add(({ isIdle }) => {
+  log("onIdleStateChangedObservable", isIdle)
+  if (isIdle)
+    shape.value = "YOU'RE AFK!"
+  else
+    shape.value = "You're not AFK!"
+})

--- a/kernel/public/test-scenes/0.14.idleStateChanged/scene.json
+++ b/kernel/public/test-scenes/0.14.idleStateChanged/scene.json
@@ -1,0 +1,30 @@
+{
+  "display": {
+    "title": "0.14.idleStateChanged",
+    "favicon": "favicon_asset"
+  },
+  "contact": {
+    "name": "author-name",
+    "email": ""
+  },
+  "owner": "",
+  "scene": {
+    "parcels": [
+      "0,14"
+    ],
+    "base": "0,14"
+  },
+  "communications": {
+    "type": "webrtc",
+    "signalling": "https://signalling-01.decentraland.org"
+  },
+  "policy": {
+    "contentRating": "E",
+    "fly": true,
+    "voiceEnabled": true,
+    "blacklist": [],
+    "teleportPosition": ""
+  },
+  "main": "game.js",
+  "tags": []
+}


### PR DESCRIPTION
# What?
Fix decentraland/unity-renderer#277
unity-renderer PR: decentraland/unity-renderer#346

Default value to be trigger the event: 60 seconds

test-scene (with 5 seconds to be idle):

https://user-images.githubusercontent.com/12563266/116919736-18d1bd00-ac28-11eb-8342-592a0182feab.mp4