### PR TITLE
fix: re-trigger non-looping animations now works when the animation f…

### DIFF
--- a/kernel/packages/decentraland-ecs/src/decentraland/Components.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Components.ts
@@ -563,6 +563,8 @@ export class Animator extends Shape {
 
     if (reset) clip.shouldReset = true
     clip.playing = true
+    clip.dirty = true
+    clip.data.nonce = Math.random()
   }
 
   /**


### PR DESCRIPTION
…inish

# What?
Main PR and depends on: decentraland/unity-renderer#451

In kernel we just force to resend the data when we execute `play`.