### PR TITLE
feat: Added API to expose explorer configuration to scenes

### DIFF
--- a/kernel/packages/decentraland-ecs/types/@decentraland/EnvironmentAPI/index.d.ts
+++ b/kernel/packages/decentraland-ecs/types/@decentraland/EnvironmentAPI/index.d.ts
@@ -8,7 +8,7 @@ declare module '@decentraland/EnvironmentAPI' {
 
   export type ExplorerData = {
     clientUri: string
-    configurations: Record<string, any>
+    configurations: Record<string, string | number | boolean>
   }
 
   /**
@@ -25,5 +25,5 @@ declare module '@decentraland/EnvironmentAPI' {
   /**
    * Returns explorer configuration and environment information
    */
-  export function getExplorerData(): Promise<ExplorerData>
+  export function getExplorerConfiguration(): Promise<ExplorerData>
 }

--- a/kernel/packages/decentraland-ecs/types/@decentraland/EnvironmentAPI/index.d.ts
+++ b/kernel/packages/decentraland-ecs/types/@decentraland/EnvironmentAPI/index.d.ts
@@ -6,7 +6,7 @@ declare module '@decentraland/EnvironmentAPI' {
     displayName: string
   }
 
-  export type ExplorerData = {
+  export type ExplorerConfiguration = {
     clientUri: string
     configurations: Record<string, string | number | boolean>
   }
@@ -25,5 +25,5 @@ declare module '@decentraland/EnvironmentAPI' {
   /**
    * Returns explorer configuration and environment information
    */
-  export function getExplorerConfiguration(): Promise<ExplorerData>
+  export function getExplorerConfiguration(): Promise<ExplorerConfiguration>
 }

--- a/kernel/packages/decentraland-ecs/types/@decentraland/EnvironmentAPI/index.d.ts
+++ b/kernel/packages/decentraland-ecs/types/@decentraland/EnvironmentAPI/index.d.ts
@@ -7,8 +7,7 @@ declare module '@decentraland/EnvironmentAPI' {
   }
 
   export type ExplorerData = {
-    clientUrl: string
-    buildNumber: number
+    clientUri: string
     configurations: Record<string, any>
   }
 

--- a/kernel/packages/decentraland-ecs/types/@decentraland/EnvironmentAPI/index.d.ts
+++ b/kernel/packages/decentraland-ecs/types/@decentraland/EnvironmentAPI/index.d.ts
@@ -5,6 +5,13 @@ declare module '@decentraland/EnvironmentAPI' {
     serverName: string
     displayName: string
   }
+
+  export type ExplorerData = {
+    clientUrl: string
+    buildNumber: number
+    configurations: Record<string, any>
+  }
+
   /**
    * Returns the current connected realm
    */
@@ -14,4 +21,10 @@ declare module '@decentraland/EnvironmentAPI' {
    * Returns whether the scene is running in preview mode or not
    */
   export function isPreviewMode(): Promise<boolean>
+
+
+  /**
+   * Returns explorer configuration and environment information
+   */
+  export function getExplorerData(): Promise<ExplorerData>
 }

--- a/kernel/packages/shared/apis/EnvironmentAPI.ts
+++ b/kernel/packages/shared/apis/EnvironmentAPI.ts
@@ -5,7 +5,6 @@ import { Store } from 'redux'
 import { RootState } from 'shared/store/rootTypes'
 import { getRealm } from 'shared/dao/selectors'
 import { getServerConfigurations, PREVIEW } from 'config'
-import { buildNumber } from 'shared/meta/env'
 
 type EnvironmentRealm = {
   domain: string
@@ -15,8 +14,7 @@ type EnvironmentRealm = {
 }
 
 type ExplorerData = {
-  clientUrl: string
-  buildNumber: number
+  clientUri: string
   configurations: Record<string, any>
 }
 
@@ -67,8 +65,7 @@ export class EnvironmentAPI extends ExposableAPI {
   @exposeMethod
   async getExplorerData(): Promise<ExplorerData> {
     return {
-      clientUrl: location.href,
-      buildNumber,
+      clientUri: location.href,
       configurations: {
         questsServerUrl: getServerConfigurations().questsUrl
       }

--- a/kernel/packages/shared/apis/EnvironmentAPI.ts
+++ b/kernel/packages/shared/apis/EnvironmentAPI.ts
@@ -13,9 +13,9 @@ type EnvironmentRealm = {
   displayName: string
 }
 
-type ExplorerData = {
+type ExplorerConfiguration = {
   clientUri: string
-  configurations: Record<string, any>
+  configurations: Record<string, string | number | boolean>
 }
 
 declare const window: any
@@ -63,7 +63,7 @@ export class EnvironmentAPI extends ExposableAPI {
    * Returns explorer configuration and environment information
    */
   @exposeMethod
-  async getExplorerData(): Promise<ExplorerData> {
+  async getExplorerConfiguration(): Promise<ExplorerConfiguration> {
     return {
       clientUri: location.href,
       configurations: {

--- a/kernel/packages/shared/apis/EnvironmentAPI.ts
+++ b/kernel/packages/shared/apis/EnvironmentAPI.ts
@@ -4,13 +4,20 @@ import { EnvironmentData } from 'shared/types'
 import { Store } from 'redux'
 import { RootState } from 'shared/store/rootTypes'
 import { getRealm } from 'shared/dao/selectors'
-import { PREVIEW } from 'config'
+import { getServerConfigurations, PREVIEW } from 'config'
+import { buildNumber } from 'shared/meta/env'
 
 type EnvironmentRealm = {
   domain: string
   layer: string
   serverName: string
   displayName: string
+}
+
+type ExplorerData = {
+  clientUrl: string
+  buildNumber: number
+  configurations: Record<string, any>
 }
 
 declare const window: any
@@ -51,6 +58,20 @@ export class EnvironmentAPI extends ExposableAPI {
       layer,
       serverName,
       displayName: `${serverName}-${layer}`
+    }
+  }
+
+  /**
+   * Returns explorer configuration and environment information
+   */
+  @exposeMethod
+  async getExplorerData(): Promise<ExplorerData> {
+    return {
+      clientUrl: location.href,
+      buildNumber,
+      configurations: {
+        questsServerUrl: getServerConfigurations().questsUrl
+      }
     }
   }
 }


### PR DESCRIPTION
Scenes currently don't really have much information about the client that is executing them. The idea is to start building an API that the scenes can use to query that information, and to start adding data to it as it is needed.

The proposed contract is that "configuration" values can be present or not, so scenes have to handle the case in which the configuration is missing or doesn't exists anymore.

For the moment, this will be used to have smart defaults for the quests library, keeping in mind that we should synchronize what the scenes see and what the UI (which is handled by kernel + unity) shows.
