### PR TITLE
fix: Graphics setting "match 1080p" works as "unlimited" every time we start the explorer

### DIFF
--- a/kernel/packages/unity-interface/UnityInterface.ts
+++ b/kernel/packages/unity-interface/UnityInterface.ts
@@ -68,10 +68,6 @@ export class UnityInterface {
       return
     }
 
-    if (this.currentHeight === height) {
-      return
-    }
-
     this.currentHeight = height
     resizeCanvas(height)
   }

--- a/kernel/packages/unity-interface/UnityInterface.ts
+++ b/kernel/packages/unity-interface/UnityInterface.ts
@@ -60,11 +60,15 @@ export class UnityInterface {
   public debug: boolean = false
   public gameInstance: any
   public Module: any
-  public currentHeight: number = 1080
+  public currentHeight: number = -1
   public crashPayloadResponseObservable: Observable<string> = new Observable<string>()
 
   public SetTargetHeight(height: number): void {
     if (EDITOR) {
+      return
+    }
+
+    if (this.currentHeight === height) {
       return
     }
 


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What does this PR change? <!-- what is this PR? -->
Fix decentraland/unity-renderer/issues/817

In macOS when we have the "match 1080p" graphics resolution setting saved in the settings panel, every time we start the explorer, it works as "unlimited", thus trying to reach max resolution which is 3072 x 1920 in retina display, greatly decreasing performance.

If I manually change the resolution setting to another setting and come back to 1080, it starts working fine again.

The canvas resolution can be checked in the dev tools, at the Elements tab, looking at the attributes of the `Canvas`, child of the `GameContainer` element:

![Screen Shot 2021-07-20 at 03.06.12.png](https://images.zenhubusercontent.com/5d9200f4f58e25000108abac/68fa6e48-d004-4a78-b0f6-364b529ee821)

### Test link
https://play.decentraland.zone/branch/fix/Graphics-setting-match-1080p-works-as-unlimited-every-time-we-start-the-explorer/index.html?ENV=org