### PR TITLE
feat: allow eth_getCode

### DIFF
--- a/kernel/packages/shared/ethereum/EthereumService.ts
+++ b/kernel/packages/shared/ethereum/EthereumService.ts
@@ -40,7 +40,8 @@ const whitelist = [
   'eth_getTransactionCount',
   'eth_getBlockByNumber',
   'eth_requestAccounts', // TODO: implement error-proof solution https://github.com/decentraland/explorer/issues/2156
-  'eth_signTypedData_v4'
+  'eth_signTypedData_v4',
+  'eth_getCode'
 ]
 
 function isWhitelistedRPC(msg: RPCSendableMessage) {


### PR DESCRIPTION
Allow [`eth_getCode`](https://infura.io/docs/ethereum/json-rpc/eth-getCode).

We are using this method to prevent smart contract wallets to send [meta transactions](https://github.com/decentraland/decentraland-transactions/blob/master/src/utils.ts#L101)