### PR TITLE
chore: print changelog on pr releases

### DIFF
--- a/.github/scripts/dump-changelog.sh
+++ b/.github/scripts/dump-changelog.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+add_line_prefix()
+{
+  echo "$(sed 's/^/- /' <<< "${1}")"
+}
+
+echo "## Kernel changelog:"
+KERNEL_CHANGELOG=$(git log --oneline origin/release..HEAD --no-merges --pretty=%s)
+
+add_line_prefix "${KERNEL_CHANGELOG}"
+
+echo " "
+echo "## Unity renderer changelog:"
+
+HEAD_HASH=$(git rev-parse HEAD)
+LAST_RELEASE_HASH=$(git rev-parse origin/release)
+
+HEAD_PACKAGE=$(git show HEAD:kernel/package.json)
+LAST_RELEASE_PACKAGE=$(git show origin/release:kernel/package.json)
+
+HEAD_RENDERER_VERSION=$(jq '."devDependencies"."@dcl/unity-renderer"' <<<"$HEAD_PACKAGE" | tr -dc '0-9.')
+LAST_RELEASE_RENDERER_VERSION=$(jq '."devDependencies"."@dcl/unity-renderer"' <<<"$LAST_RELEASE_PACKAGE" | tr -dc '0-9.')
+
+HEAD_RENDERER_HASH=$(npm view @dcl/unity-renderer@${HEAD_RENDERER_VERSION} commit)
+LAST_RELEASE_RENDERER_HASH=$(npm view @dcl/unity-renderer@${LAST_RELEASE_RENDERER_VERSION} commit)
+
+git remote add renderer https://github.com/decentraland/unity-renderer.git
+git fetch renderer --quiet
+
+RENDERER_CHANGELOG=$(git log renderer/master --oneline ${LAST_RELEASE_RENDERER_HASH}..${HEAD_RENDERER_HASH} --no-merges --pretty=%s)
+
+RENDERER_CHANGELOG=$(add_line_prefix "${RENDERER_CHANGELOG}")
+
+echo "${RENDERER_CHANGELOG// \(#/ \(https://github.com/decentraland/unity-renderer/pull/}"
+
+git remote remove renderer

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -1,0 +1,44 @@
+name: Release Changelog Notification
+
+on:
+  pull_request:
+    types: [ opened, synchronize ]
+    branches:
+      - 'release-*'
+      - 'release'
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get changelog
+        id: get-comment-body
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+          content="$(./.github/scripts/dump-changelog.sh)"
+          content="${content//'%'/'%25'}"
+          content="${content//$'\n'/'%0A'}"
+          content="${content//$'\r'/'%0D'}"
+          echo ::set-output name=changelog::${content}
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Changelog
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            # Changelog
+
+            ${{ steps.get-comment-body.outputs.changelog }}
+          edit-mode: replace

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -2,10 +2,10 @@ name: Release Changelog Notification
 
 on:
   pull_request:
-    types: [ opened, synchronize ]
+    types: [opened, synchronize]
     branches:
-      - 'release-*'
-      - 'release'
+      - "release-*"
+      - "release"
 
 jobs:
   comment:

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -2,10 +2,7 @@ name: Release Changelog Notification
 
 on:
   pull_request:
-    types: [ opened, synchronize ]
-    branches:
-      - 'release-*'
-      - 'release'
+    types: [opened, synchronize]
 
 jobs:
   comment:

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -27,7 +27,7 @@ jobs:
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
+          comment-author: "github-actions[bot]"
           body-includes: Changelog
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@v1

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -2,7 +2,10 @@ name: Release Changelog Notification
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [ opened, synchronize ]
+    branches:
+      - 'release-*'
+      - 'release'
 
 jobs:
   comment:


### PR DESCRIPTION
Close decentraland/unity-renderer#586

# What? <!-- what is this PR? -->
Add a GitHub Action that comment the releases with the Changelog of `explorer` and `unity-renderer`.

# Test
See last github-actions comment