### PR TITLE
feat: Selecting quests url based on TLD + making the quests saga failure tolerant

### DIFF
--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -56,8 +56,10 @@ export namespace parcelLimits {
   export const minParcelX = -150
   export const minParcelZ = -150
 
-  export const descriptiveValidWorldRanges = getWorld().validWorldRanges
-    .map((range) => `(X from ${range.xMin} to ${range.xMax}, and Y from ${range.yMin} to ${range.yMax})`)
+  export const descriptiveValidWorldRanges = getWorld()
+    .validWorldRanges.map(
+      (range) => `(X from ${range.xMin} to ${range.xMax}, and Y from ${range.yMin} to ${range.yMax})`
+    )
     .join(' or ')
 }
 export namespace playerConfigurations {
@@ -150,8 +152,6 @@ export const TEST_WEARABLES_OVERRIDE = location.search.includes('TEST_WEARABLES'
 export const QUESTS_ENABLED = location.search.includes('QUESTS_ENABLED')
 
 const META_CONFIG_URL = qs.META_CONFIG_URL
-
-const QUESTS_SERVER_URL = qs.QUESTS_SERVER_URL ?? 'https://quests-api.decentraland.io'
 
 export namespace commConfigurations {
   export const debug = true
@@ -288,6 +288,8 @@ export function getServerConfigurations() {
   const metaConfigBaseUrl = META_CONFIG_URL || `https://config.decentraland.${notToday}/explorer.json`
   const metaFeatureFlagsBaseUrl = `https://feature-flags.decentraland.${notToday}/explorer.json`
   const ASSET_BUNDLES_DOMAIN = qs.ASSET_BUNDLES_DOMAIN || `content-assets-as-bundle.decentraland.${TLDDefault}`
+
+  const QUESTS_SERVER_URL = qs.QUESTS_SERVER_URL ?? `https://quests-api.decentraland.${notToday}`
 
   return {
     contentAsBundle: `https://${ASSET_BUNDLES_DOMAIN}`,

--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -289,7 +289,8 @@ export function getServerConfigurations() {
   const metaFeatureFlagsBaseUrl = `https://feature-flags.decentraland.${notToday}/explorer.json`
   const ASSET_BUNDLES_DOMAIN = qs.ASSET_BUNDLES_DOMAIN || `content-assets-as-bundle.decentraland.${TLDDefault}`
 
-  const QUESTS_SERVER_URL = qs.QUESTS_SERVER_URL ?? `https://quests-api.decentraland.${notToday}`
+  const QUESTS_SERVER_URL =
+    qs.QUESTS_SERVER_URL ?? `https://quests-api.decentraland.${notToday === 'org' ? 'org' : 'io'}`
 
   return {
     contentAsBundle: `https://${ASSET_BUNDLES_DOMAIN}`,

--- a/kernel/packages/shared/quests/client.ts
+++ b/kernel/packages/shared/quests/client.ts
@@ -13,7 +13,13 @@ export async function questsClient() {
   })
 }
 
-export async function questsRequest<T>(request: (client: QuestsClient) => Promise<ClientResponse<T>>) {
-  const client = await questsClient()
-  return request(client)
+export async function questsRequest<T>(
+  request: (client: QuestsClient) => Promise<ClientResponse<T>>
+): Promise<ClientResponse<T>> {
+  try {
+    const client = await questsClient()
+    return await request(client)
+  } catch (e) {
+    return { ok: false, status: 0, body: { status: 'unknown error', message: e.message } }
+  }
 }


### PR DESCRIPTION
We will soon have two quests URLs: One for production and one for development. Explorer should select which one based on its TLD.

The server can also be adjusted through the QUESTS_SERVER_URL url parameter.