### PR TITLE
chore: rename performance meter tool parameter

### DIFF
--- a/kernel/packages/unity-interface/UnityInterface.ts
+++ b/kernel/packages/unity-interface/UnityInterface.ts
@@ -546,8 +546,8 @@ export class ClientDebug {
     this.unityInterface.SendMessageToUnity('Main', 'DumpRendererLockersInfo')
   }
 
-  public RunPerformanceMeterTool(durationInMilliseconds: number) {
-    this.unityInterface.SendMessageToUnity('Main', 'RunPerformanceMeterTool', durationInMilliseconds)
+  public RunPerformanceMeterTool(durationInSeconds: number) {
+    this.unityInterface.SendMessageToUnity('Main', 'RunPerformanceMeterTool', durationInSeconds)
   }
 }
 


### PR DESCRIPTION
Changed performance meter tool input param to be for seconds instead of millieconds

client side: https://github.com/decentraland/unity-renderer/pull/460

Testing:
1. access: https://play.decentraland.zone/branch/chore/ChangePerformanceMeterToolParameter/index.html?renderer=urn:decentraland:off-chain:renderer-artifacts:feat/PerformanceMeterTool&ENV=org
2. open the browser console and execute `clientDebug.RunPerformanceMeterTool(10);` to run the performance meter tool for 10 seconds
3. wait for the complete data report to be printed in the console