### PR TITLE
feat: system info (gpu) metrics

### DIFF
--- a/kernel/packages/unity-interface/BrowserInterface.ts
+++ b/kernel/packages/unity-interface/BrowserInterface.ts
@@ -80,6 +80,15 @@ const positionEvent = {
   immediate: false // By default the renderer lerps avatars position
 }
 
+type SystemInfoPayload = {
+  graphicsDeviceName: string
+  graphicsDeviceVersion: string
+  graphicsMemorySize: number
+  processorType: string
+  processorCount: number
+  systemMemorySize: number
+}
+
 export class BrowserInterface {
   private lastBalanceOfMana: number = -1
 
@@ -159,6 +168,10 @@ export class BrowserInterface {
   }) {
     const perfReport = getPerformanceInfo(data)
     trackEvent('performance report', perfReport)
+  }
+
+  public SystemInfoReport(data: SystemInfoPayload) {
+    trackEvent('system info report', data)
   }
 
   public PreloadFinished(data: { sceneId: string }) {


### PR DESCRIPTION
# What?
Resolves decentraland/unity-renderer#215
Depends on PR: decentraland/unity-renderer#372

Added system info, mainly for the gpu data to the metrics.

# Test

Open this link:
https://play.decentraland.zone/branch/feat/gpu-metrics/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:feat/gpu-metrics&DEBUG_ANALYTICS

and after the unity-renderer finish we can see something like in the console:

```
graphicsDeviceName: "ANGLE (NVIDIA Corporation, GeForce GTX 1660 Ti/PCIe/SSE2, OpenGL 4.5.0 NVIDIA 460.56)"
graphicsDeviceVersion: "OpenGL ES 3.0 (WebGL 2.0 (OpenGL ES 3.0 Chromium))"
graphicsMemorySize: 512
processorCount: 1
processorType: "n/a"
sessionId: "27ad6e01-9150-40e8-a6ef-aac81cbbd46d"
systemMemorySize: 256
time: "2021-05-06T02:20:54.384Z"
version: "70e47eeade1720a903b33f60cf48e9f912279016"
```

We can discuss what data we track.
Some data that we can get (not everything is available in the browser):
https://docs.unity3d.com/ScriptReference/SystemInfo.html