### PR TITLE
feat: support unpublished wearables

### DIFF
--- a/kernel/packages/shared/apis/SceneStateStorageController/BuilderServerAPIManager.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/BuilderServerAPIManager.ts
@@ -5,7 +5,7 @@ import { BuilderAsset, BuilderManifest, BuilderProject, BuilderScene, AssetId, A
 import { getDefaultTLD } from 'config'
 import { defaultLogger } from '../../logger'
 
-const BASE_DOWNLOAD_URL = 'https://builder-api.decentraland.org/v1/storage/contents'
+export const BASE_DOWNLOAD_URL = 'https://builder-api.decentraland.org/v1/storage/contents'
 const BASE_BUILDER_SERVER_URL_ROPSTEN = 'https://builder-api.decentraland.io/v1/'
 const BASE_BUILDER_SERVER_URL = 'https://builder-api.decentraland.org/v1/'
 

--- a/kernel/packages/shared/catalogs/sagas.ts
+++ b/kernel/packages/shared/catalogs/sagas.ts
@@ -200,7 +200,7 @@ function* fetchWearablesV2(filters: WearablesRequestFilters) {
 
       // Fetch unpublished collections from builder server
       const uuidCollections = collectionIds.filter((collectionId) => !collectionId.startsWith('urn'))
-      if (uuidCollections) {
+      if (uuidCollections.length > 0) {
         const identity = yield select(getCurrentIdentity)
         for (const collectionUuid of uuidCollections) {
           const path = `collections/${collectionUuid}/items`

--- a/kernel/packages/shared/catalogs/types.ts
+++ b/kernel/packages/shared/catalogs/types.ts
@@ -20,6 +20,30 @@ export type Wearable = {
   thumbnail: string
 }
 
+export type PreviewWearable = {
+  id: string // uuid
+  rarity: string
+  name: string
+  thumbnail: string
+  description: string
+  data: {
+    category: string
+    tags: string[]
+    hides?: string[]
+    replaces?: string[]
+    representations: PreviewBodyShapeRepresentation[]
+  }
+  contents: Record<string, string> // from file name to hash
+}
+
+export type PreviewBodyShapeRepresentation = {
+  bodyShapes: string[]
+  mainFile: string
+  overrideHides?: string[]
+  overrideReplaces?: string[]
+  contents: string[]
+}
+
 export type WearableV2 = {
   id: string
   rarity: string

--- a/kernel/packages/shared/catalogs/types.ts
+++ b/kernel/packages/shared/catalogs/types.ts
@@ -20,7 +20,7 @@ export type Wearable = {
   thumbnail: string
 }
 
-export type PreviewWearable = {
+export type UnpublishedWearable = {
   id: string // uuid
   rarity: string
   name: string
@@ -31,12 +31,12 @@ export type PreviewWearable = {
     tags: string[]
     hides?: string[]
     replaces?: string[]
-    representations: PreviewBodyShapeRepresentation[]
+    representations: UnpublishedBodyShapeRepresentation[]
   }
   contents: Record<string, string> // from file name to hash
 }
 
-export type PreviewBodyShapeRepresentation = {
+type UnpublishedBodyShapeRepresentation = {
   bodyShapes: string[]
   mainFile: string
   overrideHides?: string[]


### PR DESCRIPTION
We are now adding support to test wearables that have not been published yet. These wearables live on the builder server, and have not been deployed on a content server yet.

Collections of this sort have a uuid instead of a urn, so the idea is to use the `WITH_COLLECTIONS` parameters with the uuid.

For example:
```play.decentraland.zone?WITH_COLLECTIONS=9d2e8db1-fbed-473d-8280-108293d4163a```
