### PR TITLE
fix: loading screen missing after signup screen migration

### DIFF
--- a/kernel/packages/unity-interface/BrowserInterface.ts
+++ b/kernel/packages/unity-interface/BrowserInterface.ts
@@ -75,6 +75,7 @@ import { unpublishSceneByCoords } from 'shared/apis/SceneStateStorageController/
 import { BuilderServerAPIManager } from 'shared/apis/SceneStateStorageController/BuilderServerAPIManager'
 import { Store } from 'redux'
 import { areCandidatesFetched } from 'shared/dao/selectors'
+import Html from 'shared/Html'
 
 declare const globalThis: StoreContainer & { gifProcessor?: GIFProcessor }
 export let futures: Record<string, IFuture<any>> = {}
@@ -287,6 +288,8 @@ export class BrowserInterface {
   }
 
   public SendPassport(passport: { name: string; email: string }) {
+    Html.switchGameContainer(false)
+    unityInterface.DeactivateRendering()
     globalThis.globalStore.dispatch(signupForm(passport.name, passport.email))
     globalThis.globalStore.dispatch(signUp())
   }


### PR DESCRIPTION
After the migration to the renderer of the signup the world was not loaded after accepting TOS.
This PR disable renderer and show the loading screen until the world is fully loaded