### PR TITLE
fix: biw hardcoded floor value

### DIFF
--- a/kernel/packages/shared/apis/SceneStateStorageController/BuilderServerAPIManager.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/BuilderServerAPIManager.ts
@@ -339,7 +339,7 @@ export class BuilderServerAPIManager {
           id: '14708436-ffd4-44d6-8a28-48d8fcb65917',
           type: 'GLTFShape',
           data: {
-            assetId: 'da1fed3c954172146414a66adfa134f7a5e1cb49c902713481bf2fe94180c2cf'
+            assetId: 'c9b17021-765c-4d9a-9966-ce93a9c323d1'
           }
         },
         '47924b6e-27ba-41a3-8bd9-c025cd092a48': {
@@ -383,7 +383,7 @@ export class BuilderServerAPIManager {
         entities: 200
       },
       ground: {
-        assetId: 'da1fed3c954172146414a66adfa134f7a5e1cb49c902713481bf2fe94180c2cf',
+        assetId: 'c9b17021-765c-4d9a-9966-ce93a9c323d1',
         componentId: 'b5edf28e-b4e4-4a27-b0ac-84b3d77eff8e'
       }
     }


### PR DESCRIPTION
# What?

This PR changes the default value of the biw floor so when it creates a new scene, it is getting the correct floor asset 

# Why? 
The builder has changed the IDs of the assets, so we need to match the new ids in order to make is work as expected
