### PR TITLE
fix: enormous transform values physics breakdown

### DIFF
--- a/kernel/packages/scene-system/sdk/Utils.ts
+++ b/kernel/packages/scene-system/sdk/Utils.ts
@@ -1,6 +1,8 @@
 import { CLASS_ID, Transform } from "decentraland-ecs/src"
 import { PB_Transform, PB_Vector3, PB_Quaternion } from "../../shared/proto/engineinterface_pb"
+import { Vector3 } from "decentraland-ecs"
 
+const VECTOR3_MEMBER_CAP = 1000000 // Value measured when genesis plaza glitch triggered a physics engine breakdown
 const pbTransform: PB_Transform = new PB_Transform()
 const pbPosition: PB_Vector3 = new PB_Vector3()
 const pbRotation: PB_Quaternion = new PB_Quaternion()
@@ -23,23 +25,50 @@ export function generatePBObjectJSON(classId: CLASS_ID, json: any): string {
 }
 
 function serializeTransform(transform: Transform): string {
-  pbPosition.setX(Math.fround(transform.position.x))
-  pbPosition.setY(Math.fround(transform.position.y))
-  pbPosition.setZ(Math.fround(transform.position.z))
+  // Position
+  // If we don't cap these vectors, scenes may trigger a physics breakdown when messaging enormous values
+  const cappedVector = new Vector3(Math.fround(transform.position.x),
+                                  Math.fround(transform.position.y),
+                                  Math.fround(transform.position.z))
+  capVector(cappedVector, VECTOR3_MEMBER_CAP)
+  pbPosition.setX(cappedVector.x)
+  pbPosition.setY(cappedVector.y)
+  pbPosition.setZ(cappedVector.z)
 
+  // Rotation
   pbRotation.setX(transform.rotation.x)
   pbRotation.setY(transform.rotation.y)
   pbRotation.setZ(transform.rotation.z)
   pbRotation.setW(transform.rotation.w)
 
-  pbScale.setX(Math.fround(transform.scale.x))
-  pbScale.setY(Math.fround(transform.scale.y))
-  pbScale.setZ(Math.fround(transform.scale.z))
+  // Scale
+  cappedVector.set(Math.fround(transform.scale.x),
+                    Math.fround(transform.scale.y),
+                    Math.fround(transform.scale.z))
+  capVector(cappedVector, VECTOR3_MEMBER_CAP)
+  pbScale.setX(cappedVector.x)
+  pbScale.setY(cappedVector.y)
+  pbScale.setZ(cappedVector.z)
 
+  // Apply values
   pbTransform.setPosition(pbPosition)
   pbTransform.setRotation(pbRotation)
   pbTransform.setScale(pbScale)
 
   let arrayBuffer: Uint8Array = pbTransform.serializeBinary()
   return btoa(String.fromCharCode(...arrayBuffer))
+}
+
+function capVector(targetVector: Vector3, cap: number) {
+  if (Math.abs(targetVector.x) > cap) {
+    targetVector.x = cap * Math.sign(targetVector.x)
+  }
+
+  if (Math.abs(targetVector.y) > cap) {
+    targetVector.y = cap * Math.sign(targetVector.y)
+  }
+
+  if (Math.abs(targetVector.z) > cap) {
+    targetVector.z = cap * Math.sign(targetVector.z)
+  }
 }


### PR DESCRIPTION
**WHY**
Right now the physics engine sync suffers a breakdown when loading the Genesis Plaza from far away (when the clouds start moving), this is due to receiving super large values for some entities position and scale, the details and evidence can be seen at the [corresponding issue](https://app.zenhub.com/workspaces/unity-6047bad476c3c0001942ee91/issues/decentraland/unity-renderer/494).

**WHAT**
Added pos and scale capping to avoid enormous values breaking the physics engine in runtime

**TESTING**
Repro steps:
1. Enter the world at `-11, -11`
2. Wait until the genesys plaza ends  its loading and then a bit more for the clouds system to start running
3. You will notice that some objects in the road at `-11, -10` are not colliding with the character (this is what the PR fixes)
4. Move to the Genesis Plaza NFTShapes gallery and you will see the picture frames are not there. (not fixed by this PR since that is consecuence of the scene code crashing)

* Production (bugged): https://play.decentraland.org/?position=-11,-11&LOS=4&realm=fenrir-amber

* This branch (fixed): https://play.decentraland.zone/branch/fix/EnormousTransformValuesPhysicsBreakdown/index.html?ENV=org&position=-11,-11&LOS=4&realm=fenrir-amber