### PR TITLE
refactor: remove wearables v2 flag

### DIFF
--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -135,8 +135,6 @@ export const PIN_CATALYST = qs.CATALYST ? addHttpsIfNoProtocolIsSet(qs.CATALYST)
 
 export const FORCE_RENDERING_STYLE = qs.FORCE_RENDERING_STYLE
 
-export const TEST_WEARABLES_OVERRIDE = location.search.includes('TEST_WEARABLES')
-
 const META_CONFIG_URL = qs.META_CONFIG_URL
 
 export namespace commConfigurations {
@@ -242,7 +240,6 @@ export function getExclusiveServer() {
   return 'https://wearable-api.decentraland.org/v2/collections'
 }
 
-export const ALL_WEARABLES = location.search.includes('ALL_WEARABLES') && getDefaultTLD() !== 'org'
 export const WITH_FIXED_COLLECTIONS = qs.WITH_COLLECTIONS && getDefaultTLD() !== 'org' ? qs.WITH_COLLECTIONS : undefined
 export const WEARABLE_API_DOMAIN = qs.WEARABLE_API_DOMAIN || 'wearable-api.decentraland.org'
 export const WEARABLE_API_PATH_PREFIX = qs.WEARABLE_API_PATH_PREFIX || 'v2'

--- a/kernel/packages/shared/catalogs/sagas.ts
+++ b/kernel/packages/shared/catalogs/sagas.ts
@@ -1,14 +1,6 @@
 import { call, put, select, take, takeEvery } from 'redux-saga/effects'
 
-import {
-  getServerConfigurations,
-  getWearablesSafeURL,
-  PIN_CATALYST,
-  WSS_ENABLED,
-  TEST_WEARABLES_OVERRIDE,
-  ALL_WEARABLES,
-  WITH_FIXED_COLLECTIONS
-} from 'config'
+import { getServerConfigurations, PIN_CATALYST, WSS_ENABLED, WITH_FIXED_COLLECTIONS } from 'config'
 
 import defaultLogger from 'shared/logger'
 import { RENDERER_INITIALIZED } from 'shared/renderer/types'
@@ -24,11 +16,8 @@ import {
   WEARABLES_REQUEST,
   WEARABLES_SUCCESS
 } from './actions'
-import { baseCatalogsLoaded, getExclusiveCatalog, getPlatformCatalog } from './selectors'
+import { baseCatalogsLoaded, getPlatformCatalog } from './selectors'
 import {
-  Wearable,
-  Collection,
-  WearableId,
   WearablesRequestFilters,
   WearableV2,
   BodyShapeRepresentationV2,
@@ -39,11 +28,8 @@ import { WORLD_EXPLORER } from '../../config/index'
 import { getResourcesURL } from '../location'
 import { RendererInterfaces } from 'unity-interface/dcl'
 import { StoreContainer } from '../store/rootTypes'
-import { retrieve, store } from 'shared/cache'
 import { ensureRealmInitialized } from 'shared/dao/sagas'
 import { ensureRenderer } from 'shared/renderer/sagas'
-import { isFeatureEnabled } from 'shared/meta/selectors'
-import { FeatureFlags } from 'shared/meta/types'
 import { CatalystClient, OwnedWearablesWithDefinition } from 'dcl-catalyst-client'
 import { fetchJson } from 'dcl-catalyst-commons'
 import { getCatalystServer, getFetchContentServer } from 'shared/dao/selectors'
@@ -75,62 +61,10 @@ export function* catalogsSaga(): any {
   yield takeEvery(WEARABLES_FAILURE, handleWearablesFailure)
 }
 
-function overrideBaseUrl(wearable: PartialWearableV2): PartialWearableV2 {
-  if (!TEST_WEARABLES_OVERRIDE) {
-    return {
-      ...wearable,
-      baseUrl: getWearablesSafeURL() + '/contents/'
-    }
-  } else {
-    return wearable
-  }
-}
-
 function* initialLoad() {
   yield call(ensureRealmInitialized)
 
-  const shouldUseV2 = yield select(isFeatureEnabled, FeatureFlags.WEARABLES_V2, false)
-
-  if (WORLD_EXPLORER && !shouldUseV2) {
-    try {
-      const catalogUrl = getServerConfigurations().avatar.catalog
-
-      let collections: Collection[] | undefined
-      if (globalThis.location.search.match(/TEST_WEARABLES/)) {
-        collections = [{ id: 'all', wearables: (yield call(fetchCatalog, catalogUrl))[0] }]
-      } else {
-        const cached = yield retrieve('catalog')
-
-        if (cached) {
-          const version = yield headCatalog(catalogUrl)
-          if (cached.version === version) {
-            collections = cached.data
-          }
-        }
-
-        if (!collections) {
-          const response = yield call(fetchCatalog, catalogUrl)
-          collections = response[0]
-
-          const version = response[1]
-          if (version) {
-            yield store('catalog', { version, data: response[0] })
-          }
-        }
-      }
-      const catalog: PartialWearableV2[] = collections!
-        .reduce((flatten, collection) => flatten.concat(collection.wearables), [] as Wearable[])
-        .filter((wearable) => !!wearable)
-        .map(mapV1WearableIntoV2)
-        .map(overrideBaseUrl)
-      const baseAvatars = catalog.filter((_: PartialWearableV2) => _.data.tags && !_.data.tags.includes('exclusive'))
-      const baseExclusive = catalog.filter((_: PartialWearableV2) => _.data.tags && _.data.tags.includes('exclusive'))
-      yield put(catalogLoaded('base-avatars', baseAvatars))
-      yield put(catalogLoaded('base-exclusive', baseExclusive))
-    } catch (error) {
-      defaultLogger.error('[FATAL]: Could not load catalog!', error)
-    }
-  } else if (!WORLD_EXPLORER) {
+  if (!WORLD_EXPLORER) {
     let baseCatalog = []
     try {
       const catalogPath = '/default-profile/basecatalog.json'
@@ -156,12 +90,12 @@ export function* handleWearablesRequest(action: WearablesRequest) {
   const valid = areFiltersValid(filters)
   if (valid) {
     try {
-      const shouldUseV2 = WORLD_EXPLORER && (yield select(isFeatureEnabled, FeatureFlags.WEARABLES_V2, false))
+      const shouldUseLocalCatalog = WORLD_EXPLORER
       const downloadUrl = yield select(getFetchContentServer)
 
-      const response: PartialWearableV2[] = shouldUseV2
-        ? yield call(fetchWearablesV2, filters)
-        : yield call(fetchWearablesV1, filters)
+      const response: PartialWearableV2[] = shouldUseLocalCatalog
+        ? yield call(fetchWearablesFromCatalyst, filters)
+        : yield call(fetchWearablesFromLocalCatalog, filters)
 
       const v2Wearables: WearableV2[] = response.map((wearable) => ({
         ...wearable,
@@ -178,7 +112,7 @@ export function* handleWearablesRequest(action: WearablesRequest) {
   }
 }
 
-function* fetchWearablesV2(filters: WearablesRequestFilters) {
+function* fetchWearablesFromCatalyst(filters: WearablesRequestFilters) {
   const catalystUrl = yield select(getCatalystServer)
   const client: CatalystClient = new CatalystClient(catalystUrl, 'EXPLORER')
 
@@ -267,41 +201,6 @@ function mapUnpublishedWearableIntoCatalystWearable(wearable: UnpublishedWearabl
   }
 }
 
-function mapV1WearableIntoV2(wearable: Wearable): PartialWearableV2 {
-  const {
-    category,
-    tags,
-    hides,
-    replaces,
-    representations,
-    id,
-    rarity,
-    i18n,
-    thumbnail,
-    baseUrl,
-    description
-  } = wearable
-  return {
-    id: mapLegacyIdToUrn(id),
-    rarity,
-    i18n,
-    thumbnail,
-    description,
-    data: {
-      category,
-      tags,
-      hides,
-      replaces,
-      representations: representations.map(({ bodyShapes, contents, ...other }) => ({
-        ...other,
-        bodyShapes: mapLegacyIdsToUrn(bodyShapes),
-        contents: contents.map(({ file, hash }) => ({ key: file, hash }))
-      }))
-    },
-    baseUrl
-  }
-}
-
 function mapCatalystRepresentationIntoV2(representation: any): BodyShapeRepresentationV2 {
   const { contents, ...other } = representation
 
@@ -340,50 +239,15 @@ function mapCatalystWearableIntoV2(v2Wearable: any): PartialWearableV2 {
   }
 }
 
-export function mapLegacyIdsToUrn(wearableIds: WearableId[]): WearableId[] {
-  return wearableIds.map(mapLegacyIdToUrn)
-}
-
-export function mapLegacyIdToUrn(wearableId: WearableId): WearableId {
-  if (!wearableId.startsWith('dcl://')) {
-    return wearableId
-  }
-  if (wearableId.startsWith('dcl://base-avatars')) {
-    const name = wearableId.substring(wearableId.lastIndexOf('/') + 1)
-    return `urn:decentraland:off-chain:base-avatars:${name}`
-  } else {
-    const [collectionName, wearableName] = wearableId.replace('dcl://', '').split('/')
-    return `urn:decentraland:ethereum:collections-v1:${collectionName}:${wearableName}`
-  }
-}
-
-function* fetchWearablesV1(filters: WearablesRequestFilters) {
+function* fetchWearablesFromLocalCatalog(filters: WearablesRequestFilters) {
   yield call(ensureBaseCatalogs)
 
   const platformCatalog = yield select(getPlatformCatalog)
-  const exclusiveCatalog = yield select(getExclusiveCatalog)
 
   let response: PartialWearableV2[]
   if (filters.wearableIds) {
     // Filtering by ids
-    response = filters.wearableIds
-      .map((wearableId) =>
-        wearableId === 'urn:decentraland:off-chain:base-avatars:SchoolShoes'
-          ? 'urn:decentraland:off-chain:base-avatars:Moccasin'
-          : wearableId
-      )
-      .map((wearableId) =>
-        wearableId.includes(`base-avatars`) ? platformCatalog[wearableId] : exclusiveCatalog[wearableId]
-      )
-      .filter((wearable) => !!wearable)
-  } else if (filters.ownedByUser) {
-    // Only owned wearables
-    if (ALL_WEARABLES) {
-      response = Object.values(exclusiveCatalog)
-    } else {
-      const inventoryItemIds: WearableId[] = yield call(fetchInventoryItemsByAddress, filters.ownedByUser)
-      response = inventoryItemIds.map((id) => exclusiveCatalog[id]).filter((wearable) => !!wearable)
-    }
+    response = filters.wearableIds.map((wearableId) => platformCatalog[wearableId]).filter((wearable) => !!wearable)
   } else if (filters.collectionIds) {
     // We assume that the only collection id used is base-avatars
     response = Object.values(platformCatalog)
@@ -430,23 +294,6 @@ function areFiltersValid(filters: WearablesRequestFilters) {
   return filtersSet === 1 && ok
 }
 
-async function headCatalog(url: string) {
-  const request = await fetch(url, { method: 'HEAD' })
-  if (!request.ok) {
-    throw new Error('Catalog not found')
-  }
-  return request.headers.get('etag')
-}
-
-async function fetchCatalog(url: string) {
-  const request = await fetch(url)
-  if (!request.ok) {
-    throw new Error('Catalog not found')
-  }
-  const etag = request.headers.get('etag')
-  return [await request.json(), etag]
-}
-
 export function informRequestFailure(error: string, context: string | undefined) {
   globalThis.unityInterface.WearablesRequestFailed(error, context)
 }
@@ -456,23 +303,7 @@ export function sendWearablesCatalog(wearables: WearableV2[], context: string | 
 }
 
 export function* ensureBaseCatalogs() {
-  const shouldUseV2: boolean =
-    WORLD_EXPLORER && isFeatureEnabled(globalThis.globalStore.getState(), FeatureFlags.WEARABLES_V2, false)
-
-  while (!shouldUseV2 && !(yield select(baseCatalogsLoaded))) {
+  while (!WORLD_EXPLORER && !(yield select(baseCatalogsLoaded))) {
     yield take(CATALOG_LOADED)
   }
-}
-
-export async function fetchInventoryItemsByAddress(address: string): Promise<WearableId[]> {
-  if (!WORLD_EXPLORER) {
-    return []
-  }
-  const result = await fetch(`${getServerConfigurations().wearablesApi}/addresses/${address}/wearables?fields=id`)
-  if (!result.ok) {
-    throw new Error('Unable to fetch inventory for address ' + address)
-  }
-  const inventory: { id: string }[] = await result.json()
-
-  return mapLegacyIdsToUrn(inventory.map((wearable) => wearable.id))
 }

--- a/kernel/packages/shared/catalogs/selectors.ts
+++ b/kernel/packages/shared/catalogs/selectors.ts
@@ -8,17 +8,8 @@ export const getPlatformCatalog = (store: RootCatalogState): Record<WearableId, 
     ? store.catalogs.catalogs['base-avatars'].data!
     : null
 
-export const getExclusiveCatalog = (store: RootCatalogState): Record<WearableId, PartialWearableV2> | null =>
-  store.catalogs.catalogs &&
-  store.catalogs.catalogs['base-exclusive'] &&
-  store.catalogs.catalogs['base-exclusive'].status === 'ok'
-    ? store.catalogs.catalogs['base-exclusive'].data!
-    : null
-
 export const baseCatalogsLoaded = (store: RootCatalogState) =>
   store.catalogs &&
   store.catalogs.catalogs &&
   store.catalogs.catalogs['base-avatars'] &&
-  store.catalogs.catalogs['base-avatars'].status === 'ok' &&
-  store.catalogs.catalogs['base-exclusive'] &&
-  store.catalogs.catalogs['base-exclusive'].status === 'ok'
+  store.catalogs.catalogs['base-avatars'].status === 'ok'

--- a/kernel/packages/shared/meta/types.ts
+++ b/kernel/packages/shared/meta/types.ts
@@ -62,7 +62,6 @@ export type CommsConfig = {
 }
 
 export enum FeatureFlags {
-  WEARABLES_V2 = 'wearables_v2',
   QUESTS = 'quests',
   BUILDER_IN_WORLD = 'builder_in_world'
 }

--- a/kernel/packages/shared/profiles/sagas.ts
+++ b/kernel/packages/shared/profiles/sagas.ts
@@ -3,7 +3,7 @@ import { EntityType, Hashing } from 'dcl-catalyst-commons'
 import { CatalystClient, ContentClient, DeploymentData } from 'dcl-catalyst-client'
 import { call, throttle, put, select, takeEvery } from 'redux-saga/effects'
 
-import { getServerConfigurations, PREVIEW, ethereumConfigurations, RESET_TUTORIAL, ALL_WEARABLES } from 'config'
+import { getServerConfigurations, PREVIEW, ethereumConfigurations, RESET_TUTORIAL } from 'config'
 
 import defaultLogger from 'shared/logger'
 import {
@@ -53,12 +53,6 @@ import { RootState } from 'shared/store/rootTypes'
 import { requestLocalProfileToPeers, updateCommsUser } from 'shared/comms'
 import { ensureRealmInitialized } from 'shared/dao/sagas'
 import { ensureRenderer } from 'shared/renderer/sagas'
-import {
-  ensureBaseCatalogs,
-  fetchInventoryItemsByAddress,
-  mapLegacyIdToUrn,
-  mapLegacyIdsToUrn
-} from 'shared/catalogs/sagas'
 import { base64ToBlob } from 'atomicHelpers/base64ToBlob'
 import { LocalProfilesRepository } from './LocalProfilesRepository'
 import { getProfileType } from './getProfileType'
@@ -66,9 +60,6 @@ import { BringDownClientAndShowError, ErrorContext, ReportFatalError } from 'sha
 import { UNEXPECTED_ERROR } from 'shared/loading/types'
 import { fetchParcelsWithAccess } from './fetchLand'
 import { ParcelsWithAccess } from 'decentraland-ecs/src'
-import { WearableId } from 'shared/types'
-import { isFeatureEnabled } from 'shared/meta/selectors'
-import { FeatureFlags } from 'shared/meta/types'
 
 const toBuffer = require('blob-to-buffer')
 
@@ -257,19 +248,6 @@ export function* handleFetchProfile(action: ProfileRequestAction): any {
 
   const passport: Profile = yield call(processServerProfile, userId, profile)
 
-  const shouldUseV2: boolean = yield select(isFeatureEnabled, FeatureFlags.WEARABLES_V2, false)
-
-  if (!ALL_WEARABLES && WORLD_EXPLORER && !shouldUseV2) {
-    try {
-      const inventory: WearableId[] = yield call(fetchInventoryItemsByAddress, userId)
-      passport.avatar.wearables = passport.avatar.wearables.filter(
-        (wearableId) => wearableId.includes('base-avatars') || inventory.includes(wearableId)
-      )
-    } catch (e) {
-      defaultLogger.error(`Failed to fetch inventory to filter owned wearables`)
-    }
-  }
-
   yield put(profileSuccess(userId, passport, hasConnectedWeb3))
 }
 
@@ -314,27 +292,11 @@ function* populateFaceIfNecessary(profile: any, resolution: string) {
   }
 }
 
-export async function profileServerRequest(userId: string) {
+export function profileServerRequest(userId: string) {
   const state = globalThis.globalStore.getState()
   const catalystUrl = getCatalystServer(state)
-  const shouldUseV2: boolean = WORLD_EXPLORER && isFeatureEnabled(state, FeatureFlags.WEARABLES_V2, false)
-  let profile: any
-  if (shouldUseV2) {
-    const client = new CatalystClient(catalystUrl, 'EXPLORER')
-    profile = await client.fetchProfiles([userId]).then((profiles) => profiles[0] ?? { avatars: [] })
-  } else {
-    const response = await fetch(`${catalystUrl}/lambdas/profile/${userId}`)
-    profile = await response.json()
-    const avatar = profile?.avatars[0]?.avatar
-    if (avatar?.bodyShape) {
-      avatar.bodyShape = mapLegacyIdToUrn(avatar.bodyShape)
-    }
-
-    if (avatar?.wearables) {
-      avatar.wearables = mapLegacyIdsToUrn(avatar.wearables)
-    }
-  }
-  return profile
+  const client = new CatalystClient(catalystUrl, 'EXPLORER')
+  return client.fetchProfiles([userId]).then((profiles) => profiles[0] ?? { avatars: [] })
 }
 
 function* handleRandomAsSuccess(action: ProfileRandomAction): any {
@@ -366,7 +328,6 @@ function* submitProfileToRenderer(action: ProfileSuccessAction): any {
   }
 
   yield call(ensureRenderer)
-  yield call(ensureBaseCatalogs)
   if ((yield select(getCurrentUserId)) === action.payload.userId) {
     yield call(sendLoadProfile, profile)
   } else {
@@ -380,8 +341,6 @@ function* submitProfileToRenderer(action: ProfileSuccessAction): any {
 }
 
 function* sendLoadProfile(profile: Profile) {
-  yield call(ensureBaseCatalogs)
-
   const identity = yield select(getCurrentIdentity)
   const parcels: ParcelsWithAccess = !identity.hasConnectedWeb3 ? [] : yield fetchParcelsWithAccess(identity.address)
   const rendererFormat = profileToRendererFormat(profile, { identity, parcels })

--- a/kernel/packages/shared/session/sagas.ts
+++ b/kernel/packages/shared/session/sagas.ts
@@ -69,7 +69,6 @@ import { generateRandomUserProfile } from '../profiles/generateRandomUserProfile
 import { unityInterface } from '../../unity-interface/UnityInterface'
 import { getSignUpIdentity, getSignUpProfile } from './selectors'
 import { ensureRealmInitialized } from '../dao/sagas'
-import { ensureBaseCatalogs } from '../catalogs/sagas'
 import { saveProfileRequest } from '../profiles/actions'
 import { Profile } from '../profiles/types'
 
@@ -208,7 +207,6 @@ function* showAvatarEditor() {
 
   const profile: Partial<Profile> = yield select(getSignUpProfile)
 
-  yield ensureBaseCatalogs()
   // TODO: Fix as any
   unityInterface.LoadProfile(profile as any)
   unityInterface.ShowAvatarEditorInSignIn()

--- a/kernel/test/unit/catalog.saga.test.tsx
+++ b/kernel/test/unit/catalog.saga.test.tsx
@@ -1,11 +1,9 @@
 import { expectSaga } from 'redux-saga-test-plan'
 import { call, select } from 'redux-saga/effects'
-import { BASE_AVATARS_COLLECTION_ID, fetchInventoryItemsByAddress, handleWearablesFailure, handleWearablesRequest, handleWearablesSuccess, informRequestFailure, sendWearablesCatalog, WRONG_FILTERS_ERROR } from 'shared/catalogs/sagas'
+import { handleWearablesFailure, handleWearablesRequest, handleWearablesSuccess, informRequestFailure, sendWearablesCatalog, WRONG_FILTERS_ERROR } from 'shared/catalogs/sagas'
 import { wearablesFailure, wearablesRequest, wearablesSuccess } from 'shared/catalogs/actions'
-import { baseCatalogsLoaded, getExclusiveCatalog, getPlatformCatalog } from 'shared/catalogs/selectors'
+import { baseCatalogsLoaded, getPlatformCatalog } from 'shared/catalogs/selectors'
 import { ensureRenderer } from 'shared/renderer/sagas'
-import { throwError } from 'redux-saga-test-plan/providers'
-import { getFetchContentServer } from 'shared/dao/selectors'
 
 const serverUrl = 'https://server.com'
 const wearableId1 = 'WearableId1'
@@ -16,46 +14,6 @@ const context = 'someContext'
 
 
 describe('Wearables Saga', () => {
-
-  it('When a wearable is requested by id, then it is returned successfully', () => {
-    return expectSaga(handleWearablesRequest, wearablesRequest({ wearableIds: [wearableId1] }, context))
-      .put(wearablesSuccess([wearable1], context))
-      .provide([
-        [select(getFetchContentServer), serverUrl],
-        [select(baseCatalogsLoaded), true],
-        [select(getPlatformCatalog), {}],
-        [select(getExclusiveCatalog), { [wearableId1]: wearable1 }],
-      ])
-      .run()
-  })
-
-  it('When all owned wearables are requested, then they are returned successfully', () => {
-    const wearables = [wearable1]
-    return expectSaga(handleWearablesRequest, wearablesRequest({ ownedByUser: userId }, context))
-      .put(wearablesSuccess(wearables, context))
-      .provide([
-        [select(getFetchContentServer), serverUrl],
-        [select(baseCatalogsLoaded), true],
-        [select(getPlatformCatalog), {}],
-        [select(getExclusiveCatalog), { [wearableId1]: wearable1 }],
-        [call(fetchInventoryItemsByAddress, userId), Promise.resolve([wearableId1])],
-      ])
-      .run()
-  })
-
-  it('When base avatars are requested, then they are returned successfully', () => {
-    const baseWearables = [wearable1]
-    return expectSaga(handleWearablesRequest, wearablesRequest({ collectionIds: [BASE_AVATARS_COLLECTION_ID] }, context))
-      .put(wearablesSuccess(baseWearables, context))
-      .provide([
-        [select(getFetchContentServer), serverUrl],
-        [select(baseCatalogsLoaded), true],
-        [select(getPlatformCatalog), { [wearableId1]: wearable1 }],
-        [select(getExclusiveCatalog), {}],
-      ])
-      .run()
-  })
-
 
   it('When wearables fetch is successful, then it is sent to the renderer with the same context', () => {
     const wearables = [wearable1]
@@ -68,28 +26,12 @@ describe('Wearables Saga', () => {
       .run()
   })
 
-  it('When wearables fetch fails to load, then the request fails', () => {
-    const errorMessage = 'Something failed'
-    const error = new Error(errorMessage)
-    return expectSaga(handleWearablesRequest, wearablesRequest({ ownedByUser: userId }, context))
-      .put(wearablesFailure(context, errorMessage))
-      .provide([
-        [select(getFetchContentServer), serverUrl],
-        [select(baseCatalogsLoaded), true],
-        [select(getPlatformCatalog), {}],
-        [select(getExclusiveCatalog), {}],
-        [call(fetchInventoryItemsByAddress, userId), throwError(error)],
-      ])
-      .run()
-  })
-
   it('When more than one filter is set, then the request fails', () => {
     return expectSaga(handleWearablesRequest, wearablesRequest({ wearableIds: ['some-id'], ownedByUser: userId }, context))
       .put(wearablesFailure(context, WRONG_FILTERS_ERROR))
       .provide([
         [select(baseCatalogsLoaded), true],
         [select(getPlatformCatalog), {}],
-        [select(getExclusiveCatalog), {}],
       ])
       .run()
   })

--- a/kernel/test/unit/profiles.saga.test.tsx
+++ b/kernel/test/unit/profiles.saga.test.tsx
@@ -12,7 +12,6 @@ import { PROFILE_SUCCESS } from '../../packages/shared/profiles/actions'
 import { isRealmInitialized, getResizeService } from '../../packages/shared/dao/selectors'
 import { getServerConfigurations } from 'config'
 import { sleep } from 'atomicHelpers/sleep'
-import { fetchInventoryItemsByAddress } from 'shared/catalogs/sagas'
 
 const profile = { data: 'profile' }
 
@@ -35,7 +34,6 @@ describe('fetchProfile behavior', () => {
       .provide([
         [select(isRealmInitialized), true],
         [call(profileServerRequest, 'user|1'), delayedProfile],
-        [call(fetchInventoryItemsByAddress, 'user|1'), []],
         [select(getCurrentUserId), 'myid'],
         [call(processServerProfile, 'user|1', profile), 'passport']
       ])
@@ -58,9 +56,7 @@ describe('fetchProfile behavior', () => {
         [select(getCurrentUserId), 'myid'],
         [call(processServerProfile, 'user|1', profile), 'passport1'],
         [call(profileServerRequest, 'user|2'), delayedProfile],
-        [call(fetchInventoryItemsByAddress, 'user|1'), []],
         [call(processServerProfile, 'user|2', profile), 'passport2'],
-        [call(fetchInventoryItemsByAddress, 'user|2'), []],
       ])
       .run()
   })
@@ -72,7 +68,6 @@ describe('fetchProfile behavior', () => {
       .provide([
         [select(getCurrentUserId), 'myid'],
         [select(getResizeService), 'http://fake/resizeurl'],
-        [call(fetchInventoryItemsByAddress, 'user|1'), []],
         [matchers.call.fn(fetch), dynamic(() => ({ ok: true }))],
         [call(profileServerRequest, 'user|1'), delayed({ avatars: [profile1] })],
         [call(processServerProfile, 'user|1', profile1), dynamic((effect) => effect.args[1])]
@@ -99,7 +94,6 @@ describe('fetchProfile behavior', () => {
       .provide([
         [select(getCurrentUserId), 'myid'],
         [select(getResizeService), 'http://fake/resizeurl'],
-        [call(fetchInventoryItemsByAddress, 'user|1'), []],
         [matchers.call.fn(fetch), dynamic(() => ({ ok: true }))],
         [call(profileServerRequest, 'user|1'), delayed({ avatars: [profile1] })],
         [call(processServerProfile, 'user|1', profile1), dynamic((effect) => effect.args[1])]
@@ -126,7 +120,6 @@ describe('fetchProfile behavior', () => {
       .provide([
         [select(getCurrentUserId), 'myid'],
         [select(getResizeService), 'http://fake/resizeurl'],
-        [call(fetchInventoryItemsByAddress, 'user|1'), []],
         [matchers.call.fn(fetch), dynamic((call) => ({ ok: !call.args[0].startsWith('http://fake/resizeurl') }))],
         [call(profileServerRequest, 'user|1'), delayed({ avatars: [profile1] })],
         [call(processServerProfile, 'user|1', profile1), dynamic((effect) => effect.args[1])]


### PR DESCRIPTION
We are now removing all code that loaded wearables from the old wearable api. Catalysts will be used at all times now.