### PR TITLE
feat: add player expression, position change and rotation change even…

### DIFF
--- a/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
@@ -1,7 +1,9 @@
 import { EventConstructor } from '../ecs/EventManager'
 import { Observable } from '../ecs/Observable'
+import { ReadOnlyQuaternion, ReadOnlyVector3 } from './math'
 import { DecentralandInterface, IEvents, RaycastResponsePayload, CameraMode } from './Types'
 export { CameraMode }
+export { ReadOnlyVector3, ReadOnlyQuaternion }
 
 /**
  * @public
@@ -81,6 +83,25 @@ export const onLeaveScene = onLeaveSceneObservable
 export const onSceneReadyObservable = new Observable<IEvents['sceneStart']>(createSubscriber('sceneStart'))
 
 /**
+ * This event is triggered when the position of the camera changes
+ * This event is throttled to 10 times per second.
+ * @public
+ */
+export const onPositionChangedObservable = new Observable<IEvents['positionChanged']>(createSubscriber('positionChanged'))
+
+/**
+ * This event is triggered when the rotation of the camera changes.
+ * This event is throttled to 10 times per second.
+ * @public
+ */
+export const onRotationChangedObservable = new Observable<IEvents['rotationChanged']>(createSubscriber('rotationChanged'))
+
+/**
+ * @public
+ */
+export const onPlayerExpressionObservable = new Observable<IEvents['playerExpression']>(createSubscriber('playerExpression'))
+
+/**
  * @internal
  * This function adds _one_ listener to the onEvent event of dcl interface.
  * Leveraging a switch to route events to the Observable handlers.
@@ -110,6 +131,18 @@ export function _initEventObservables(dcl: DecentralandInterface) {
         }
         case 'sceneStart': {
           onSceneReadyObservable.notifyObservers(event.data as IEvents['sceneStart'])
+          return
+        }
+        case 'positionChanged': {
+          onPositionChangedObservable.notifyObservers(event.data as IEvents['positionChanged'])
+          return
+        }
+        case 'rotationChanged': {
+          onRotationChangedObservable.notifyObservers(event.data as IEvents['rotationChanged'])
+          return
+        }
+        case 'playerExpression': {
+          onPlayerExpressionObservable.notifyObservers(event.data as IEvents['playerExpression'])
           return
         }
       }

--- a/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
@@ -188,7 +188,6 @@ export interface IEvents {
   }
 
   playerExpression: {
-    userId: string
     expressionId: string
   }
 

--- a/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Types.ts
@@ -187,6 +187,11 @@ export interface IEvents {
     isIdle: boolean
   }
 
+  playerExpression: {
+    userId: string
+    expressionId: string
+  }
+
   /**
    * `pointerUp` is triggered when the user releases an input pointer.
    * It could be a VR controller, a touch screen or the mouse.

--- a/kernel/packages/shared/world/SceneSystemWorker.ts
+++ b/kernel/packages/shared/world/SceneSystemWorker.ts
@@ -11,8 +11,6 @@ import { ParcelSceneAPI } from './ParcelSceneAPI'
 import { CustomWebWorkerTransport } from './CustomWebWorkerTransport'
 import { sceneObservable } from 'shared/world/sceneState'
 import { UserIdentity } from 'shared/apis/UserIdentity'
-import { avatarMessageObservable, getUser } from 'shared/comms/peers'
-import { AvatarMessageType } from 'shared/comms/interface/types'
 
 const gamekitWorkerRaw = require('raw-loader!../../../static/systems/scene.system.js')
 const gamekitWorkerBLOB = new Blob([gamekitWorkerRaw])
@@ -46,7 +44,6 @@ export class SceneSystemWorker extends SceneWorker {
     this.subscribeToWorldRunningEvents()
     this.subscribeToPositionEvents()
     this.subscribeToSceneChangeEvents()
-    this.subscribeToAvatarMessageEvents()
   }
 
   private static buildWebWorkerTransport(parcelScene: ParcelSceneAPI): ScriptingTransport {
@@ -137,22 +134,10 @@ export class SceneSystemWorker extends SceneWorker {
           }
         })
       })
-      .catch(e => {
+      .catch((e) => {
         // @ts-ignore
         console['error'](e)
       })
-  }
-
-  private subscribeToAvatarMessageEvents() {
-    avatarMessageObservable.add((evt) => {
-      if (evt.type === AvatarMessageType.USER_EXPRESSION) {
-        let userId = getUser(evt.uuid)?.userId
-        if (userId) {
-          let expressionId = evt.expressionId
-          this.engineAPI!.sendSubscriptionEvent('playerExpression', { userId, expressionId })
-        }
-      }
-    })
   }
 
   private subscribeToWorldRunningEvents() {

--- a/kernel/packages/ui/avatar/avatarSystem.ts
+++ b/kernel/packages/ui/avatar/avatarSystem.ts
@@ -14,8 +14,6 @@ import {
   UUID
 } from 'shared/comms/interface/types'
 
-import { defaultLogger } from 'shared/logger'
-
 export const avatarMessageObservable = new Observable<AvatarMessage>()
 
 const avatarMap = new Map<string, AvatarEntity>()
@@ -124,7 +122,6 @@ export class AvatarEntity extends Entity {
  * @param uuid
  */
 function ensureAvatar(uuid: UUID): AvatarEntity {
-  defaultLogger.log("ensureAvatar", uuid)
   let avatar = avatarMap.get(uuid)
 
   if (avatar) {

--- a/kernel/packages/ui/avatar/avatarSystem.ts
+++ b/kernel/packages/ui/avatar/avatarSystem.ts
@@ -14,6 +14,8 @@ import {
   UUID
 } from 'shared/comms/interface/types'
 
+import { defaultLogger } from 'shared/logger'
+
 export const avatarMessageObservable = new Observable<AvatarMessage>()
 
 const avatarMap = new Map<string, AvatarEntity>()
@@ -122,6 +124,7 @@ export class AvatarEntity extends Entity {
  * @param uuid
  */
 function ensureAvatar(uuid: UUID): AvatarEntity {
+  defaultLogger.log("ensureAvatar", uuid)
   let avatar = avatarMap.get(uuid)
 
   if (avatar) {

--- a/kernel/packages/unity-interface/BrowserInterface.ts
+++ b/kernel/packages/unity-interface/BrowserInterface.ts
@@ -1,7 +1,7 @@
 import { uuid } from 'decentraland-ecs/src'
 import { sendPublicChatMessage } from 'shared/comms'
 import { AvatarMessageType } from 'shared/comms/interface/types'
-import { avatarMessageObservable } from 'shared/comms/peers'
+import { avatarMessageObservable, localProfileUUID } from 'shared/comms/peers'
 import { hasConnectedWeb3 } from 'shared/profiles/selectors'
 import { TeleportController } from 'shared/world/TeleportController'
 import { reportScenesAroundParcel } from 'shared/atlas/actions'
@@ -190,9 +190,10 @@ export class BrowserInterface {
   }
 
   public TriggerExpression(data: { id: string; timestamp: number }) {
+
     avatarMessageObservable.notifyObservers({
       type: AvatarMessageType.USER_EXPRESSION,
-      uuid: uuid(),
+      uuid: localProfileUUID || "non-local-profile-uuid",
       expressionId: data.id,
       timestamp: data.timestamp
     })

--- a/kernel/packages/unity-interface/BrowserInterface.ts
+++ b/kernel/packages/unity-interface/BrowserInterface.ts
@@ -5,7 +5,13 @@ import { avatarMessageObservable, localProfileUUID } from 'shared/comms/peers'
 import { hasConnectedWeb3 } from 'shared/profiles/selectors'
 import { TeleportController } from 'shared/world/TeleportController'
 import { reportScenesAroundParcel } from 'shared/atlas/actions'
-import { decentralandConfigurations, ethereumConfigurations, parcelLimits, playerConfigurations, WORLD_EXPLORER } from 'config'
+import {
+  decentralandConfigurations,
+  ethereumConfigurations,
+  parcelLimits,
+  playerConfigurations,
+  WORLD_EXPLORER
+} from 'config'
 import { Quaternion, ReadOnlyQuaternion, ReadOnlyVector3, Vector3 } from '../decentraland-ecs/src/decentraland/math'
 import { IEventNames } from '../decentraland-ecs/src/decentraland/Types'
 import { renderDistanceObservable, sceneLifeCycleObservable } from '../decentraland-loader/lifecycle/controllers/scene'
@@ -190,13 +196,20 @@ export class BrowserInterface {
   }
 
   public TriggerExpression(data: { id: string; timestamp: number }) {
-
     avatarMessageObservable.notifyObservers({
       type: AvatarMessageType.USER_EXPRESSION,
-      uuid: localProfileUUID || "non-local-profile-uuid",
+      uuid: localProfileUUID || 'non-local-profile-uuid',
       expressionId: data.id,
       timestamp: data.timestamp
     })
+
+    this.AllScenesEvent({
+      eventType: 'playerExpression',
+      payload: {
+        expressionId: data.id
+      }
+    })
+
     const messageId = uuid()
     const body = `␐${data.id} ${data.timestamp}`
 

--- a/kernel/public/test-scenes/1.14.playerEvents/game.ts
+++ b/kernel/public/test-scenes/1.14.playerEvents/game.ts
@@ -1,33 +1,52 @@
-import { engine, Entity, Transform, Vector3, onPlayerExpressionObservable, onPositionChangedObservable, onRotationChangedObservable, TextShape, onEnterSceneObservable, BoxShape, Quaternion } from 'decentraland-ecs/src'
+import {
+  engine,
+  Entity,
+  Transform,
+  Vector3,
+  onPlayerExpressionObservable,
+  onPositionChangedObservable,
+  onRotationChangedObservable,
+  TextShape,
+  onEnterSceneObservable,
+  BoxShape,
+  Quaternion
+} from 'decentraland-ecs/src'
 
-const box = new Entity();
-box.addComponent(new BoxShape());
-box.addComponent(new Transform({ position: new Vector3(8, 2, 8), scale: new Vector3(0.25, 0.25, 1) }));
-engine.addEntity(box);
+const box = new Entity()
+box.addComponent(new BoxShape())
+box.addComponent(new Transform({ position: new Vector3(8, 2, 8), scale: new Vector3(0.25, 0.25, 1) }))
+engine.addEntity(box)
 
 //Create entity and assign shape
 const text = new Entity()
-const shape = new TextShape("Null...")
+const shape = new TextShape('Null...')
 text.addComponent(shape)
 
-text.addComponent(new Transform({
-  position: new Vector3(8, 1, 8),
-  scale: new Vector3(-0.25, 0.25, -0.25)
-}))
+text.addComponent(
+  new Transform({
+    position: new Vector3(8, 1, 8),
+    scale: new Vector3(-0.25, 0.25, -0.25)
+  })
+)
 
-engine.addEntity(text);
+engine.addEntity(text)
 
 onEnterSceneObservable.add(({ userId }) => {
-  shape.value = "Enter: " + userId
+  shape.value = 'Enter: ' + userId
 })
 
-onPlayerExpressionObservable.add(({ userId, expressionId }) => {
-  shape.value = "Expression: " + userId + " - " + expressionId
+onPlayerExpressionObservable.add(({ expressionId }) => {
+  shape.value = 'Expression: ' + expressionId
 })
 
 onPositionChangedObservable.add((eventData) => {
   text.getComponent(Transform).lookAt(new Vector3(eventData.position.x, eventData.position.y, eventData.position.z))
 })
 onRotationChangedObservable.add((eventData) => {
-  box.getComponent(Transform).rotation = new Quaternion(eventData.quaternion.x, eventData.quaternion.y, eventData.quaternion.z, eventData.quaternion.w)
+  box.getComponent(Transform).rotation = new Quaternion(
+    eventData.quaternion.x,
+    eventData.quaternion.y,
+    eventData.quaternion.z,
+    eventData.quaternion.w
+  )
 })

--- a/kernel/public/test-scenes/1.14.playerEvents/game.ts
+++ b/kernel/public/test-scenes/1.14.playerEvents/game.ts
@@ -1,0 +1,33 @@
+import { engine, Entity, Transform, Vector3, onPlayerExpressionObservable, onPositionChangedObservable, onRotationChangedObservable, TextShape, onEnterSceneObservable, BoxShape, Quaternion } from 'decentraland-ecs/src'
+
+const box = new Entity();
+box.addComponent(new BoxShape());
+box.addComponent(new Transform({ position: new Vector3(8, 2, 8), scale: new Vector3(0.25, 0.25, 1) }));
+engine.addEntity(box);
+
+//Create entity and assign shape
+const text = new Entity()
+const shape = new TextShape("Null...")
+text.addComponent(shape)
+
+text.addComponent(new Transform({
+  position: new Vector3(8, 1, 8),
+  scale: new Vector3(-0.25, 0.25, -0.25)
+}))
+
+engine.addEntity(text);
+
+onEnterSceneObservable.add(({ userId }) => {
+  shape.value = "Enter: " + userId
+})
+
+onPlayerExpressionObservable.add(({ userId, expressionId }) => {
+  shape.value = "Expression: " + userId + " - " + expressionId
+})
+
+onPositionChangedObservable.add((eventData) => {
+  text.getComponent(Transform).lookAt(new Vector3(eventData.position.x, eventData.position.y, eventData.position.z))
+})
+onRotationChangedObservable.add((eventData) => {
+  box.getComponent(Transform).rotation = new Quaternion(eventData.quaternion.x, eventData.quaternion.y, eventData.quaternion.z, eventData.quaternion.w)
+})

--- a/kernel/public/test-scenes/1.14.playerEvents/scene.json
+++ b/kernel/public/test-scenes/1.14.playerEvents/scene.json
@@ -1,0 +1,30 @@
+{
+  "display": {
+    "title": "1.14.playerEvents",
+    "favicon": "favicon_asset"
+  },
+  "contact": {
+    "name": "author-name",
+    "email": ""
+  },
+  "owner": "",
+  "scene": {
+    "parcels": [
+      "1,14"
+    ],
+    "base": "1,14"
+  },
+  "communications": {
+    "type": "webrtc",
+    "signalling": "https://signalling-01.decentraland.org"
+  },
+  "policy": {
+    "contentRating": "E",
+    "fly": true,
+    "voiceEnabled": true,
+    "blacklist": [],
+    "teleportPosition": ""
+  },
+  "main": "game.js",
+  "tags": []
+}


### PR DESCRIPTION
…ts to the sdk

# What? <!-- what is this PR? -->
Resolves decentraland/unity-renderer#300

New SDK events when we...
... play emotes/expressions ~~(multiplayer event!)~~
... change our position
... change our camera rotation

https://user-images.githubusercontent.com/12563266/118167917-9f8f5280-b3fd-11eb-962c-216684490085.mp4

the test-scenes does:
- The text depends on what `emote` you execute ~~(multiplayer!!)~~ (using `onPlayerExpressionObservable`)
- The text always `lookAt` your position (using `onPositionChangedObservable`)
- The `box shape` replicates your camera rotation (using `onRotationChangedObservable`)

**Incidence:**
I found a problem with the `Expressions` where the each expression event from the local user was being executed with an invalid `uuid`, more info -> decentraland/unity-renderer#300 

# Why? <!-- Explain the reason -->
Add features to the SDK