### PR TITLE
fix: stuck in loading while in signup flow

### DIFF
--- a/kernel/packages/entryPoints/website.ts
+++ b/kernel/packages/entryPoints/website.ts
@@ -42,6 +42,7 @@ import { kernelConfigForRenderer } from '../unity-interface/kernelConfigForRende
 import Html from 'shared/Html'
 import { filterInvalidNameCharacters, isBadWord } from 'shared/profiles/utils/names'
 import { startRealmsReportToRenderer } from 'unity-interface/realmsForRenderer'
+import { isWaitingTutorial } from 'shared/loading/selectors'
 
 const logger = createLogger('website.ts: ')
 
@@ -141,16 +142,18 @@ namespace webApp {
         i.ConfigureHUDElement(HUDElementID.USERS_AROUND_LIST_HUD, { active: voiceChatEnabled, visible: false })
         i.ConfigureHUDElement(HUDElementID.FRIENDS, { active: identity.hasConnectedWeb3, visible: false })
 
-        ensureRendererEnabled().then(() => {
-          globalThis.globalStore.dispatch(setLoadingWaitTutorial(false))
-          globalThis.globalStore.dispatch(experienceStarted())
-          globalThis.globalStore.dispatch(setLoadingScreen(false))
-          Html.switchGameContainer(true)
-        }).catch(logger.error)
+        ensureRendererEnabled()
+          .then(() => {
+            globalThis.globalStore.dispatch(setLoadingWaitTutorial(false))
+            globalThis.globalStore.dispatch(experienceStarted())
+            globalThis.globalStore.dispatch(setLoadingScreen(false))
+            Html.switchGameContainer(true)
+          })
+          .catch(logger.error)
 
         const tutorialConfig = {
           fromDeepLink: HAS_INITIAL_POSITION_MARK,
-          enableNewTutorialCamera: enableNewTutorialCamera,
+          enableNewTutorialCamera: enableNewTutorialCamera
         }
 
         EnsureProfile(identity.address)
@@ -158,6 +161,10 @@ namespace webApp {
             i.ConfigureEmailPrompt(profile.tutorialStep)
             i.ConfigureTutorial(profile.tutorialStep, tutorialConfig)
             i.ConfigureHUDElement(HUDElementID.GRAPHIC_CARD_WARNING, { active: true, visible: true })
+
+            if (isWaitingTutorial(globalThis.globalStore.getState())) {
+              teleportObservable.notifyObservers(worldToGrid(lastPlayerPosition))
+            }
           })
           .catch((e) => logger.error(`error getting profile ${e}`))
       })
@@ -194,13 +201,17 @@ namespace webApp {
     })
 
     if (!NO_MOTD) {
-      waitForMessageOfTheDay().then((messageOfTheDay) => {
-        i.ConfigureHUDElement(
-          HUDElementID.MESSAGE_OF_THE_DAY,
-          { active: !!messageOfTheDay, visible: false },
-          messageOfTheDay
-        )
-      }).catch(() => {/*noop*/})
+      waitForMessageOfTheDay()
+        .then((messageOfTheDay) => {
+          i.ConfigureHUDElement(
+            HUDElementID.MESSAGE_OF_THE_DAY,
+            { active: !!messageOfTheDay, visible: false },
+            messageOfTheDay
+          )
+        })
+        .catch(() => {
+          /*noop*/
+        })
     }
 
     teleportObservable.notifyObservers(worldToGrid(lastPlayerPosition))

--- a/kernel/packages/entryPoints/website.ts
+++ b/kernel/packages/entryPoints/website.ts
@@ -162,9 +162,9 @@ namespace webApp {
             i.ConfigureTutorial(profile.tutorialStep, tutorialConfig)
             i.ConfigureHUDElement(HUDElementID.GRAPHIC_CARD_WARNING, { active: true, visible: true })
 
-            if (isWaitingTutorial(globalThis.globalStore.getState())) {
-              teleportObservable.notifyObservers(worldToGrid(lastPlayerPosition))
-            }
+            // NOTE: here we make sure that if signup (tutorial) just finished
+            // the player is set in the correct spawn position plus we make sure that the proper scene is loaded
+            setUserPositionAfterTutorial()
           })
           .catch((e) => logger.error(`error getting profile ${e}`))
       })
@@ -227,6 +227,12 @@ namespace webApp {
   export const utils = {
     isBadWord,
     filterInvalidNameCharacters
+  }
+
+  function setUserPositionAfterTutorial() {
+    if (isWaitingTutorial(globalThis.globalStore.getState())) {
+      teleportObservable.notifyObservers(worldToGrid(lastPlayerPosition))
+    }
   }
 }
 


### PR DESCRIPTION
New users are often stuck in an infinite loading screen while creating their profile.
This is because activate the renderer was only called when scenes at player's position finished loading.
In the signup flow scenario, the scene finished loading but kernel deactivate the renderer and didn't activate it again.
So if scene finished loading before user finished the signup then the renderer is never activated.

Steps to reproduce the issue:
1- open browser, incognito, cache clean and with metamask disabled (cause it's easier to test as a guest)
2- go to play.decentraland.zone
3- mute the tab (you can thank me later)
4- enter as guest
5- you now see avatar editor, don't click anything
6- open a new tab/window on your browser and go to your favorite crypto-news website and catch up with the latest news (you need to wait like a minute or more to make sure that scenes finish loading on background)
7- go back to avatar editor, press done
8- fill up your avatar name ("TheRealPravus" is recommended but not mandatory)
9- accept TOS
10- if everything went wrong then you are stuck in an eternal loading screen