### PR TITLE
feat: crash payload message

### DIFF
--- a/kernel/packages/unity-interface/BrowserInterface.ts
+++ b/kernel/packages/unity-interface/BrowserInterface.ts
@@ -180,8 +180,8 @@ export class BrowserInterface {
     trackEvent('system info report', data)
   }
 
-  public CrashPayloadResponse(json: string) {
-    unityInterface.onCrashPayloadResponse.notifyObservers(json)
+  public CrashPayloadResponse(data: { json: string }) {
+    unityInterface.onCrashPayloadResponse.notifyObservers(data.json)
   }
 
   public PreloadFinished(data: { sceneId: string }) {

--- a/kernel/packages/unity-interface/BrowserInterface.ts
+++ b/kernel/packages/unity-interface/BrowserInterface.ts
@@ -180,6 +180,10 @@ export class BrowserInterface {
     trackEvent('system info report', data)
   }
 
+  public CrashPayloadResponse(json: string) {
+    unityInterface.onCrashPayloadResponse.notifyObservers(json)
+  }
+
   public PreloadFinished(data: { sceneId: string }) {
     // stub. there is no code about this in unity side yet
   }

--- a/kernel/packages/unity-interface/BrowserInterface.ts
+++ b/kernel/packages/unity-interface/BrowserInterface.ts
@@ -180,8 +180,8 @@ export class BrowserInterface {
     trackEvent('system info report', data)
   }
 
-  public CrashPayloadResponse(data: { json: string }) {
-    unityInterface.onCrashPayloadResponse.notifyObservers(data.json)
+  public CrashPayloadResponse(data: { payload: any }) {
+    unityInterface.crashPayloadResponseObservable.notifyObservers(JSON.stringify(data))
   }
 
   public PreloadFinished(data: { sceneId: string }) {

--- a/kernel/packages/unity-interface/UnityInterface.ts
+++ b/kernel/packages/unity-interface/UnityInterface.ts
@@ -61,7 +61,7 @@ export class UnityInterface {
   public gameInstance: any
   public Module: any
   public currentHeight: number = 1080
-  public onCrashPayloadResponse: Observable<string> = new Observable<string>()
+  public crashPayloadResponseObservable: Observable<string> = new Observable<string>()
 
   public SetTargetHeight(height: number): void {
     if (EDITOR) {
@@ -196,17 +196,15 @@ export class UnityInterface {
 
     // For websocket this should take more frames, so we need promises.
     let promise = new Promise<string>((resolve, reject) => {
-      let crashListener = (payload: string) => {
+      let crashListener = this.crashPayloadResponseObservable.addOnce((payload) => {
         resolve(payload)
-      }
-
-      this.onCrashPayloadResponse.addOnce(crashListener)
+      })
 
       // We solve on timeout anyways to simplify usage.
       setTimeout(() => {
-        this.onCrashPayloadResponse.removeCallback(crashListener)
+        this.crashPayloadResponseObservable.remove(crashListener)
         resolve('Crash payload request failed')
-      }, 1000)
+      }, 10000)
 
       this.SendMessageToUnity('Main', 'CrashPayloadRequest')
     })

--- a/kernel/packages/unity-interface/UnityInterface.ts
+++ b/kernel/packages/unity-interface/UnityInterface.ts
@@ -549,6 +549,10 @@ export class ClientDebug {
   public RunPerformanceMeterTool(durationInMilliseconds: number) {
     this.unityInterface.SendMessageToUnity('Main', 'RunPerformanceMeterTool', durationInMilliseconds)
   }
+
+  public DumpCrashPayload() {
+    this.unityInterface.SendMessageToUnity('Main', 'DumpCrashPayload')
+  }
 }
 
 export let unityInterface: UnityInterface = new UnityInterface()


### PR DESCRIPTION
Sibling PR of https://github.com/decentraland/unity-renderer/pull/479

## What this PR includes?

This PR adds new functionality to add dump information about the internal state of the client. The payload definition can be found in this [RFC](https://docs.google.com/document/d/1eCHxBpvnFc-fvEXf540y7unUr0mXhQ6TmidkkUnTn2E/edit#heading=h.o921fa8bd20p).


## How to test it?
1. Go to: https://play.decentraland.zone/branch/feat/crash-payload-message/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:feat/crash-payload-message
2. Put the following command on the browser console:
`clientDebug.DumpCrashPayload()`
3. The full payload should be outputted in the console's log.

![image](https://user-images.githubusercontent.com/6875814/119748490-64fccf80-be6b-11eb-9ba1-57d95c29c464.png)

## Our Code Review Standards
https://github.com/decentraland/unity-renderer/blob/master/docs/code-review-standards.md