### PR TITLE
chore: preload unity while signing

### DIFF
--- a/kernel/packages/shared/ethereum/provider.ts
+++ b/kernel/packages/shared/ethereum/provider.ts
@@ -40,7 +40,7 @@ export function getEthConnector(): EthereumConnector {
 
 export async function requestProvider(type: ProviderType | null) {
   try {
-    const { provider } = await ethConnector.connect(type)
+    const { provider } = await getEthConnector().connect(type)
     requestManager.setProvider(provider)
     providerFuture.resolve({
       successful: !isGuest(),
@@ -56,7 +56,7 @@ export async function requestProvider(type: ProviderType | null) {
 }
 
 export function isGuest(): boolean {
-  return ethConnector.isGuest()
+  return getEthConnector().isGuest()
 }
 
 export function getProviderType() {

--- a/kernel/packages/shared/session/sagas.ts
+++ b/kernel/packages/shared/session/sagas.ts
@@ -72,7 +72,7 @@ import { ensureRealmInitialized } from '../dao/sagas'
 import { ensureBaseCatalogs } from '../catalogs/sagas'
 import { saveProfileRequest } from '../profiles/actions'
 import { Profile } from '../profiles/types'
-import {ensureUnityInterface} from "../renderer";
+import { ensureUnityInterface } from "../renderer"
 
 const TOS_KEY = 'tos'
 const logger = createLogger('session: ')

--- a/kernel/packages/shared/session/sagas.ts
+++ b/kernel/packages/shared/session/sagas.ts
@@ -72,6 +72,7 @@ import { ensureRealmInitialized } from '../dao/sagas'
 import { ensureBaseCatalogs } from '../catalogs/sagas'
 import { saveProfileRequest } from '../profiles/actions'
 import { Profile } from '../profiles/types'
+import {ensureUnityInterface} from "../renderer";
 
 const TOS_KEY = 'tos'
 const logger = createLogger('session: ')
@@ -208,6 +209,7 @@ function* showAvatarEditor() {
 
   const profile: Partial<Profile> = yield select(getSignUpProfile)
 
+  yield ensureUnityInterface()
   yield ensureBaseCatalogs()
   // TODO: Fix as any
   unityInterface.LoadProfile(profile as any)

--- a/kernel/packages/shared/session/sagas.ts
+++ b/kernel/packages/shared/session/sagas.ts
@@ -184,6 +184,7 @@ function isGuestWithProfile(session: StoredSession) {
 }
 
 function* startSignUp(userId: string, identity: ExplorerIdentity) {
+  yield ensureUnityInterface()
   yield put(signUpSetIsSignUp(true))
   let prevGuest = fetchProfileLocally(userId)
   let profile: Profile = prevGuest ? prevGuest : yield generateRandomUserProfile(userId)
@@ -208,7 +209,6 @@ function* showAvatarEditor() {
 
   const profile: Partial<Profile> = yield select(getSignUpProfile)
 
-  yield ensureUnityInterface()
   // TODO: Fix as any
   unityInterface.LoadProfile(profile as any)
   unityInterface.ShowAvatarEditorInSignIn()

--- a/website/src/components/auth/EthLogin.stories.tsx
+++ b/website/src/components/auth/EthLogin.stories.tsx
@@ -5,7 +5,6 @@ import { EthLogin, EthLoginProps } from "./EthLogin";
 export default {
   title: "Explorer/auth/EthLogin",
   args: {
-    loading: false,
     provider: null,
     hasMetamask: true,
   },
@@ -28,12 +27,10 @@ LoginHome.args = {
 
 export const LoginSigning = Template.bind({});
 LoginSigning.args = {
-  ...Template.args,
-  loading: true,
+  ...Template.args
 };
 
 export const LoginPreviousSession = Template.bind({});
 LoginPreviousSession.args = {
-  ...Template.args,
-  loading: false,
+  ...Template.args
 };

--- a/website/src/components/auth/EthLogin.tsx
+++ b/website/src/components/auth/EthLogin.tsx
@@ -8,15 +8,13 @@ import { track } from "../../utils"
 import "./EthLogin.css"
 
 export interface EthLoginProps {
-  loading: boolean
   availableProviders: ProviderType[]
   onLogin: (provider: ProviderType | null) => void
   signing: boolean
 }
 
 export const EthLogin: React.FC<EthLoginProps> = (props) => {
-  const [showWalletSelector, setShowWalletSelector] = useState(false)
-  const isLoading = props.loading || showWalletSelector
+  const [showWalletSelector, setShowWalletSelector] = useState(false)  
 
   function handlePlay() {
     track('open_login_popup')
@@ -39,7 +37,7 @@ export const EthLogin: React.FC<EthLoginProps> = (props) => {
       <LoginHeader />
       <Avatars />
       <div id="eth-login-confirmation-wrapper">
-        {isLoading && props.signing && <Spinner />}
+        {props.signing && <Spinner />}
         {!props.signing && (
           <React.Fragment>
             <button className="eth-login-confirm-button" onClick={handlePlay}>

--- a/website/src/components/auth/EthLogin.tsx
+++ b/website/src/components/auth/EthLogin.tsx
@@ -53,6 +53,7 @@ export const EthLogin: React.FC<EthLoginProps> = (props) => {
       </div>
       <WalletSelector
         open={showWalletSelector}
+        loading={props.signing}
         onLogin={handleLogin}
         availableProviders={props.availableProviders}
         onCancel={() => setShowWalletSelector(false)}

--- a/website/src/components/auth/EthLogin.tsx
+++ b/website/src/components/auth/EthLogin.tsx
@@ -11,6 +11,7 @@ export interface EthLoginProps {
   loading: boolean
   availableProviders: ProviderType[]
   onLogin: (provider: ProviderType | null) => void
+  signing: boolean
 }
 
 export const EthLogin: React.FC<EthLoginProps> = (props) => {
@@ -38,8 +39,8 @@ export const EthLogin: React.FC<EthLoginProps> = (props) => {
       <LoginHeader />
       <Avatars />
       <div id="eth-login-confirmation-wrapper">
-        {isLoading && <Spinner />}
-        {!isLoading && (
+        {isLoading && props.signing && <Spinner />}
+        {!props.signing && (
           <React.Fragment>
             <button className="eth-login-confirm-button" onClick={handlePlay}>
               Play
@@ -52,7 +53,6 @@ export const EthLogin: React.FC<EthLoginProps> = (props) => {
       </div>
       <WalletSelector
         open={showWalletSelector}
-        loading={props.loading}
         onLogin={handleLogin}
         availableProviders={props.availableProviders}
         onCancel={() => setShowWalletSelector(false)}

--- a/website/src/components/auth/LoginContainer.tsx
+++ b/website/src/components/auth/LoginContainer.tsx
@@ -68,9 +68,10 @@ export const LoginContainer: React.FC<LoginContainerProps> = (props) => {
             <Container className="eth-login-popup">
               {full && (
                 <EthLogin
-                  loading={loading || props.signing}
+                  loading={loading}
                   availableProviders={props.availableProviders}
                   onLogin={props.onLogin}
+                  signing={props.signing}
                 />
               )}
               {props.stage === LoginStage.CONNECT_ADVICE && <EthConnectAdvice onLogin={props.onLogin} />}

--- a/website/src/components/auth/LoginContainer.tsx
+++ b/website/src/components/auth/LoginContainer.tsx
@@ -68,7 +68,6 @@ export const LoginContainer: React.FC<LoginContainerProps> = (props) => {
             <Container className="eth-login-popup">
               {full && (
                 <EthLogin
-                  loading={loading}
                   availableProviders={props.availableProviders}
                   onLogin={props.onLogin}
                   signing={props.signing}

--- a/website/src/components/auth/wallet/WalletSelector.tsx
+++ b/website/src/components/auth/wallet/WalletSelector.tsx
@@ -16,7 +16,6 @@ export interface WalletSelectorProps {
 
 export const WalletSelector: React.FC<WalletSelectorProps> = ({
   open,
-  loading,
   availableProviders,
   onLogin,
   onCancel,
@@ -82,8 +81,7 @@ export const WalletSelector: React.FC<WalletSelectorProps> = ({
     >
       <div className="walletSelector">
         <h2 className="walletSelectorTitle">Sign In or Create an Account</h2>
-        {loading && <div className="walletButtonContainer"><Spinner /></div>}
-        {!loading && <div className="walletButtonContainer">
+        {<div className="walletButtonContainer">
           {wallets.map(wallet => (
             <WalletButton
               key={wallet}

--- a/website/src/components/auth/wallet/WalletSelector.tsx
+++ b/website/src/components/auth/wallet/WalletSelector.tsx
@@ -3,10 +3,12 @@ import { ProviderType } from "decentraland-connect";
 import { isCucumberProvider, isDapperProvider } from "decentraland-dapps/dist/lib/eth";
 import { Modal } from "../../common/Modal";
 import { WalletButton, WalletButtonLogo } from "./WalletButton";
+import { Spinner } from "../../common/Spinner";
 import "./WalletSelector.css";
 
 export interface WalletSelectorProps {
   open: boolean;
+  loading: boolean;
   availableProviders: ProviderType[];
   onLogin: (provider: ProviderType | null) => void;
   onCancel: () => void;
@@ -14,6 +16,7 @@ export interface WalletSelectorProps {
 
 export const WalletSelector: React.FC<WalletSelectorProps> = ({
   open,
+  loading,
   availableProviders,
   onLogin,
   onCancel,
@@ -79,7 +82,8 @@ export const WalletSelector: React.FC<WalletSelectorProps> = ({
     >
       <div className="walletSelector">
         <h2 className="walletSelectorTitle">Sign In or Create an Account</h2>
-        {<div className="walletButtonContainer">
+        {loading && <div className="walletButtonContainer"><Spinner /></div>}
+        {!loading && <div className="walletButtonContainer">
           {wallets.map(wallet => (
             <WalletButton
               key={wallet}
@@ -90,7 +94,7 @@ export const WalletSelector: React.FC<WalletSelectorProps> = ({
           ))}
         </div>}
       </div>
-      {<a className="guestSelector" href="#guest" onClick={handleGuestLogin}>
+      {!loading && <a className="guestSelector" href="#guest" onClick={handleGuestLogin}>
         Play as Guest
       </a>}
     </Modal>

--- a/website/src/components/auth/wallet/WalletSelector.tsx
+++ b/website/src/components/auth/wallet/WalletSelector.tsx
@@ -3,7 +3,6 @@ import { ProviderType } from "decentraland-connect";
 import { isCucumberProvider, isDapperProvider } from "decentraland-dapps/dist/lib/eth";
 import { Modal } from "../../common/Modal";
 import { WalletButton, WalletButtonLogo } from "./WalletButton";
-import { Spinner } from "../../common/Spinner";
 import "./WalletSelector.css";
 
 export interface WalletSelectorProps {

--- a/website/src/components/auth/wallet/WalletSelector.tsx
+++ b/website/src/components/auth/wallet/WalletSelector.tsx
@@ -7,7 +7,6 @@ import "./WalletSelector.css";
 
 export interface WalletSelectorProps {
   open: boolean;
-  loading: boolean;
   availableProviders: ProviderType[];
   onLogin: (provider: ProviderType | null) => void;
   onCancel: () => void;
@@ -91,7 +90,7 @@ export const WalletSelector: React.FC<WalletSelectorProps> = ({
           ))}
         </div>}
       </div>
-      {!loading && <a className="guestSelector" href="#guest" onClick={handleGuestLogin}>
+      {<a className="guestSelector" href="#guest" onClick={handleGuestLogin}>
         Play as Guest
       </a>}
     </Modal>


### PR DESCRIPTION
Fix decentraland/explorer#632

Currently we have a spinner blocking any signin interaction until unity is ready. The metrics show users dropping-off without even seeing the signin buttons due to large loading times. 

This PR addresses the situation by allowing the signin process to be started while the Unity build is loading in the background. The spinner now will be visible if after finishing signin Unity is not ready.