### PR TITLE
feat: biw reactivate org project saving

### DIFF
--- a/kernel/packages/shared/apis/SceneStateStorageController/BuilderServerAPIManager.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/BuilderServerAPIManager.ts
@@ -267,11 +267,7 @@ export class BuilderServerAPIManager {
   }
 
   private async setManifestOnServer(builderManifest: BuilderManifest, identity: ExplorerIdentity) {
-    // TODO: We should delete this when we enter in production or we won't be able to set the project in production
-    if (getDefaultTLD() === 'org') {
-      defaultLogger.log('Project saving is disable in org for the moment!')
-      return undefined
-    }
+
     const queryParams = 'projects/' + builderManifest.project.id + '/manifest'
     const urlToFecth = `${this.getBaseUrl()}${queryParams}`
 


### PR DESCRIPTION
# What? 

This PR reactivates the saving of the project in (production) .org 
 

# Why? 

The saving in production was disable to do not increase the amount of projects that we had in production while we were developing the tool, since we are very near to the release of the product we need to reactivate it

