### PR TITLE
feat: add sdk event when the scene started/is ready

### DIFF
--- a/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
@@ -75,10 +75,10 @@ export const onLeaveSceneObservable = new Observable<IEvents['onLeaveScene']>(cr
 export const onLeaveScene = onLeaveSceneObservable
 
 /**
- * This event is triggered once the scene should start.
+ * This event is triggered after all the resources of the scene were loaded (models, textures, etc...)
  * @public
  */
-export const onSceneStartObservable = new Observable<IEvents['sceneStart']>(createSubscriber('sceneStart'))
+export const onSceneReadyObservable = new Observable<IEvents['sceneStart']>(createSubscriber('sceneStart'))
 
 /**
  * @internal
@@ -109,7 +109,7 @@ export function _initEventObservables(dcl: DecentralandInterface) {
           return
         }
         case 'sceneStart': {
-          onSceneStartObservable.notifyObservers(event.data as IEvents['sceneStart'])
+          onSceneReadyObservable.notifyObservers(event.data as IEvents['sceneStart'])
           return
         }
       }

--- a/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
@@ -75,6 +75,12 @@ export const onLeaveSceneObservable = new Observable<IEvents['onLeaveScene']>(cr
 export const onLeaveScene = onLeaveSceneObservable
 
 /**
+ * This event is triggered once the scene should start.
+ * @public
+ */
+ export const onSceneStartObservable = new Observable<IEvents['sceneStart']>(createSubscriber('sceneStart'))
+
+/**
  * @internal
  * This function adds _one_ listener to the onEvent event of dcl interface.
  * Leveraging a switch to route events to the Observable handlers.
@@ -100,6 +106,10 @@ export function _initEventObservables(dcl: DecentralandInterface) {
         }
         case 'idleStateChanged': {
           onIdleStateChangedObservable.notifyObservers(event.data as IEvents['idleStateChanged'])
+          return
+        }
+        case 'sceneStart': {
+          onSceneStartObservable.notifyObservers(event.data as IEvents['sceneStart'])
           return
         }
       }

--- a/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
@@ -78,7 +78,7 @@ export const onLeaveScene = onLeaveSceneObservable
  * This event is triggered once the scene should start.
  * @public
  */
- export const onSceneStartObservable = new Observable<IEvents['sceneStart']>(createSubscriber('sceneStart'))
+export const onSceneStartObservable = new Observable<IEvents['sceneStart']>(createSubscriber('sceneStart'))
 
 /**
  * @internal

--- a/kernel/public/test-scenes/0.15.sceneStarted/game.ts
+++ b/kernel/public/test-scenes/0.15.sceneStarted/game.ts
@@ -1,4 +1,4 @@
-import { log, engine, Entity, Transform, Vector3, onSceneStartObservable, TextShape } from 'decentraland-ecs/src'
+import { log, engine, Entity, Transform, Vector3, onSceneReadyObservable, TextShape } from 'decentraland-ecs/src'
 
 //Create entity and assign shape
 const text = new Entity()
@@ -12,7 +12,7 @@ text.addComponent(new Transform({
 
 engine.addEntity(text);
 
-onSceneStartObservable.add(() => {
-  log("onSceneStartObservable")
+onSceneReadyObservable.add(() => {
+  log("onSceneReadyObservable")
   shape.value = "Scene ready!"
 })

--- a/kernel/public/test-scenes/0.15.sceneStarted/game.ts
+++ b/kernel/public/test-scenes/0.15.sceneStarted/game.ts
@@ -1,0 +1,18 @@
+import { log, engine, Entity, Transform, Vector3, onSceneStartObservable, TextShape } from 'decentraland-ecs/src'
+
+//Create entity and assign shape
+const text = new Entity()
+const shape = new TextShape("Loading scene...")
+text.addComponent(shape)
+
+text.addComponent(new Transform({
+  position: new Vector3(8, 2, 8),
+  scale: new Vector3(1, 1, 1),
+}))
+
+engine.addEntity(text);
+
+onSceneStartObservable.add(() => {
+  log("onSceneStartObservable")
+  shape.value = "Scene ready!"
+})

--- a/kernel/public/test-scenes/0.15.sceneStarted/scene.json
+++ b/kernel/public/test-scenes/0.15.sceneStarted/scene.json
@@ -1,0 +1,30 @@
+{
+  "display": {
+    "title": "0.15.sceneStarted",
+    "favicon": "favicon_asset"
+  },
+  "contact": {
+    "name": "author-name",
+    "email": ""
+  },
+  "owner": "",
+  "scene": {
+    "parcels": [
+      "0,15"
+    ],
+    "base": "0,15"
+  },
+  "communications": {
+    "type": "webrtc",
+    "signalling": "https://signalling-01.decentraland.org"
+  },
+  "policy": {
+    "contentRating": "E",
+    "fly": true,
+    "voiceEnabled": true,
+    "blacklist": [],
+    "teleportPosition": ""
+  },
+  "main": "game.js",
+  "tags": []
+}


### PR DESCRIPTION
# What? <!-- what is this PR? -->
Resolves decentraland/unity-renderer#276

Add observable event to the sdk, that it triggers when the scene started / is ready.

# Test
I added a test-scene to see the result.

Currently the only way to test is cloning this branch and executing: `make test-scenes` and then `make watch`