### PR TITLE
fix: builder in world. translate rotation applied by builder's deploy

### DIFF
--- a/kernel/packages/shared/apis/SceneStateStorageController/BuilderServerAPIManager.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/BuilderServerAPIManager.ts
@@ -18,7 +18,8 @@ import { getDefaultTLD } from 'config'
 import { defaultLogger } from '../../logger'
 import { getParcelSceneLimits } from 'atomicHelpers/landHelpers'
 import { CLASS_ID } from 'decentraland-ecs/src'
-import { toHumanReadableType, fromHumanReadableType } from './utils'
+import { toHumanReadableType, fromHumanReadableType, getLayoutFromParcels } from './utils'
+import { SceneSourcePlacement } from 'shared/types'
 
 export const BASE_DOWNLOAD_URL = 'https://builder-api.decentraland.org/v1/storage/contents'
 const BASE_BUILDER_SERVER_URL_ROPSTEN = 'https://builder-api.decentraland.io/v1/'
@@ -155,55 +156,92 @@ export class BuilderServerAPIManager {
     return builderManifest
   }
 
-  async createManifestFromSerializedState(
+  async builderManifesFromSerializedState(
     builderSceneId: string,
     builderProjectId: string,
     baseParcel: string,
     parcels: string[],
     title: string | undefined,
     description: string | undefined,
+    ethAddress: string,
     scene: SerializedSceneState,
-    identity: ExplorerIdentity
-  ): Promise<BuilderManifest | undefined> {
-    try {
-      const builderManifest = await this.builderManifesFromSerializedState(
-        builderSceneId,
-        builderProjectId,
-        baseParcel,
-        parcels,
-        title,
-        description,
-        identity.rawAddress,
-        scene
-      )
-      await this.setManifestOnServer(builderManifest, identity)
-      return builderManifest
-    } catch (e) {
-      defaultLogger.error(e)
+    sceneLayout: SceneSourcePlacement['layout'] | undefined
+  ): Promise<BuilderManifest> {
+    const builderProject: BuilderProject = this.createBuilderProject(
+      builderSceneId,
+      builderProjectId,
+      baseParcel,
+      parcels,
+      ethAddress,
+      title,
+      description,
+      sceneLayout?.cols,
+      sceneLayout?.rows
+    )
+
+    const { entities, components } = getBuilderEntitiesAndComponentsFromSerializedState(scene)
+    const assetsId: string[] = Object.values(components)
+      .filter((component) => fromHumanReadableType(component.type) === CLASS_ID.GLTF_SHAPE)
+      .map((component) => component.data.assetId)
+
+    const assets = await this.getAssets(assetsId)
+
+    const ground: BuilderGround = Object.values(assets)
+      .filter((asset) => asset.category === 'ground')
+      ?.map((groundAsset) => {
+        return {
+          assetId: groundAsset.id,
+          componentId: Object.values(components).filter((component) => component.data.assetId === groundAsset.id)[0]?.id
+        }
+      })[0]
+
+    const groundEntity = Object.values(entities).filter((entity) =>
+      entity.components.find((componentId) => componentId === ground.componentId)
+    )[0]
+
+    if (groundEntity) {
+      groundEntity.disableGizmos = true
     }
-    return undefined
+
+    // NOTE: scene metrics are calculated again in builder dapp, so for now we only fill entities count
+    let builderScene: BuilderScene = {
+      id: builderSceneId,
+      entities,
+      components,
+      assets,
+      ground,
+      limits: getSceneLimits(parcels.length),
+      metrics: {
+        textures: 0,
+        triangles: 0,
+        materials: 0,
+        meshes: 0,
+        bodies: 0,
+        entities: Object.keys(entities).length
+      }
+    }
+
+    return {
+      version: BUILDER_MANIFEST_VERSION,
+      project: builderProject,
+      scene: builderScene
+    }
   }
 
-  createBuilderProject(
+  private createBuilderProject(
     builderSceneId: string,
     builderProjectId: string,
     baseParcel: string,
     parcels: string[],
     ethAddress: string,
-    title: string | undefined = undefined,
-    description: string | undefined = undefined
+    title?: string,
+    description?: string,
+    cols?: number,
+    rows?: number
   ): BuilderProject {
     const today = new Date().toISOString()
-    let rows = 1
-    let cols = 1
 
-    if (parcels.length > 1) {
-      const rowsAll: number[] = parcels.map((parcel) => parseInt(parcel.split(',')[1], 10))
-      const colsAll: number[] = parcels.map((parcel) => parseInt(parcel.split(',')[0], 10))
-
-      rows = Math.max(...rowsAll) - Math.min(...rowsAll)
-      cols = Math.max(...colsAll) - Math.min(...colsAll)
-    }
+    const layout = getLayoutFromParcels(parcels)
 
     return {
       id: builderProjectId,
@@ -212,8 +250,8 @@ export class BuilderServerAPIManager {
       is_public: false,
       scene_id: builderSceneId,
       eth_address: ethAddress,
-      rows: rows,
-      cols: cols,
+      rows: rows ?? layout.rows,
+      cols: cols ?? layout.cols,
       created_at: today,
       updated_at: today,
       creation_coords: baseParcel
@@ -364,76 +402,6 @@ export class BuilderServerAPIManager {
       scene: builderScene
     }
     return builderManifest
-  }
-
-  private async builderManifesFromSerializedState(
-    builderSceneId: string,
-    builderProjectId: string,
-    baseParcel: string,
-    parcels: string[],
-    title: string | undefined,
-    description: string | undefined,
-    ethAddress: string,
-    scene: SerializedSceneState
-  ): Promise<BuilderManifest> {
-    const builderProject: BuilderProject = this.createBuilderProject(
-      builderSceneId,
-      builderProjectId,
-      baseParcel,
-      parcels,
-      ethAddress,
-      title,
-      description
-    )
-
-    const { entities, components } = getBuilderEntitiesAndComponentsFromSerializedState(scene)
-
-    const assetsId = Object.values(components)
-      .filter((component) => fromHumanReadableType(component.type) === CLASS_ID.GLTF_SHAPE)
-      .map((component) => component.data.assetId)
-
-    const assets = await this.getAssets(assetsId)
-
-    const ground: BuilderGround = Object.values(assets)
-      .filter((asset) => asset.category === 'ground')
-      ?.map((groundAsset) => {
-        return {
-          assetId: groundAsset.id,
-          componentId: Object.values(components).filter((component) => component.data.assetId === groundAsset.id)[0]?.id
-        }
-      })[0]
-
-    const groundEntity = Object.values(entities).filter((entity) =>
-      entity.components.find((componentId) => componentId === ground.componentId)
-    )[0]
-
-    if (groundEntity) {
-      groundEntity.disableGizmos = true
-    }
-
-    // NOTE: scene metrics are calculated again in builder dapp, so for now we only fill entities count
-    let builderScene: BuilderScene = {
-      id: builderSceneId,
-      entities,
-      components,
-      assets,
-      ground,
-      limits: getSceneLimits(parcels.length),
-      metrics: {
-        textures: 0,
-        triangles: 0,
-        materials: 0,
-        meshes: 0,
-        bodies: 0,
-        entities: Object.keys(entities).length
-      }
-    }
-
-    return {
-      version: BUILDER_MANIFEST_VERSION,
-      project: builderProject,
-      scene: builderScene
-    }
   }
 }
 

--- a/kernel/packages/shared/apis/SceneStateStorageController/BuilderServerAPIManager.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/BuilderServerAPIManager.ts
@@ -156,7 +156,7 @@ export class BuilderServerAPIManager {
     return builderManifest
   }
 
-  async builderManifesFromSerializedState(
+  async builderManifestFromSerializedState(
     builderSceneId: string,
     builderProjectId: string,
     baseParcel: string,

--- a/kernel/packages/shared/apis/SceneStateStorageController/SceneStateStorageController.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/SceneStateStorageController.ts
@@ -9,7 +9,6 @@ import { DEBUG } from '../../../config'
 import {
   Asset,
   AssetId,
-  BuilderComponent,
   BuilderManifest,
   CONTENT_PATH,
   DeploymentResult,
@@ -288,13 +287,10 @@ export class SceneStateStorageController extends ExposableAPI implements ISceneS
           // Transform manifest components
           this.transformTranslator = new SceneTransformTranslator(this.parcelIdentity.land.sceneJsonData.source)
 
-          const transformedComponents: Record<string, BuilderComponent> = {}
-          for (let key of Object.keys(builderManifest.scene.components)) {
-            transformedComponents[key] = this.transformTranslator.transformBuilderComponent(
-              builderManifest.scene.components[key]
-            )
-          }
-          builderManifest.scene.components = transformedComponents
+          builderManifest.scene.components = Object.entries(builderManifest.scene.components).reduce(
+            (acc, [k, v]) => ({ ...acc, [k]: this.transformTranslator.transformBuilderComponent(v) }),
+            {}
+          )
 
           // Notify renderer about the project information
           globalThis.unityInterface.SendBuilderProjectInfo(

--- a/kernel/packages/shared/apis/SceneStateStorageController/SceneStateStorageController.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/SceneStateStorageController.ts
@@ -9,6 +9,7 @@ import { DEBUG } from '../../../config'
 import {
   Asset,
   AssetId,
+  BuilderComponent,
   BuilderManifest,
   CONTENT_PATH,
   DeploymentResult,
@@ -35,6 +36,8 @@ import { ExplorerIdentity } from 'shared/session/types'
 import { deserializeSceneState, serializeSceneState } from 'scene-system/stateful-scene/SceneStateDefinitionSerializer'
 import { ISceneStateStorageController } from './ISceneStateStorageController'
 import { base64ToBlob } from 'atomicHelpers/base64ToBlob'
+import { getLayoutFromParcels } from './utils'
+import { SceneTransformTranslator } from './SceneTransformTranslator'
 
 declare const globalThis: any
 
@@ -42,6 +45,7 @@ export class SceneStateStorageController extends ExposableAPI implements ISceneS
   private readonly builderApiManager = new BuilderServerAPIManager()
   private parcelIdentity = this.options.getAPIInstance(ParcelIdentity)
   private builderManifest!: BuilderManifest
+  private transformTranslator!: SceneTransformTranslator
 
   @exposeMethod
   async getProjectManifest(projectId: string): Promise<SerializedSceneState | undefined> {
@@ -51,7 +55,8 @@ export class SceneStateStorageController extends ExposableAPI implements ISceneS
 
     globalThis.unityInterface.SendBuilderProjectInfo(manifest.project.title, manifest.project.description)
     this.builderManifest = manifest
-    const definition = fromBuildertoStateDefinitionFormat(manifest.scene)
+    this.transformTranslator = new SceneTransformTranslator(this.parcelIdentity.land.sceneJsonData.source)
+    const definition = fromBuildertoStateDefinitionFormat(manifest.scene, this.transformTranslator)
     return serializeSceneState(definition)
   }
 
@@ -61,7 +66,11 @@ export class SceneStateStorageController extends ExposableAPI implements ISceneS
     if (newProject) {
       globalThis.unityInterface.SendBuilderProjectInfo(newProject.project.title, newProject.project.description)
       this.builderManifest = newProject
-      const translatedManifest = fromBuildertoStateDefinitionFormat(this.builderManifest.scene)
+      this.transformTranslator = new SceneTransformTranslator(this.parcelIdentity.land.sceneJsonData.source)
+      const translatedManifest = fromBuildertoStateDefinitionFormat(
+        this.builderManifest.scene,
+        this.transformTranslator
+      )
       return serializeSceneState(translatedManifest)
     }
     return undefined
@@ -72,6 +81,7 @@ export class SceneStateStorageController extends ExposableAPI implements ISceneS
     const newProject = await this.builderApiManager.createProjectWithCoords(coordinates, this.getIdentity())
     globalThis.unityInterface.SendBuilderProjectInfo(newProject.project.title, newProject.project.description)
     this.builderManifest = newProject
+    this.transformTranslator = new SceneTransformTranslator(this.parcelIdentity.land.sceneJsonData.source)
     return newProject ? true : false
   }
 
@@ -87,7 +97,8 @@ export class SceneStateStorageController extends ExposableAPI implements ISceneS
       let builderManifest = await toBuilderFromStateDefinitionFormat(
         sceneState,
         this.builderManifest,
-        this.builderApiManager
+        this.builderApiManager,
+        this.transformTranslator
       )
 
       // Update the manifest
@@ -117,7 +128,8 @@ export class SceneStateStorageController extends ExposableAPI implements ISceneS
     let builderManifest = await toBuilderFromStateDefinitionFormat(
       deserializedSceneState,
       this.builderManifest,
-      this.builderApiManager
+      this.builderApiManager,
+      this.transformTranslator
     )
 
     // Update the project info
@@ -179,7 +191,12 @@ export class SceneStateStorageController extends ExposableAPI implements ISceneS
             source: {
               origin: 'builder-in-world',
               version: 1,
-              projectId: this.builderManifest.project.id
+              projectId: this.builderManifest.project.id,
+              rotation: this.parcelIdentity.land.sceneJsonData.source?.rotation ?? 'east',
+              layout: this.parcelIdentity.land.sceneJsonData.source?.layout ?? getLayoutFromParcels(parcels),
+              point:
+                this.parcelIdentity.land.sceneJsonData.source?.point ??
+                this.parcelIdentity.land.sceneJsonData.scene.base
             } as SceneDeploymentSourceMetadata
           }
         })
@@ -247,53 +264,74 @@ export class SceneStateStorageController extends ExposableAPI implements ISceneS
     const parcels: string[] = sceneJson.scene.parcels
     const title: string | undefined = sceneJson.display?.title
     const description: string | undefined = sceneJson.display?.description
-    const thumbnailHash: string | undefined = this.parcelIdentity.land.mappingsResponse.contents.find(
-      (pair) => pair.file === CONTENT_PATH.SCENE_THUMBNAIL
-    )?.hash
 
     try {
       const serializedScene = await this.getStoredState(sceneId)
       if (serializedScene) {
         const identity = this.getIdentity()
 
-        let builderManifest = await this.builderApiManager.createManifestFromSerializedState(
+        // Create builder manifest from serialized scene
+        let builderManifest = await this.builderApiManager.builderManifesFromSerializedState(
           uuid(),
           uuid(),
           baseParcel,
           parcels,
           title,
           description,
+          identity.rawAddress,
           serializedScene,
-          identity
+          this.parcelIdentity.land.sceneJsonData.source?.layout
         )
+
         if (builderManifest) {
-          this.builderManifest = builderManifest
+          // Transform manifest components
+          this.transformTranslator = new SceneTransformTranslator(this.parcelIdentity.land.sceneJsonData.source)
+
+          const transformedComponents: Record<string, BuilderComponent> = {}
+          for (let key of Object.keys(builderManifest.scene.components)) {
+            transformedComponents[key] = this.transformTranslator.transformBuilderComponent(
+              builderManifest.scene.components[key]
+            )
+          }
+          builderManifest.scene.components = transformedComponents
+
+          // Notify renderer about the project information
           globalThis.unityInterface.SendBuilderProjectInfo(
             builderManifest.project.title,
             builderManifest.project.description
           )
 
-          let thumbnail: string = ''
+          // Update/Create manifest in builder-server
+          this.builderManifest = builderManifest
+          this.builderApiManager
+            .updateProjectManifest(builderManifest, identity)
+            .catch((error) => defaultLogger.error(`Error updating project manifest ${error}`))
 
+          // Retrieve deployed thumbnail
+          const thumbnailHash: string | undefined = this.parcelIdentity.land.mappingsResponse.contents.find(
+            (pair) => pair.file === CONTENT_PATH.SCENE_THUMBNAIL
+          )?.hash
+          let thumbnail: string = ''
           if (thumbnailHash) {
             const contentClient = this.getContentClient()
             const thumbnailBuffer = await contentClient.downloadContent(thumbnailHash, { attempts: 3 })
             thumbnail = thumbnailBuffer.toString('base64')
           }
 
+          // Publish scene
           this.publishSceneState(
             sceneId,
             builderManifest.project.title,
             builderManifest.project.description,
             thumbnail,
             serializedScene
-          ).catch((error) => defaultLogger.error(`Error updating project manifest ${error}`))
+          ).catch((error) => defaultLogger.error(`Error publishing scene ${error}`))
 
           return serializedScene
         }
       }
     } catch (error) {
-      defaultLogger.error(`Failed creating project from state definition at coords ${baseParcel}`)
+      defaultLogger.error(`Failed creating project from state definition at coords ${baseParcel}`, error)
     }
   }
 

--- a/kernel/packages/shared/apis/SceneStateStorageController/SceneStateStorageController.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/SceneStateStorageController.ts
@@ -271,7 +271,7 @@ export class SceneStateStorageController extends ExposableAPI implements ISceneS
         const identity = this.getIdentity()
 
         // Create builder manifest from serialized scene
-        let builderManifest = await this.builderApiManager.builderManifesFromSerializedState(
+        let builderManifest = await this.builderApiManager.builderManifestFromSerializedState(
           uuid(),
           uuid(),
           baseParcel,

--- a/kernel/packages/shared/apis/SceneStateStorageController/SceneTransformTranslator.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/SceneTransformTranslator.ts
@@ -1,0 +1,94 @@
+import { Component } from 'scene-system/stateful-scene/types'
+import { CLASS_ID, Matrix, Quaternion, Vector3 } from 'decentraland-ecs/src'
+import { SceneSource, SceneSourcePlacement } from 'shared/types'
+import { BuilderComponent } from './types'
+import { toHumanReadableType } from './utils'
+import { parcelLimits } from 'config'
+
+/**
+ * Utility class to translate the transformation that the builder dapp applies to the scene, while deploying,
+ * to the stateful scene definition
+ */
+
+export class SceneTransformTranslator {
+  private builderToStateDefinitionMatrix!: Matrix
+  private stateDefinitionToBuilderMatrix!: Matrix
+
+  public constructor(sceneSource?: SceneSource | undefined) {
+    this.setBuilderSceneTransformation(sceneSource)
+  }
+
+  public setBuilderSceneTransformation(sceneSource: SceneSource | undefined) {
+    const rotation: SceneSourcePlacement['rotation'] | undefined = sceneSource?.rotation
+    const layout: SceneSourcePlacement['layout'] | undefined = sceneSource?.layout
+    const parcelSize = parcelLimits.parcelSize
+
+    if (!rotation || !layout) {
+      this.builderToStateDefinitionMatrix = Matrix.Identity()
+      this.stateDefinitionToBuilderMatrix = Matrix.Identity()
+      return
+    }
+
+    const sceneRotation: Quaternion = Quaternion.Identity
+    const sceneTranslation: Vector3 = Vector3.Zero()
+
+    switch (rotation) {
+      case 'north':
+        sceneRotation.setEuler(0, -90, 0)
+        sceneTranslation.set(layout.cols * parcelSize, 0, 0)
+        break
+      case 'east':
+        break
+      case 'south':
+        sceneRotation.setEuler(0, 90, 0)
+        sceneTranslation.set(0, 0, layout.rows * parcelSize)
+        break
+      case 'west':
+        sceneRotation.setEuler(0, 180, 0)
+        sceneTranslation.set(layout.rows * parcelSize, 0, layout.cols * parcelSize)
+        break
+    }
+
+    this.builderToStateDefinitionMatrix = Matrix.Compose(Vector3.One(), sceneRotation, sceneTranslation)
+    this.stateDefinitionToBuilderMatrix = Matrix.Invert(this.builderToStateDefinitionMatrix)
+  }
+
+  public transformBuilderComponent(builderComponent: Readonly<BuilderComponent>): BuilderComponent {
+    const componentData = { ...builderComponent.data }
+
+    if (builderComponent.type === toHumanReadableType(CLASS_ID.TRANSFORM)) {
+      componentData.position = Vector3.TransformCoordinates(componentData.position, this.stateDefinitionToBuilderMatrix)
+      let matrixRotation = Quaternion.Identity
+      this.stateDefinitionToBuilderMatrix.decompose(undefined, matrixRotation, undefined)
+      const componentRotation = new Quaternion(
+        componentData.rotation.x,
+        componentData.rotation.y,
+        componentData.rotation.z,
+        componentData.rotation.w
+      )
+      componentData.rotation = matrixRotation.multiply(componentRotation)
+    }
+
+    return { ...builderComponent, data: componentData }
+  }
+
+  public transformStateDefinitionComponent(statedDefinitionComponent: Readonly<Component>): Component {
+    const transformMatrix = this.builderToStateDefinitionMatrix
+    const componentData = { ...statedDefinitionComponent.data }
+
+    if (statedDefinitionComponent.componentId === CLASS_ID.TRANSFORM) {
+      componentData.position = Vector3.TransformCoordinates(componentData.position, transformMatrix)
+      let matrixRotation = Quaternion.Identity
+      transformMatrix.decompose(undefined, matrixRotation, undefined)
+      const componentRotation = new Quaternion(
+        componentData.rotation.x,
+        componentData.rotation.y,
+        componentData.rotation.z,
+        componentData.rotation.w
+      )
+      componentData.rotation = matrixRotation.multiply(componentRotation)
+    }
+
+    return { ...statedDefinitionComponent, data: componentData }
+  }
+}

--- a/kernel/packages/shared/apis/SceneStateStorageController/StorableSceneStateTranslation.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/StorableSceneStateTranslation.ts
@@ -12,6 +12,7 @@ import {
 } from './types'
 import { BuilderServerAPIManager } from './BuilderServerAPIManager'
 import { toHumanReadableType, fromHumanReadableType } from './utils'
+import { SceneTransformTranslator } from './SceneTransformTranslator'
 
 const CURRENT_SCHEMA_VERSION = 1
 
@@ -33,7 +34,8 @@ type StorableComponent = {
 export async function toBuilderFromStateDefinitionFormat(
   scene: SceneStateDefinition,
   builderManifest: BuilderManifest,
-  builderApiManager: BuilderServerAPIManager
+  builderApiManager: BuilderServerAPIManager,
+  transfromTranslator: SceneTransformTranslator
 ): Promise<BuilderManifest> {
   let entities: Record<string, BuilderEntity> = {}
   let builderComponents: Record<string, BuilderComponent> = {}
@@ -57,11 +59,11 @@ export async function toBuilderFromStateDefinitionFormat(
       }
 
       // we add the component to the builder format
-      let builderComponent: BuilderComponent = {
+      let builderComponent: BuilderComponent = transfromTranslator.transformBuilderComponent({
         id: newId,
         type: componentType,
         data: component.data
-      }
+      })
       builderComponents[builderComponent.id] = builderComponent
     }
 
@@ -154,7 +156,10 @@ export async function toBuilderFromStateDefinitionFormat(
   return builderManifest
 }
 
-export function fromBuildertoStateDefinitionFormat(scene: BuilderScene): SceneStateDefinition {
+export function fromBuildertoStateDefinitionFormat(
+  scene: BuilderScene,
+  transfromTranslator: SceneTransformTranslator
+): SceneStateDefinition {
   const sceneState = new SceneStateDefinition()
 
   const componentMap = new Map(Object.entries(scene.components))
@@ -184,10 +189,11 @@ export function fromBuildertoStateDefinitionFormat(scene: BuilderScene): SceneSt
           componentData.color = color
           componentData.style = 0
         }
-        let component: Component = {
+
+        let component: Component = transfromTranslator.transformStateDefinitionComponent({
           componentId: fromHumanReadableType(componentMap.get(componentId)!.type),
           data: componentData
-        }
+        })
         components.push(component)
       }
     }

--- a/kernel/packages/shared/apis/SceneStateStorageController/types.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/types.ts
@@ -1,4 +1,4 @@
-import { ContentMapping } from '../../types'
+import { ContentMapping, SceneSource } from 'shared/types'
 
 export type AssetId = string
 
@@ -112,9 +112,4 @@ export type UnityColor = {
   a: number
 }
 
-export type SceneDeploymentSourceMetadata = {
-  version: number
-  origin: string
-  projectId?: string
-  isEmpty?: boolean
-}
+export type SceneDeploymentSourceMetadata = SceneSource

--- a/kernel/packages/shared/apis/SceneStateStorageController/utils.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/utils.ts
@@ -1,4 +1,5 @@
 import { CLASS_ID } from 'decentraland-ecs/src'
+import { SceneSourcePlacement } from 'shared/types'
 
 /**
  * We are converting from numeric ids to a more human readable format. It might make sense to change this in the future,
@@ -30,4 +31,15 @@ export function fromHumanReadableType(humanReadableType: string): number {
     throw new Error(`Unknown human readable type ${humanReadableType}`)
   }
   return type
+}
+
+export function getLayoutFromParcels(parcels: string[]): SceneSourcePlacement['layout'] {
+  let rows = 1
+  let cols = 1
+
+  if (parcels.length > 1) {
+    rows = [...new Set(parcels.map((parcel) => parcel.split(',')[1]))].length
+    cols = [...new Set(parcels.map((parcel) => parcel.split(',')[0]))].length
+  }
+  return { cols, rows }
 }

--- a/kernel/packages/shared/types.ts
+++ b/kernel/packages/shared/types.ts
@@ -209,6 +209,17 @@ export type ScenePolicy = {
 export type SceneSource = {
   origin?: string
   projectId?: string
+  version?: number
+  rotation?: SceneSourcePlacement['rotation']
+  point?: SceneSourcePlacement['point']
+  layout?: SceneSourcePlacement['layout']
+  isEmpty?: boolean
+}
+
+export type SceneSourcePlacement = {
+  rotation: 'north' | 'east' | 'south' | 'west'
+  point: { x: number; y: number }
+  layout: { cols: number; rows: number }
 }
 
 /// https://github.com/decentraland/proposals/blob/master/dsp/0020.mediawiki


### PR DESCRIPTION
while deploying a scene using builder you can choose to rotate it.
we need to translate those transformations from builder to scene's state definition when editing in builder in world and from scene's state definition to builder when updating the project to the builder-server.
