### PR TITLE
feat: Remove klaviyo integration exclusion

### DIFF
--- a/kernel/packages/shared/analytics.ts
+++ b/kernel/packages/shared/analytics.ts
@@ -92,7 +92,7 @@ export function trackEvent(eventName: string, eventData: Record<string, any>) {
     return
   }
 
-  window.analytics.track(eventName, data, { integrations: { Klaviyo: false } })
+  window.analytics.track(eventName, data)
 }
 
 const TRACEABLE_AVATAR_EVENTS = [


### PR DESCRIPTION
We do not need to exclude these analytics any more, this destination is disabled in Segment now, reducing our browser HTTPS calls for a service we are not using. This commit only removes the manual exclusion, reducing the payload of events sent to segment.