### PR TITLE
fix: chrome 92.0.4515.107 crash

### DIFF
--- a/kernel/packages/scene-system/sdk/SceneRuntime.ts
+++ b/kernel/packages/scene-system/sdk/SceneRuntime.ts
@@ -1,7 +1,6 @@
 import { Script, inject, EventSubscriber } from 'decentraland-rpc'
 
 import { Vector2 } from 'decentraland-ecs/src'
-import { worldToGrid } from 'atomicHelpers/parcelScenePositions'
 import { sleep } from 'atomicHelpers/sleep'
 import future, { IFuture } from 'fp-future'
 
@@ -577,7 +576,13 @@ export abstract class SceneRuntime extends Script {
       }
 
       const e = event.data as IEvents['positionChanged']
-      const playerPosition = worldToGrid(e.cameraPosition)
+
+      //NOTE: calling worldToGrid from parcelScenePositions.ts here crashes kernel when there are 80+ workers since chrome 92.
+      const PARCEL_SIZE = 16
+      const playerPosition = new Vector2(
+        Math.floor(e.cameraPosition.x / PARCEL_SIZE),
+        Math.floor(e.cameraPosition.z / PARCEL_SIZE)
+      )
 
       // @ts-ignore
       if (playerPosition === undefined || this.scenePosition === undefined) {


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
When starting out from 100,100 and walking forwards, the client crashes when it reaches 80+ workers. This PR its an attempt to fix that.

### Steps to reproduce

Open this link:
https://play.decentraland.zone/branch/fix/chrome-92-crash/index.html?ENV=org&position=100,100

Walk forward until the client crashes (or not) with a `STATUS_BREAKPOINT` error.

# Why? <!-- Explain the reason -->
I have no idea.
