### PR TITLE
feat: remove timestamp from analytics

### DIFF
--- a/kernel/packages/shared/analytics.ts
+++ b/kernel/packages/shared/analytics.ts
@@ -82,7 +82,7 @@ export function identifyEmail(email: string, userId?: string) {
 }
 
 export function trackEvent(eventName: string, eventData: Record<string, any>) {
-  const data = { ...eventData, time: new Date().toISOString(), sessionId, version: (window as any)['VERSION'] }
+  const data = { ...eventData, sessionId, version: (window as any)['VERSION'] }
 
   if (DEBUG_ANALYTICS) {
     defaultLogger.info(`Tracking event "${eventName}": `, data)


### PR DESCRIPTION

# What? 

This PR removes the timestamp from all analytics events 

# Why? 

We already have the timestamp in segment 
