### PR TITLE
refactor: use content server directly

### DIFF
--- a/kernel/packages/decentraland-loader/lifecycle/controllers/EmptyParcelController.ts
+++ b/kernel/packages/decentraland-loader/lifecycle/controllers/EmptyParcelController.ts
@@ -12,7 +12,6 @@ export class EmptyParcelController {
     public options: {
       contentServer: string
       catalystServer: string
-      metaContentService: string
       contentServerBundles: string
       worldConfig: WorldConfig
       rootUrl: string

--- a/kernel/packages/decentraland-loader/lifecycle/controllers/download.ts
+++ b/kernel/packages/decentraland-loader/lifecycle/controllers/download.ts
@@ -32,7 +32,6 @@ export class SceneDataDownloadManager {
     public options: {
       contentServer: string
       catalystServer: string
-      metaContentService: string
       contentServerBundles: string
       worldConfig: WorldConfig
       rootUrl: string

--- a/kernel/packages/decentraland-loader/lifecycle/manager.ts
+++ b/kernel/packages/decentraland-loader/lifecycle/manager.ts
@@ -11,7 +11,7 @@ import { resolveUrl } from 'atomicHelpers/parseUrl'
 import { DEBUG, parcelLimits, getServerConfigurations, ENABLE_EMPTY_SCENES, LOS, PIN_CATALYST } from 'config'
 
 import { ILand } from 'shared/types'
-import { getFetchContentServer, getCatalystServer, getFetchMetaContentService } from 'shared/dao/selectors'
+import { getFetchContentServer, getCatalystServer } from 'shared/dao/selectors'
 import defaultLogger from 'shared/logger'
 import { StoreContainer } from 'shared/store/rootTypes'
 
@@ -127,7 +127,6 @@ export async function initParcelSceneWorker() {
   server.notify('Lifecycle.initialize', {
     contentServer: DEBUG ? localServer : getFetchContentServer(state),
     catalystServer: DEBUG ? localServer : getCatalystServer(state),
-    metaContentService: DEBUG ? localServer : getFetchMetaContentService(state),
     contentServerBundles: DEBUG || PIN_CATALYST ? '' : getServerConfigurations().contentAsBundle + '/',
     rootUrl: fullRootUrl,
     lineOfSightRadius: LOS ? Number.parseInt(LOS, 10) : parcelLimits.visibleRadius,

--- a/kernel/packages/decentraland-loader/lifecycle/worker.ts
+++ b/kernel/packages/decentraland-loader/lifecycle/worker.ts
@@ -40,7 +40,6 @@ let downloadManager: SceneDataDownloadManager
     (options: {
       contentServer: string
       catalystServer: string
-      metaContentService: string
       contentServerBundles: string
       rootUrl: string
       lineOfSightRadius: number
@@ -50,7 +49,6 @@ let downloadManager: SceneDataDownloadManager
       downloadManager = new SceneDataDownloadManager({
         contentServer: options.contentServer,
         catalystServer: options.catalystServer,
-        metaContentService: options.metaContentService,
         contentServerBundles: options.contentServerBundles,
         worldConfig: options.worldConfig,
         rootUrl: options.rootUrl

--- a/kernel/packages/shared/dao/reducer.ts
+++ b/kernel/packages/shared/dao/reducer.ts
@@ -119,7 +119,7 @@ export function daoReducer(state?: DaoState, action?: AnyAction): DaoState {
 function realmProperties(realm: Realm, configOverride: boolean = true): Partial<DaoState> {
   const domain = realm.domain
   return {
-    fetchContentServer: FETCH_CONTENT_SERVICE && configOverride ? FETCH_CONTENT_SERVICE : domain + '/lambdas/contentv2',
+    fetchContentServer: FETCH_CONTENT_SERVICE && configOverride ? FETCH_CONTENT_SERVICE : domain + '/content',
     catalystServer: domain,
     updateContentServer: UPDATE_CONTENT_SERVICE && configOverride ? UPDATE_CONTENT_SERVICE : domain + '/content',
     commsServer: COMMS_SERVICE && configOverride ? COMMS_SERVICE : domain + '/comms',
@@ -150,7 +150,7 @@ function ensureContentWhitelist(state: Partial<DaoState>, contentWhitelist: Cand
   const { domain } = contentWhitelist[0]
   return {
     ...state,
-    fetchContentServer: FETCH_CONTENT_SERVICE ? FETCH_CONTENT_SERVICE : domain + '/lambdas/contentv2'
+    fetchContentServer: FETCH_CONTENT_SERVICE ? FETCH_CONTENT_SERVICE : domain + '/content'
   }
 }
 

--- a/kernel/packages/shared/dao/selectors.ts
+++ b/kernel/packages/shared/dao/selectors.ts
@@ -5,7 +5,6 @@ export const getUpdateProfileServer = (store: RootDaoState) => store.dao.updateC
 
 export const getFetchContentServer = (store: RootDaoState) => store.dao.fetchContentServer
 export const getCatalystServer = (store: RootDaoState) => store.dao.catalystServer
-export const getFetchMetaContentService = (store: RootDaoState) => store.dao.catalystServer + '/lambdas/contentv2'
 export const getResizeService = (store: RootDaoState) => store.dao.resizeService
 
 export const getCommsServer = (store: RootDaoState) => store.dao.commsServer


### PR DESCRIPTION
This PR does two things:
1. Deletes the `metaContentService`, which wasn't being used at all
2. The `fetchContentServer` will use the content server directly, instead of using the `/contentv2` lambdas. The use of this lambda is no longer necessary, since now all content (including wearables) can be found on the content server