### PR TITLE
style: image for genesis plaza tip updated

### DIFF
--- a/kernel/static/images/decentraland-connect/loadingtips/GenesisPlazaImg.png
+++ b/kernel/static/images/decentraland-connect/loadingtips/GenesisPlazaImg.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9df62b026b52187e3e3360ac331f1be11b8a1fe158707a146811d17fab91e845
-size 54327
+oid sha256:837faf7e40a9ab24f7e28efc394c547f93086e7265e4cfd887d9081bff0f6787
+size 62021


### PR DESCRIPTION
The Genesis Plaza's main building image was replaced by the new one.

OLD
<img width="1103" alt="Screen Shot 2021-05-20 at 14 55 04" src="https://user-images.githubusercontent.com/51088292/119145877-75065080-ba20-11eb-93e3-58cfa51b5482.png">

NEW
<img width="820" alt="Screen Shot 2021-05-21 at 10 38 46" src="https://user-images.githubusercontent.com/51088292/119146165-bf87cd00-ba20-11eb-8b1a-7e5b490cdb00.png">
