### PR TITLE
chore: update renderer to 1.0.1837

### DIFF
--- a/kernel/package-lock.json
+++ b/kernel/package-lock.json
@@ -450,9 +450,9 @@
       }
     },
     "@dcl/unity-renderer": {
-      "version": "1.0.1308",
-      "resolved": "https://registry.npmjs.org/@dcl/unity-renderer/-/unity-renderer-1.0.1308.tgz",
-      "integrity": "sha512-jCq3WD+/CcbhR9pOakqRaMeEO+snAnfn8R1KV7M6YLvv/YAFfzSnZAm+NhxzFRZGivtD6pPKoasZwksoEStcqQ==",
+      "version": "1.0.1837",
+      "resolved": "https://registry.npmjs.org/@dcl/unity-renderer/-/unity-renderer-1.0.1837.tgz",
+      "integrity": "sha512-LEQKhctpm0lFezBkVD5tqJ0hHfluZGoV08PHilS6zWqp+Fv3XrQF9F0e0OeCaH00dZBDo4ZN3Zfzam8HAIYqPQ==",
       "dev": true
     },
     "@dcl/urn-resolver": {
@@ -2271,7 +2271,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -3226,7 +3226,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -6563,7 +6563,7 @@
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         }
@@ -8087,7 +8087,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -13535,7 +13535,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -13571,7 +13571,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {

--- a/kernel/package.json
+++ b/kernel/package.json
@@ -41,7 +41,7 @@
     "all": true
   },
   "devDependencies": {
-    "@dcl/unity-renderer": "^1.0.1419",
+    "@dcl/unity-renderer": "^1.0.1837",
     "@microsoft/api-documenter": "^7.2.2",
     "@microsoft/api-extractor": "^7.1.7",
     "@tweenjs/tween.js": "^17.2.0",


### PR DESCRIPTION
We are updating the renderer to `1.0.1837`