### PR TITLE
fix: the name of the component is now correct

### DIFF
--- a/kernel/packages/shared/apis/SceneStateStorageController/StorableSceneStateTranslation.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/StorableSceneStateTranslation.ts
@@ -214,7 +214,7 @@ export function fromBuildertoStateDefinitionFormat(
     for (let component of components) {
       if (component.componentId === CLASS_ID.NAME) {
         componentFound = true
-        component.data.values = component.data.value
+        component.data.value = component.data.value
         component.data.builderValue = entity.name
         break
       }


### PR DESCRIPTION
# What? 
This PR fixes a name problem with the builder in world

# Why? 

The builder in world names was not assigned correctly because there was a mismatching between the name in kernel and unity-renderer