### PR TITLE
fix: Revert the hotfix "Set ScenesLoadRadius default value to 3"

### DIFF
--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -36,7 +36,7 @@ export namespace parcelLimits {
   export const halfParcelSize = parcelSize / 2 /* meters */
   export const centimeter = 0.01
 
-  export let visibleRadius = 3
+  export let visibleRadius = 4
 
   export const maxX = 3000
   export const maxZ = 3000

--- a/kernel/packages/unity-interface/BrowserInterface.ts
+++ b/kernel/packages/unity-interface/BrowserInterface.ts
@@ -382,7 +382,7 @@ export class BrowserInterface {
   }
 
   public SetScenesLoadRadius(data: { newRadius: number }) {
-    parcelLimits.visibleRadius = Math.min(Math.round(data.newRadius), 3)
+    parcelLimits.visibleRadius = Math.round(data.newRadius)
 
     renderDistanceObservable.notifyObservers({
       distanceInParcels: parcelLimits.visibleRadius


### PR DESCRIPTION
Revert the hotfix https://github.com/decentraland/explorer/pull/2511. It was only a temporal fix while we found a solution (https://github.com/decentraland/explorer/pull/2512), so it is no longer needed.