### PR TITLE
fix: caching problems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
       - run:
           name: Install differences in node_modules
           command: |
-            npm ci
+            npm i
       - save_cache:
           name: Store node_modules cache
           paths:


### PR DESCRIPTION
There are two problems in software engineering:
- Naming things
- Cache invalidation
- Off-by-one error