### PR TITLE
refactor: ENABLE_WEB3=false enters always as a guest

### DIFF
--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -91,12 +91,12 @@ export const OPEN_AVATAR_EDITOR = location.search.includes('OPEN_AVATAR_EDITOR')
 
 export const STATIC_WORLD = location.search.includes('STATIC_WORLD') || !!(global as any).staticWorld || EDITOR
 
+const qs = queryString.parse(location.search)
+
 // Development
-export const ENABLE_WEB3 = location.search.includes('ENABLE_WEB3') || !!(global as any).enableWeb3
+export const ENABLE_WEB3 = qs.ENABLE_WEB3 ? !!qs.ENABLE_WEB3 : location.search.includes('ENABLE_WEB3') || !!(global as any).enableWeb3 // Accept ENABLE_WEB3, ENABLE_WEB3=true/false
 export const ENV_OVERRIDE = location.search.includes('ENV')
 export const GIF_WORKERS = location.search.includes('GIF_WORKERS')
-
-const qs = queryString.parse(location.search)
 
 // Comms
 export const USE_LOCAL_COMMS = location.search.includes('LOCAL_COMMS') || PREVIEW

--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -94,7 +94,7 @@ export const STATIC_WORLD = location.search.includes('STATIC_WORLD') || !!(globa
 const qs = queryString.parse(location.search)
 
 // Development
-export const ENABLE_WEB3 = qs.ENABLE_WEB3 ? !!qs.ENABLE_WEB3 : location.search.includes('ENABLE_WEB3') || !!(global as any).enableWeb3 // Accept ENABLE_WEB3, ENABLE_WEB3=true/false
+export const ENABLE_WEB3 = qs.ENABLE_WEB3 !== 'false' && (qs.ENABLE_WEB3 === 'true' || qs.ENABLE_WEB3 === '' || !!(global as any).enableWeb3) // Accept ENABLE_WEB3, ENABLE_WEB3=true/false
 export const ENV_OVERRIDE = location.search.includes('ENV')
 export const GIF_WORKERS = location.search.includes('GIF_WORKERS')
 

--- a/kernel/packages/shared/profiles/sagas.ts
+++ b/kernel/packages/shared/profiles/sagas.ts
@@ -3,7 +3,7 @@ import { EntityType, Hashing } from 'dcl-catalyst-commons'
 import { CatalystClient, ContentClient, DeploymentData } from 'dcl-catalyst-client'
 import { call, throttle, put, select, takeEvery } from 'redux-saga/effects'
 
-import { getServerConfigurations, PREVIEW, ethereumConfigurations, RESET_TUTORIAL, ALL_WEARABLES } from 'config'
+import { getServerConfigurations, PREVIEW, ethereumConfigurations, RESET_TUTORIAL, ALL_WEARABLES, ENABLE_WEB3 } from 'config'
 
 import defaultLogger from 'shared/logger'
 import {
@@ -202,7 +202,7 @@ export function* handleFetchProfile(action: ProfileRequestAction): any {
   const currentId = yield select(getCurrentUserId)
   let profile: any
   let hasConnectedWeb3 = false
-  if (WORLD_EXPLORER) {
+  if (WORLD_EXPLORER && ENABLE_WEB3) {
     try {
       if (profileType === ProfileType.LOCAL && currentId !== userId) {
         const peerProfile: Profile = yield requestLocalProfileToPeers(userId)

--- a/kernel/packages/shared/session/sagas.ts
+++ b/kernel/packages/shared/session/sagas.ts
@@ -119,11 +119,11 @@ function* initSession() {
   if (ENABLE_WEB3) {
     yield checkPreviousSession()
     Html.showEthLogin()
+    yield put(changeLoginStage(LoginStage.SIGN_IN))
   } else {
     yield previewAutoSignIn()
+    yield put(changeLoginStage(LoginStage.COMPLETED))
   }
-
-  yield put(changeLoginStage(LoginStage.SIGN_IN))
 
   if (ENABLE_WEB3) {
     const connecetor = getEthConnector()

--- a/kernel/test/index.ts
+++ b/kernel/test/index.ts
@@ -1,5 +1,5 @@
 global['isRunningTests'] = true
-
+global['enableWeb3'] = true
 /**
  * Hello, this file is the tests entry point.
  * You should import all your tests here.

--- a/kernel/test/unit/catalog.saga.test.tsx
+++ b/kernel/test/unit/catalog.saga.test.tsx
@@ -9,7 +9,7 @@ import { getFetchContentServer } from 'shared/dao/selectors'
 
 const serverUrl = 'https://server.com'
 const wearableId1 = 'WearableId1'
-const wearable1 = { id: wearableId1, baseUrl: serverUrl + 'contents/', baseUrlBundles: "https://content-assets-as-bundle.decentraland.zone/" } as any
+const wearable1 = { id: wearableId1, baseUrl: serverUrl + 'contents/', baseUrlBundles: "https://content-assets-as-bundle.decentraland.org/" } as any
 
 const userId = 'userId'
 const context = 'someContext'


### PR DESCRIPTION
# What?
Related to #487

When we splicitly set `ENABLE_WEB3=false` in the browser, we disable the sign in process, and we enter directly as a guest.

# Why?
To have a way to skip Web3 interaction for tests and desktop (temporarly)