### PR TITLE
feat: generic analytics endpoint for Unity

### DIFF
--- a/kernel/packages/unity-interface/BrowserInterface.ts
+++ b/kernel/packages/unity-interface/BrowserInterface.ts
@@ -89,11 +89,6 @@ type SystemInfoPayload = {
   systemMemorySize: number
 }
 
-type GenericAnalyticPayload = {
-  eventName: string
-  data: any
-}
-
 export class BrowserInterface {
   private lastBalanceOfMana: number = -1
 
@@ -179,16 +174,12 @@ export class BrowserInterface {
     trackEvent('system info report', data)
   }
 
-  public GenericAnalytic(payload: GenericAnalyticPayload) {
-    trackEvent(payload.eventName, payload.data)
-  }
-
   public PreloadFinished(data: { sceneId: string }) {
     // stub. there is no code about this in unity side yet
   }
 
-  public Track(data: { name: string; properties: { key: string; value: string }[] | null }) {
-    const properties: Record<string, string> = {}
+  public Track(data: { name: string; properties: { key: string; value: any }[] | null }) {
+    const properties: Record<string, any> = {}
     if (data.properties) {
       for (const property of data.properties) {
         properties[property.key] = property.value

--- a/kernel/packages/unity-interface/BrowserInterface.ts
+++ b/kernel/packages/unity-interface/BrowserInterface.ts
@@ -89,6 +89,11 @@ type SystemInfoPayload = {
   systemMemorySize: number
 }
 
+type GenericAnalyticPayload = {
+  eventName: string
+  data: any
+}
+
 export class BrowserInterface {
   private lastBalanceOfMana: number = -1
 
@@ -172,6 +177,10 @@ export class BrowserInterface {
 
   public SystemInfoReport(data: SystemInfoPayload) {
     trackEvent('system info report', data)
+  }
+
+  public GenericAnalytic(payload: GenericAnalyticPayload) {
+    trackEvent(payload.eventName, payload.data)
   }
 
   public PreloadFinished(data: { sceneId: string }) {


### PR DESCRIPTION
Solves this: https://app.zenhub.com/workspaces/unity-6047bad476c3c0001942ee91/issues/decentraland/unity-renderer/299

Goes in pair with this `unity-renderer` PR: https://github.com/decentraland/unity-renderer/pull/458


Provide an endpoint for Unity to track generic events.
