### PR TITLE
fix: set feature-flags opaque cookies

### DIFF
--- a/kernel/packages/shared/meta/sagas.ts
+++ b/kernel/packages/shared/meta/sagas.ts
@@ -111,7 +111,7 @@ async function fetchFeatureFlags(): Promise<Record<string, boolean> | undefined>
   const featureFlagsEndpoint = getServerConfigurations().explorerFeatureFlags
   try {
     const response = await fetch(featureFlagsEndpoint, {
-      credentials: 'same-origin'
+      credentials: 'include'
     })
     if (response.ok) {
       const { flags } = await response.json()


### PR DESCRIPTION
Sends opaque SessionID to feature-flags service to use always the same subset of feature flags. Consistenly