### PR TITLE
Feat: Use the new catalyst health check to verify a server is up before connecting

### DIFF
--- a/kernel/packages/shared/dao/index.ts
+++ b/kernel/packages/shared/dao/index.ts
@@ -120,7 +120,7 @@ export async function fetchCatalystRealms(nodesEndpoint: string | undefined): Pr
 }
 
 async function fetchPeerHealthStatus(node: CatalystNode) {
-  return await (await fetch(peerHealthStatusUrl(node.domain))).json()
+  return (await fetch(peerHealthStatusUrl(node.domain))).json()
 }
 
 export function isPeerHealthy(peerStatus: Record<string, HealthStatus>) {

--- a/kernel/packages/shared/dao/types.ts
+++ b/kernel/packages/shared/dao/types.ts
@@ -85,3 +85,9 @@ export type PingResult = {
   status?: ServerConnectionStatus
   result?: CatalystLayers
 }
+
+export enum HealthStatus {
+  HEALTHY = 'HEALTHY',
+  UNHEALTHY = 'UNHEALTHY',
+  DOWN = 'DOWN'
+}

--- a/kernel/packages/shared/dao/types.ts
+++ b/kernel/packages/shared/dao/types.ts
@@ -87,7 +87,7 @@ export type PingResult = {
 }
 
 export enum HealthStatus {
-  HEALTHY = 'HEALTHY',
-  UNHEALTHY = 'UNHEALTHY',
-  DOWN = 'DOWN'
+  HEALTHY = 'Healthy',
+  UNHEALTHY = 'Unhealthy',
+  DOWN = 'Down'
 }


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Filters out non healthy catalyst peers, to prevent connecting to an unhealthy one

# Why? <!-- Explain the reason -->
...
