### PR TITLE
fix: Deactivate errors reporting after client down

### DIFF
--- a/kernel/packages/entryPoints/website.ts
+++ b/kernel/packages/entryPoints/website.ts
@@ -86,13 +86,13 @@ namespace webApp {
       await loadWebsiteSystems()
     } catch (err) {
       document.body.classList.remove('dcl-loading')
+      ReportFatalError(err, ErrorContext.WEBSITE_INIT)
       if (err.message === AUTH_ERROR_LOGGED_OUT || err.message === NOT_INVITED) {
         BringDownClientAndShowError(NOT_INVITED)
       } else {
         console['error']('Error loading Unity', err)
         BringDownClientAndShowError(FAILED_FETCHING_UNITY)
       }
-      ReportFatalError(err, ErrorContext.WEBSITE_INIT)
       throw err
     }
   }

--- a/kernel/packages/shared/comms/index.ts
+++ b/kernel/packages/shared/comms/index.ts
@@ -148,10 +148,10 @@ export class PeerTrackingInfo {
     version: number | null
     status: 'ok' | 'loading' | 'error'
   } = {
-      promise: Promise.resolve(),
-      version: null,
-      status: 'loading'
-    }
+    promise: Promise.resolve(),
+    version: null,
+    status: 'loading'
+  }
 
   profileType?: ProfileType
 

--- a/kernel/packages/shared/comms/index.ts
+++ b/kernel/packages/shared/comms/index.ts
@@ -148,10 +148,10 @@ export class PeerTrackingInfo {
     version: number | null
     status: 'ok' | 'loading' | 'error'
   } = {
-    promise: Promise.resolve(),
-    version: null,
-    status: 'loading'
-  }
+      promise: Promise.resolve(),
+      version: null,
+      status: 'loading'
+    }
 
   profileType?: ProfileType
 
@@ -523,28 +523,28 @@ function processProfileRequest(context: Context, fromAlias: string, message: Pac
   if (context.sendingProfileResponse) return
 
   context.sendingProfileResponse = true
-  ;(async () => {
-    const timeSinceLastProfile = Date.now() - context.lastProfileResponseTime
+    ; (async () => {
+      const timeSinceLastProfile = Date.now() - context.lastProfileResponseTime
 
-    // We don't want to send profile responses too frequently, so we delay the response to send a maximum of 1 per TIME_BETWEEN_PROFILE_RESPONSES
-    if (timeSinceLastProfile < TIME_BETWEEN_PROFILE_RESPONSES) {
-      await sleep(TIME_BETWEEN_PROFILE_RESPONSES - timeSinceLastProfile)
-    }
+      // We don't want to send profile responses too frequently, so we delay the response to send a maximum of 1 per TIME_BETWEEN_PROFILE_RESPONSES
+      if (timeSinceLastProfile < TIME_BETWEEN_PROFILE_RESPONSES) {
+        await sleep(TIME_BETWEEN_PROFILE_RESPONSES - timeSinceLastProfile)
+      }
 
-    const profile = await ProfileAsPromise(
-      myAddress,
-      message.data.version ? parseInt(message.data.version, 10) : undefined,
-      getProfileType(myIdentity)
-    )
+      const profile = await ProfileAsPromise(
+        myAddress,
+        message.data.version ? parseInt(message.data.version, 10) : undefined,
+        getProfileType(myIdentity)
+      )
 
-    if (context.currentPosition) {
-      context.worldInstanceConnection?.sendProfileResponse(context.currentPosition, stripSnapshots(profile))
-    }
+      if (context.currentPosition) {
+        context.worldInstanceConnection?.sendProfileResponse(context.currentPosition, stripSnapshots(profile))
+      }
 
-    context.lastProfileResponseTime = Date.now()
-  })()
-    .finally(() => (context.sendingProfileResponse = false))
-    .catch((e) => defaultLogger.error('Error getting profile for responding request to comms', e))
+      context.lastProfileResponseTime = Date.now()
+    })()
+      .finally(() => (context.sendingProfileResponse = false))
+      .catch((e) => defaultLogger.error('Error getting profile for responding request to comms', e))
 }
 
 function processProfileResponse(context: Context, fromAlias: string, message: Package<ProfileResponse>) {
@@ -1007,8 +1007,8 @@ export async function connect(userId: string) {
         } catch (e) {
           disconnect()
           defaultLogger.error(`error while trying to establish communications `, e)
-          BringDownClientAndShowError(ESTABLISHING_COMMS)
           ReportFatalErrorWithCommsPayload(e, ErrorContext.COMMS_INIT)
+          BringDownClientAndShowError(ESTABLISHING_COMMS)
         }
       })
     }
@@ -1035,8 +1035,8 @@ export async function startCommunications(context: Context) {
           // max number of attemps reached => rethrow error
           logger.info(`Max number of attemps reached (${maxAttemps}), unsuccessful connection`)
           disconnect()
-          BringDownClientAndShowError(COMMS_COULD_NOT_BE_ESTABLISHED)
           ReportFatalErrorWithCommsPayload(e, ErrorContext.COMMS_INIT)
+          BringDownClientAndShowError(COMMS_COULD_NOT_BE_ESTABLISHED)
           throw e
         } else {
           // max number of attempts not reached => continue with loop
@@ -1174,7 +1174,7 @@ async function doStartCommunications(context: Context) {
       voiceCommunicator.addStreamRecordingListener((recording) => {
         store.dispatch(voiceRecordingUpdate(recording))
       })
-      ;(globalThis as any).__DEBUG_VOICE_COMMUNICATOR = voiceCommunicator
+        ; (globalThis as any).__DEBUG_VOICE_COMMUNICATOR = voiceCommunicator
     }
   } catch (e) {
     throw new ConnectionEstablishmentError(e.message)
@@ -1203,8 +1203,8 @@ function handleReconnectionError() {
 
 function handleIdTaken() {
   disconnect()
+  ReportFatalErrorWithCommsPayload(new Error(`Handle Id already taken`), ErrorContext.COMMS_INIT)
   BringDownClientAndShowError(NEW_LOGIN)
-  ReportFatalErrorWithCommsPayload(new Error(`Handle Id already taken`), `comms#init`)
 }
 
 function handleFullLayer() {

--- a/kernel/packages/shared/dao/sagas.ts
+++ b/kernel/packages/shared/dao/sagas.ts
@@ -103,8 +103,8 @@ function* loadCatalystRealms() {
       try {
         yield call(initializeCatalystCandidates)
       } catch (e) {
-        BringDownClientAndShowError(CATALYST_COULD_NOT_LOAD)
         ReportFatalErrorWithCatalystPayload(e, ErrorContext.KERNEL_INIT)
+        BringDownClientAndShowError(CATALYST_COULD_NOT_LOAD)
         throw e
       }
 

--- a/kernel/packages/shared/loading/ReportFatalError.ts
+++ b/kernel/packages/shared/loading/ReportFatalError.ts
@@ -62,7 +62,7 @@ export function BringDownClientAndShowError(event: ExecutionLifecycleEvent) {
   aborted = true
 
   if (window.Rollbar) {
-    window.Rollbar.configure({ enabled: false });
+    window.Rollbar.configure({ enabled: false })
   }
 }
 

--- a/kernel/packages/shared/store/store.ts
+++ b/kernel/packages/shared/store/store.ts
@@ -13,8 +13,8 @@ export const buildStore = () => {
   const sagaMiddleware = createSagaMiddleware({
     onError: (error: Error, { sagaStack }: { sagaStack: string }) => {
       defaultLogger.log('SAGA-ERROR: ', error)
-      BringDownClientAndShowError(error.message as any)
       ReportFatalError(error, ErrorContext.KERNEL_SAGA, { sagaStack })
+      BringDownClientAndShowError(error.message as any)
     }
   })
   const composeEnhancers = (DEBUG_REDUX && (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose

--- a/kernel/packages/unity-interface/BrowserInterface.ts
+++ b/kernel/packages/unity-interface/BrowserInterface.ts
@@ -119,7 +119,7 @@ export class BrowserInterface {
   public handleUnityMessage(type: string, message: any) {
     if (type in this) {
       // tslint:disable-next-line:semicolon
-      ;(this as any)[type](message)
+      ; (this as any)[type](message)
     } else {
       defaultLogger.info(`Unknown message (did you forget to add ${type} to unity-interface/dcl.ts?)`, message)
     }
@@ -610,8 +610,8 @@ export class BrowserInterface {
 
   public ReportAvatarFatalError() {
     // TODO(Brian): Add more parameters?
-    BringDownClientAndShowError(AVATAR_LOADING_ERROR)
     ReportFatalErrorWithUnityPayload(new Error(AVATAR_LOADING_ERROR), ErrorContext.RENDERER_AVATARS)
+    BringDownClientAndShowError(AVATAR_LOADING_ERROR)
   }
 
   public UnpublishScene(data: { coordinates: string }) {


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What does this PR fix? <!-- what is this PR? -->
## Fixes https://github.com/decentraland/unity-renderer/pull/662
Each time the user receives a black screen error, the background flow continues and during this process we are reporting extra errors that are contaminating our metrics. After any of these errors, no more errors should be tracked neither reported to rollbar.

![image](https://user-images.githubusercontent.com/64659061/124639108-0d02b100-de8c-11eb-8589-2f28149b2f73.png)

**SOLUTION:** Once the `BringDownClientAndShowError(...)` function is called, we stop track events and deactivate `Rollbar`.