### PR TITLE
fix: map profiles to urn everywhere

### DIFF
--- a/kernel/packages/shared/profiles/sagas.ts
+++ b/kernel/packages/shared/profiles/sagas.ts
@@ -233,15 +233,6 @@ export function* handleFetchProfile(action: ProfileRequestAction): any {
         profile = localProfile
       }
 
-      const avatar = profile?.avatars[0]?.avatar
-      if (avatar?.bodyShape) {
-        avatar.bodyShape = mapLegacyIdToUrn(avatar.bodyShape)
-      }
-
-      if (avatar?.wearables) {
-        avatar.wearables = mapLegacyIdsToUrn(avatar.wearables)
-      }
-
       const identity: ExplorerIdentity = yield select(getCurrentIdentity)
       profile.ethAddress = identity.rawAddress
     }
@@ -516,12 +507,7 @@ async function deploy(
   // Build entity and group all files
   const preparationData = await (contentFiles.size
     ? catalyst.buildEntity({ type: EntityType.PROFILE, pointers: [identity.address], files: contentFiles, metadata })
-    : catalyst.buildEntityWithoutNewFiles({
-        type: EntityType.PROFILE,
-        pointers: [identity.address],
-        hashesByKey: contentHashes,
-        metadata
-      }))
+    : catalyst.buildEntityWithoutNewFiles({ type: EntityType.PROFILE, pointers: [identity.address], hashesByKey: contentHashes, metadata }))
   // sign the entity id
   const authChain = Authenticator.signPayload(identity, preparationData.entityId)
   // Build the deploy data

--- a/kernel/packages/shared/profiles/sagas.ts
+++ b/kernel/packages/shared/profiles/sagas.ts
@@ -233,6 +233,15 @@ export function* handleFetchProfile(action: ProfileRequestAction): any {
         profile = localProfile
       }
 
+      const avatar = profile?.avatars[0]?.avatar
+      if (avatar?.bodyShape) {
+        avatar.bodyShape = mapLegacyIdToUrn(avatar.bodyShape)
+      }
+
+      if (avatar?.wearables) {
+        avatar.wearables = mapLegacyIdsToUrn(avatar.wearables)
+      }
+
       const identity: ExplorerIdentity = yield select(getCurrentIdentity)
       profile.ethAddress = identity.rawAddress
     }
@@ -507,7 +516,12 @@ async function deploy(
   // Build entity and group all files
   const preparationData = await (contentFiles.size
     ? catalyst.buildEntity({ type: EntityType.PROFILE, pointers: [identity.address], files: contentFiles, metadata })
-    : catalyst.buildEntityWithoutNewFiles({ type: EntityType.PROFILE, pointers: [identity.address], hashesByKey: contentHashes, metadata }))
+    : catalyst.buildEntityWithoutNewFiles({
+        type: EntityType.PROFILE,
+        pointers: [identity.address],
+        hashesByKey: contentHashes,
+        metadata
+      }))
   // sign the entity id
   const authChain = Authenticator.signPayload(identity, preparationData.entityId)
   // Build the deploy data

--- a/kernel/packages/shared/profiles/transformations/isValidBodyShape.ts
+++ b/kernel/packages/shared/profiles/transformations/isValidBodyShape.ts
@@ -1,4 +1,6 @@
 const BODY_SHAPES = [
+  'dcl://base-avatars:BaseFemale',
+  'dcl://base-avatars:BaseMale',
   'urn:decentraland:off-chain:base-avatars:BaseFemale',
   'urn:decentraland:off-chain:base-avatars:BaseMale'
 ]

--- a/kernel/packages/shared/profiles/transformations/isValidBodyShape.ts
+++ b/kernel/packages/shared/profiles/transformations/isValidBodyShape.ts
@@ -1,6 +1,6 @@
 const BODY_SHAPES = [
-  'dcl://base-avatars:BaseFemale',
-  'dcl://base-avatars:BaseMale',
+  'dcl://base-avatars/BaseFemale',
+  'dcl://base-avatars/BaseMale',
   'urn:decentraland:off-chain:base-avatars:BaseFemale',
   'urn:decentraland:off-chain:base-avatars:BaseMale'
 ]

--- a/kernel/packages/shared/profiles/transformations/profileToServerFormat.ts
+++ b/kernel/packages/shared/profiles/transformations/profileToServerFormat.ts
@@ -2,6 +2,7 @@ import { analizeColorPart, stripAlpha } from './analizeColorPart'
 import { isValidBodyShape } from './isValidBodyShape'
 import { Profile, Snapshots } from '../types'
 import { WearableId } from 'decentraland-ecs/src'
+import { mapLegacyIdsToUrn, mapLegacyIdToUrn } from 'shared/catalogs/sagas'
 
 export function ensureServerFormat(profile: Profile): ServerFormatProfile {
   const { avatar } = profile
@@ -25,12 +26,12 @@ export function ensureServerFormat(profile: Profile): ServerFormatProfile {
   return {
     ...profile,
     avatar: {
-      bodyShape: avatar.bodyShape,
+      bodyShape: mapLegacyIdToUrn(avatar.bodyShape),
       snapshots: avatar.snapshots,
       eyes: { color: eyes },
       hair: { color: hair },
       skin: { color: skin },
-      wearables: avatar.wearables
+      wearables: mapLegacyIdsToUrn(avatar.wearables)
     }
   }
 }


### PR DESCRIPTION
Now that unity supports URNs, we need to map all legacy ids to URNs. The problem is that we forgot to map ids in profiles in two different scenarios:
* Profiles that were stored in local storage.
* Profiles received by comms

We are now fixing that.