### PR TITLE
fix: trigger enter/leave events when we enter parcel without an scene…

### DIFF
--- a/kernel/packages/shared/comms/sagas.ts
+++ b/kernel/packages/shared/comms/sagas.ts
@@ -76,8 +76,10 @@ function* listenToWhetherSceneSupportsVoiceChat() {
     const previouslyEnabled = previousScene
       ? isFeatureToggleEnabled(SceneFeatureToggles.VOICE_CHAT, previousScene.sceneJsonData)
       : undefined
-    const nowEnabled = isFeatureToggleEnabled(SceneFeatureToggles.VOICE_CHAT, newScene.sceneJsonData)
-    if (previouslyEnabled !== nowEnabled) {
+    const nowEnabled = newScene
+      ? isFeatureToggleEnabled(SceneFeatureToggles.VOICE_CHAT, newScene.sceneJsonData)
+      : undefined
+    if (previouslyEnabled !== nowEnabled && nowEnabled !== undefined) {
       unityInterface.SetVoiceChatEnabledByScene(nowEnabled)
       if (!nowEnabled) {
         // We want to stop any potential recordings when a user enters a new scene

--- a/kernel/packages/shared/world/SceneSystemWorker.ts
+++ b/kernel/packages/shared/world/SceneSystemWorker.ts
@@ -127,7 +127,7 @@ export class SceneSystemWorker extends SceneWorker {
       .then((userData) => userData!.userId)
       .then((userId) => {
         this.sceneChangeObserver = sceneObservable.add((report) => {
-          if (report.newScene.sceneId === this.getSceneId()) {
+          if (report.newScene?.sceneId === this.getSceneId()) {
             this.engineAPI!.sendSubscriptionEvent('onEnterScene', { userId })
           } else if (report.previousScene?.sceneId === this.getSceneId()) {
             this.engineAPI!.sendSubscriptionEvent('onLeaveScene', { userId })

--- a/kernel/packages/shared/world/sceneState.ts
+++ b/kernel/packages/shared/world/sceneState.ts
@@ -9,12 +9,12 @@ export type SceneReport = {
   /** Scene where the user was */
   previousScene?: ILand
   /** Scene the user just entered */
-  newScene: ILand
+  newScene?: ILand
 }
 
 // Called each time the user changes scene
 export const sceneObservable = new Observable<SceneReport>()
-export let lastPlayerScene: ILand
+export let lastPlayerScene: ILand | undefined
 
 // TODO: fetchSceneIds and fetchSceneJson don't work on preview mode, so we are disabling this for now. We need to figure out a way to make those queries in a way that they work in preview mode also
 if (WORLD_EXPLORER) {
@@ -28,6 +28,9 @@ if (WORLD_EXPLORER) {
         const land = (await fetchSceneJson([sceneId]))[0]
         sceneObservable.notifyObservers({ previousScene: lastPlayerScene, newScene: land })
         lastPlayerScene = land
+      } else {
+        sceneObservable.notifyObservers({ previousScene: lastPlayerScene })
+        lastPlayerScene = undefined
       }
     }
   })


### PR DESCRIPTION
… (useful for preview mode)

# What? <!-- what is this PR? -->
Fix decentraland/unity-renderer#415

Trigger enter/leave events even when we enter/leave a parcel without an scene


https://user-images.githubusercontent.com/12563266/117693378-5ab4b300-b194-11eb-990d-3979e37c400d.mp4

# Why? <!-- Explain the reason -->
We need this for preview mode mainly and test-scenes. Even if the world doesn't have parcels without scene.
