### PR TITLE
fix: removed observable events of position and rotation to take over …

### DIFF
--- a/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
+++ b/kernel/packages/decentraland-ecs/src/decentraland/Events.ts
@@ -1,9 +1,7 @@
 import { EventConstructor } from '../ecs/EventManager'
 import { Observable } from '../ecs/Observable'
-import { ReadOnlyQuaternion, ReadOnlyVector3 } from './math'
 import { DecentralandInterface, IEvents, RaycastResponsePayload, CameraMode } from './Types'
 export { CameraMode }
-export { ReadOnlyVector3, ReadOnlyQuaternion }
 
 /**
  * @public
@@ -83,20 +81,6 @@ export const onLeaveScene = onLeaveSceneObservable
 export const onSceneReadyObservable = new Observable<IEvents['sceneStart']>(createSubscriber('sceneStart'))
 
 /**
- * This event is triggered when the position of the camera changes
- * This event is throttled to 10 times per second.
- * @public
- */
-export const onPositionChangedObservable = new Observable<IEvents['positionChanged']>(createSubscriber('positionChanged'))
-
-/**
- * This event is triggered when the rotation of the camera changes.
- * This event is throttled to 10 times per second.
- * @public
- */
-export const onRotationChangedObservable = new Observable<IEvents['rotationChanged']>(createSubscriber('rotationChanged'))
-
-/**
  * @public
  */
 export const onPlayerExpressionObservable = new Observable<IEvents['playerExpression']>(createSubscriber('playerExpression'))
@@ -131,14 +115,6 @@ export function _initEventObservables(dcl: DecentralandInterface) {
         }
         case 'sceneStart': {
           onSceneReadyObservable.notifyObservers(event.data as IEvents['sceneStart'])
-          return
-        }
-        case 'positionChanged': {
-          onPositionChangedObservable.notifyObservers(event.data as IEvents['positionChanged'])
-          return
-        }
-        case 'rotationChanged': {
-          onRotationChangedObservable.notifyObservers(event.data as IEvents['rotationChanged'])
           return
         }
         case 'playerExpression': {

--- a/kernel/public/test-scenes/1.14.playerEvents/game.ts
+++ b/kernel/public/test-scenes/1.14.playerEvents/game.ts
@@ -4,22 +4,12 @@ import {
   Transform,
   Vector3,
   onPlayerExpressionObservable,
-  onPositionChangedObservable,
-  onRotationChangedObservable,
-  TextShape,
-  onEnterSceneObservable,
-  BoxShape,
-  Quaternion
+  TextShape
 } from 'decentraland-ecs/src'
-
-const box = new Entity()
-box.addComponent(new BoxShape())
-box.addComponent(new Transform({ position: new Vector3(8, 2, 8), scale: new Vector3(0.25, 0.25, 1) }))
-engine.addEntity(box)
 
 //Create entity and assign shape
 const text = new Entity()
-const shape = new TextShape('Null...')
+const shape = new TextShape('Make an expression!')
 text.addComponent(shape)
 
 text.addComponent(
@@ -31,22 +21,6 @@ text.addComponent(
 
 engine.addEntity(text)
 
-onEnterSceneObservable.add(({ userId }) => {
-  shape.value = 'Enter: ' + userId
-})
-
 onPlayerExpressionObservable.add(({ expressionId }) => {
   shape.value = 'Expression: ' + expressionId
-})
-
-onPositionChangedObservable.add((eventData) => {
-  text.getComponent(Transform).lookAt(new Vector3(eventData.position.x, eventData.position.y, eventData.position.z))
-})
-onRotationChangedObservable.add((eventData) => {
-  box.getComponent(Transform).rotation = new Quaternion(
-    eventData.quaternion.x,
-    eventData.quaternion.y,
-    eventData.quaternion.z,
-    eventData.quaternion.w
-  )
 })


### PR DESCRIPTION
…those in the future with more consistency names

# What? <!-- what is this PR? -->
In #2360 I misunderstud @menduz and I merge two events that he said to remove.

The reason to delete is because we want to think a solution to have more consistency names for the events. And we cannot release something in the SDK and modify it later.