### PR TITLE
fix: add name to entities for builder in world projects

### DIFF
--- a/kernel/packages/shared/apis/SceneStateStorageController/BuilderServerAPIManager.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/BuilderServerAPIManager.ts
@@ -233,7 +233,8 @@ export class BuilderServerAPIManager {
         '29d657c1-95cf-4e17-b424-fe252d43ced5': {
           id: '29d657c1-95cf-4e17-b424-fe252d43ced5',
           components: ['14708436-ffd4-44d6-8a28-48d8fcb65917', '47924b6e-27ba-41a3-8bd9-c025cd092a48'],
-          disableGizmos: true
+          disableGizmos: true,
+          name: '29d657c1-95cf-4e17-b424-fe252d43ced5'
         }
       },
       components: {

--- a/kernel/packages/shared/apis/SceneStateStorageController/StorableSceneStateTranslation.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/StorableSceneStateTranslation.ts
@@ -69,7 +69,8 @@ export async function toBuilderFromStateDefinitionFormat(
     let builderEntity: BuilderEntity = {
       id: entityId,
       components: builderComponentsIds,
-      disableGizmos: false
+      disableGizmos: false,
+      name: entityId
     }
     entities[builderEntity.id] = builderEntity
   }

--- a/kernel/packages/shared/apis/SceneStateStorageController/types.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/types.ts
@@ -67,6 +67,7 @@ export type BuilderEntity = {
   id: string
   components: string[]
   disableGizmos: boolean
+  name: string
 }
 
 export type BuilderComponent = {


### PR DESCRIPTION
partially-fix: https://github.com/decentraland/unity-renderer/issues/578
builder dapp needs entities to have a defined name while exporting