### PR TITLE
Fix: Allow for jumps ins and gotos in layerless realms

### DIFF
--- a/kernel/packages/shared/dao/sagas.ts
+++ b/kernel/packages/shared/dao/sagas.ts
@@ -197,8 +197,6 @@ function* initializeCatalystCandidates() {
 }
 
 async function checkValidRealm(realm: Realm) {
-  debugger
-  // TODO! review this function usage
   const realmHasValues = realm && realm.domain && realm.catalystName && realm.layer
   if (!realmHasValues) {
     return false

--- a/kernel/packages/shared/dao/sagas.ts
+++ b/kernel/packages/shared/dao/sagas.ts
@@ -37,7 +37,11 @@ import {
 import { getAllCatalystCandidates, isRealmInitialized } from './selectors'
 import { saveToLocalStorage, getFromLocalStorage } from '../../atomicHelpers/localStorage'
 import defaultLogger from '../logger'
-import { BringDownClientAndShowError, ErrorContext, ReportFatalErrorWithCatalystPayload } from 'shared/loading/ReportFatalError'
+import {
+  BringDownClientAndShowError,
+  ErrorContext,
+  ReportFatalErrorWithCatalystPayload
+} from 'shared/loading/ReportFatalError'
 import { CATALYST_COULD_NOT_LOAD } from 'shared/loading/types'
 import { META_CONFIGURATION_INITIALIZED } from 'shared/meta/actions'
 import { checkTldVsWeb3Network, registerProviderNetChanges } from 'shared/web3'
@@ -193,6 +197,8 @@ function* initializeCatalystCandidates() {
 }
 
 async function checkValidRealm(realm: Realm) {
+  debugger
+  // TODO! review this function usage
   const realmHasValues = realm && realm.domain && realm.catalystName && realm.layer
   if (!realmHasValues) {
     return false

--- a/kernel/packages/shared/world/TeleportController.ts
+++ b/kernel/packages/shared/world/TeleportController.ts
@@ -174,12 +174,19 @@ async function fetchLayerUsersParcels(): Promise<ParcelArray[]> {
   const realm = getRealm(globalThis.globalStore.getState())
   const commsUrl = getCommsServer(globalThis.globalStore.getState())
 
-  // TODO! review this function usage
-  if (realm && realm.layer && commsUrl) {
-    const layerUsersResponse = await fetch(`${commsUrl}/layers/${realm.layer}/users`)
-    if (layerUsersResponse.ok) {
-      const layerUsers: LayerUserInfo[] = await layerUsersResponse.json()
-      return layerUsers.filter((it) => it.parcel).map((it) => it.parcel!)
+  if (realm && commsUrl) {
+    if (realm.layer) {
+      const layerUsersResponse = await fetch(`${commsUrl}/layers/${realm.layer}/users`)
+      if (layerUsersResponse.ok) {
+        const layerUsers: LayerUserInfo[] = await layerUsersResponse.json()
+        return layerUsers.filter((it) => it.parcel).map((it) => it.parcel!)
+      }
+    } else {
+      const commsStatusResponse = await fetch(`${commsUrl}/status?includeUsersParcels=true`)
+      if (commsStatusResponse.ok) {
+        const layerUsers = await commsStatusResponse.json()
+        return layerUsers.usersParcels
+      }
     }
   }
 

--- a/kernel/packages/shared/world/TeleportController.ts
+++ b/kernel/packages/shared/world/TeleportController.ts
@@ -174,6 +174,7 @@ async function fetchLayerUsersParcels(): Promise<ParcelArray[]> {
   const realm = getRealm(globalThis.globalStore.getState())
   const commsUrl = getCommsServer(globalThis.globalStore.getState())
 
+  // TODO! review this function usage
   if (realm && realm.layer && commsUrl) {
     const layerUsersResponse = await fetch(`${commsUrl}/layers/${realm.layer}/users`)
     if (layerUsersResponse.ok) {

--- a/kernel/packages/unity-interface/BrowserInterface.ts
+++ b/kernel/packages/unity-interface/BrowserInterface.ts
@@ -76,6 +76,7 @@ import { ProviderType } from 'decentraland-connect'
 import { BuilderServerAPIManager } from 'shared/apis/SceneStateStorageController/BuilderServerAPIManager'
 import { Store } from 'redux'
 import { areCandidatesFetched } from 'shared/dao/selectors'
+import { realmToString } from 'shared/dao/utils/realmToString'
 
 declare const globalThis: StoreContainer & { gifProcessor?: GIFProcessor }
 export let futures: Record<string, IFuture<any>> = {}
@@ -118,7 +119,7 @@ export class BrowserInterface {
   public handleUnityMessage(type: string, message: any) {
     if (type in this) {
       // tslint:disable-next-line:semicolon
-      ; (this as any)[type](message)
+      ;(this as any)[type](message)
     } else {
       defaultLogger.info(`Unknown message (did you forget to add ${type} to unity-interface/dcl.ts?)`, message)
     }
@@ -289,7 +290,11 @@ export class BrowserInterface {
   }
 
   public SendAuthentication(data: { rendererAuthenticationType: string }) {
-    const providerType: ProviderType | null = Object.values(ProviderType).includes(data.rendererAuthenticationType as ProviderType) ? data.rendererAuthenticationType as ProviderType : null
+    const providerType: ProviderType | null = Object.values(ProviderType).includes(
+      data.rendererAuthenticationType as ProviderType
+    )
+      ? (data.rendererAuthenticationType as ProviderType)
+      : null
 
     authenticateWhenItsReady(providerType)
   }
@@ -483,7 +488,7 @@ export class BrowserInterface {
       realm: { serverName, layer }
     } = data
 
-    const realmString = serverName + '-' + layer
+    const realmString = realmToString({ serverName, layer })
 
     notifyStatusThroughChat(`Jumping to ${realmString} at ${x},${y}...`)
 


### PR DESCRIPTION
# What? <!-- what is this PR? -->
In this PR:
- The jump In function is updated to use the `realmToString` function which returns the correct URL when the layer is not present
- The goto function uses the status for the island in the case there is no layer present

# Why? <!-- Explain the reason -->
...
