### PR TITLE
feat: biw asset retro compatibility

### DIFF
--- a/kernel/packages/scene-system/stateful-scene/BuilderStatefulActor.ts
+++ b/kernel/packages/scene-system/stateful-scene/BuilderStatefulActor.ts
@@ -1,6 +1,6 @@
 ﻿import { SceneStateDefinition } from './SceneStateDefinition'
 import { ILand } from 'shared/types'
-import { deserializeSceneState } from './SceneStateDefinitionSerializer'
+import { deserializeSceneState, serializeSceneState } from './SceneStateDefinitionSerializer'
 import { ISceneStateStorageController } from 'shared/apis/SceneStateStorageController/ISceneStateStorageController'
 import { CONTENT_PATH } from 'shared/apis/SceneStateStorageController/types'
 
@@ -10,6 +10,11 @@ export class BuilderStatefulActor {
   async getInititalSceneState(): Promise<SceneStateDefinition> {
     const sceneState = await this.getContentLandDefinition()
     return sceneState ? sceneState : new SceneStateDefinition()
+  }
+
+  async sendAssetsFromScene(scene: SceneStateDefinition ): Promise<string | undefined > {
+    const result = await this.sceneStorage.sendAssetsToRenderer(serializeSceneState(scene))
+    return result;
   }
 
   private async getContentLandDefinition(): Promise<SceneStateDefinition | undefined> {

--- a/kernel/packages/scene-system/stateful.scene.system.ts
+++ b/kernel/packages/scene-system/stateful.scene.system.ts
@@ -51,6 +51,8 @@ class StatefulWebWorkerScene extends Script {
     // Listen to the renderer and update the local scene state
     this.rendererActor.forwardChangesTo(this.sceneDefinition)
 
+    await this.builderActor.sendAssetsFromScene(this.sceneDefinition)
+
     // Send the initial state ot the renderer
     this.sceneDefinition.sendStateTo(this.rendererActor)
 

--- a/kernel/packages/shared/apis/SceneStateStorageController/BuilderServerAPIManager.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/BuilderServerAPIManager.ts
@@ -45,10 +45,9 @@ export class BuilderServerAPIManager {
 
   public addBuilderAssets(assets: BuilderAsset[]) {
     if (assets) {
-      try{
-      assets.forEach((asset) => this.assets.set(asset.id, asset))
-      }
-      catch(e){
+      try {
+        assets.forEach((asset) => this.assets.set(asset.id, asset))
+      } catch (e) {
         defaultLogger.error(e)
       }
     }
@@ -77,7 +76,7 @@ export class BuilderServerAPIManager {
     return assets
   }
 
-  async getBuilderAssets(assetIds: AssetId[]): Promise< BuilderAsset[]> {
+  async getBuilderAssets(assetIds: AssetId[]): Promise<BuilderAsset[]> {
     await this.getAssets(assetIds)
     const builderAssets: BuilderAsset[] = []
     assetIds.forEach((assetId) => builderAssets.push(this.assets.get(assetId)!))

--- a/kernel/packages/shared/apis/SceneStateStorageController/BuilderServerAPIManager.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/BuilderServerAPIManager.ts
@@ -43,6 +43,17 @@ export class BuilderServerAPIManager {
     return headers
   }
 
+  public addBuilderAssets(assets: BuilderAsset[]) {
+    if (assets) {
+      try{
+      assets.forEach((asset) => this.assets.set(asset.id, asset))
+      }
+      catch(e){
+        defaultLogger.error(e)
+      }
+    }
+  }
+
   async getAssets(assetIds: AssetId[]): Promise<Record<string, BuilderAsset>> {
     const unknownAssets = assetIds.filter((assetId) => !this.assets.has(assetId))
     // TODO: If there are too many assets, we might end up over the url limit, so we might need to send multiple requests
@@ -64,6 +75,13 @@ export class BuilderServerAPIManager {
       assets[assetId] = this.assets.get(assetId)!
     })
     return assets
+  }
+
+  async getBuilderAssets(assetIds: AssetId[]): Promise< BuilderAsset[]> {
+    await this.getAssets(assetIds)
+    const builderAssets: BuilderAsset[] = []
+    assetIds.forEach((assetId) => builderAssets.push(this.assets.get(assetId)!))
+    return builderAssets
   }
 
   async getConvertedAssets(assetIds: AssetId[]): Promise<Map<AssetId, Asset>> {
@@ -267,7 +285,6 @@ export class BuilderServerAPIManager {
   }
 
   private async setManifestOnServer(builderManifest: BuilderManifest, identity: ExplorerIdentity) {
-
     const queryParams = 'projects/' + builderManifest.project.id + '/manifest'
     const urlToFecth = `${this.getBaseUrl()}${queryParams}`
 

--- a/kernel/packages/shared/apis/SceneStateStorageController/ISceneStateStorageController.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/ISceneStateStorageController.ts
@@ -9,4 +9,5 @@ export interface ISceneStateStorageController {
   createProjectWithCoords(coordinates: string): Promise<boolean>
   createProjectFromStateDefinition(): Promise<SerializedSceneState | undefined>
   saveProjectInfo(sceneState: SerializedSceneState, projectName: string, projectDescription: string, projectScreenshot: string): Promise<boolean>
+  sendAssetsToRenderer(state: SerializedSceneState): Promise<string>
 }

--- a/kernel/packages/shared/apis/SceneStateStorageController/ISceneStateStorageController.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/ISceneStateStorageController.ts
@@ -1,13 +1,24 @@
 import { SerializedSceneState, DeploymentResult } from './types'
 
 export interface ISceneStateStorageController {
-  publishSceneState(sceneId: string, sceneName: string, sceneDescription: string, sceneScreenshot: string, sceneState: SerializedSceneState): Promise<DeploymentResult>
+  publishSceneState(
+    sceneId: string,
+    sceneName: string,
+    sceneDescription: string,
+    sceneScreenshot: string,
+    sceneState: SerializedSceneState
+  ): Promise<DeploymentResult>
   getStoredState(sceneId: string): Promise<SerializedSceneState | undefined>
   saveSceneState(serializedSceneState: SerializedSceneState): Promise<DeploymentResult>
   getProjectManifest(projectId: string): Promise<SerializedSceneState | undefined>
   getProjectManifestByCoordinates(land: string): Promise<SerializedSceneState | undefined>
   createProjectWithCoords(coordinates: string): Promise<boolean>
   createProjectFromStateDefinition(): Promise<SerializedSceneState | undefined>
-  saveProjectInfo(sceneState: SerializedSceneState, projectName: string, projectDescription: string, projectScreenshot: string): Promise<boolean>
+  saveProjectInfo(
+    sceneState: SerializedSceneState,
+    projectName: string,
+    projectDescription: string,
+    projectScreenshot: string
+  ): Promise<boolean>
   sendAssetsToRenderer(state: SerializedSceneState): Promise<string>
 }

--- a/kernel/packages/shared/apis/SceneStateStorageController/SceneStateStorageController.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/SceneStateStorageController.ts
@@ -9,6 +9,7 @@ import { DEBUG } from '../../../config'
 import {
   Asset,
   AssetId,
+  BuilderAsset,
   BuilderManifest,
   CONTENT_PATH,
   DeploymentResult,
@@ -153,6 +154,8 @@ export class SceneStateStorageController extends ExposableAPI implements ISceneS
         // Fetch all asset metadata
         const assets = await this.getAllAssets(sceneState)
 
+        const assetsArray = await this.getAllBuilderAssets(sceneState)
+        
         // Download asset files
         const models = await this.downloadAssetFiles(assets)
 
@@ -173,6 +176,7 @@ export class SceneStateStorageController extends ExposableAPI implements ISceneS
           [CONTENT_PATH.BUNDLED_GAME_FILE, Buffer.from(gameFile)],
           [CONTENT_PATH.SCENE_FILE, Buffer.from(JSON.stringify(sceneJson))],
           [CONTENT_PATH.SCENE_THUMBNAIL, await blobToBuffer(thumbnailBlob)],
+          [CONTENT_PATH.ASSETS, Buffer.from(JSON.stringify(assetsArray))],
           ...models
         ])
 
@@ -272,6 +276,20 @@ export class SceneStateStorageController extends ExposableAPI implements ISceneS
       const serializedScene = await this.getStoredState(sceneId)
       if (serializedScene) {
         const identity = this.getIdentity()
+        const contentClient = this.getContentClient()
+
+        const assetsFileHash: string | undefined = this.parcelIdentity.land.mappingsResponse.contents.find(
+          (pair) => pair.file === CONTENT_PATH.ASSETS
+        )?.hash
+        if(assetsFileHash)
+        {
+          const assetJson = await contentClient.downloadContent(assetsFileHash, { attempts: 3 })
+
+          if(assetJson){
+            const assets: BuilderAsset[] = JSON.parse(assetJson.toString())
+            this.builderApiManager.addBuilderAssets(assets);
+          }
+        }
 
         // Create builder manifest from serialized scene
         let builderManifest = await this.builderApiManager.builderManifestFromSerializedState(
@@ -314,7 +332,7 @@ export class SceneStateStorageController extends ExposableAPI implements ISceneS
           )?.hash
           let thumbnail: string = ''
           if (thumbnailHash) {
-            const contentClient = this.getContentClient()
+      
             const thumbnailBuffer = await contentClient.downloadContent(thumbnailHash, { attempts: 3 })
             thumbnail = thumbnailBuffer.toString('base64')
           }
@@ -335,6 +353,24 @@ export class SceneStateStorageController extends ExposableAPI implements ISceneS
       defaultLogger.error(`Failed creating project from state definition at coords ${baseParcel}`, error)
     }
   }
+
+  @exposeMethod
+  async sendAssetsToRenderer(state: SerializedSceneState): Promise<string>{
+    const assets = await this.getAllBuilderAssets(state)
+    globalThis.unityInterface.SendSceneAssets(assets)
+    return "OK"
+  }
+
+  private async getAllBuilderAssets(state: SerializedSceneState): Promise<BuilderAsset[]> {
+    const assetIds: Set<AssetId> = new Set()
+    for (const entity of state.entities) {
+      entity.components
+        .filter(({ type, value }) => type === CLASS_ID.GLTF_SHAPE && value.assetId)
+        .forEach(({ value }) => assetIds.add(value.assetId))
+    }
+    return this.builderApiManager.getBuilderAssets([...assetIds])
+  }
+
 
   private getIdentity(): ExplorerIdentity {
     const store: Store<RootState> = globalThis['globalStore']

--- a/kernel/packages/shared/apis/SceneStateStorageController/SceneStateStorageController.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/SceneStateStorageController.ts
@@ -155,7 +155,7 @@ export class SceneStateStorageController extends ExposableAPI implements ISceneS
         const assets = await this.getAllAssets(sceneState)
 
         const assetsArray = await this.getAllBuilderAssets(sceneState)
-        
+
         // Download asset files
         const models = await this.downloadAssetFiles(assets)
 
@@ -281,13 +281,12 @@ export class SceneStateStorageController extends ExposableAPI implements ISceneS
         const assetsFileHash: string | undefined = this.parcelIdentity.land.mappingsResponse.contents.find(
           (pair) => pair.file === CONTENT_PATH.ASSETS
         )?.hash
-        if(assetsFileHash)
-        {
+        if (assetsFileHash) {
           const assetJson = await contentClient.downloadContent(assetsFileHash, { attempts: 3 })
 
-          if(assetJson){
+          if (assetJson) {
             const assets: BuilderAsset[] = JSON.parse(assetJson.toString())
-            this.builderApiManager.addBuilderAssets(assets);
+            this.builderApiManager.addBuilderAssets(assets)
           }
         }
 
@@ -332,7 +331,6 @@ export class SceneStateStorageController extends ExposableAPI implements ISceneS
           )?.hash
           let thumbnail: string = ''
           if (thumbnailHash) {
-      
             const thumbnailBuffer = await contentClient.downloadContent(thumbnailHash, { attempts: 3 })
             thumbnail = thumbnailBuffer.toString('base64')
           }
@@ -355,10 +353,10 @@ export class SceneStateStorageController extends ExposableAPI implements ISceneS
   }
 
   @exposeMethod
-  async sendAssetsToRenderer(state: SerializedSceneState): Promise<string>{
+  async sendAssetsToRenderer(state: SerializedSceneState): Promise<string> {
     const assets = await this.getAllBuilderAssets(state)
     globalThis.unityInterface.SendSceneAssets(assets)
-    return "OK"
+    return 'OK'
   }
 
   private async getAllBuilderAssets(state: SerializedSceneState): Promise<BuilderAsset[]> {
@@ -370,7 +368,6 @@ export class SceneStateStorageController extends ExposableAPI implements ISceneS
     }
     return this.builderApiManager.getBuilderAssets([...assetIds])
   }
-
 
   private getIdentity(): ExplorerIdentity {
     const store: Store<RootState> = globalThis['globalStore']

--- a/kernel/packages/shared/apis/SceneStateStorageController/types.ts
+++ b/kernel/packages/shared/apis/SceneStateStorageController/types.ts
@@ -28,7 +28,8 @@ export enum CONTENT_PATH {
   SCENE_FILE = 'scene.json',
   MODELS_FOLDER = 'models',
   BUNDLED_GAME_FILE = 'bin/game.js',
-  SCENE_THUMBNAIL = 'thumbnail.png'
+  SCENE_THUMBNAIL = 'thumbnail.png',
+  ASSETS = "scene-assets.json"
 }
 
 export type DeploymentResult = { ok: true } | { ok: false; error: string }

--- a/kernel/packages/unity-interface/UnityInterface.ts
+++ b/kernel/packages/unity-interface/UnityInterface.ts
@@ -27,7 +27,7 @@ import { HotSceneInfo } from 'shared/social/hotScenes'
 import { defaultLogger } from 'shared/logger'
 import { setDelightedSurveyEnabled } from './delightedSurvey'
 import { renderStateObservable } from '../shared/world/worldState'
-import { DeploymentResult } from '../shared/apis/SceneStateStorageController/types'
+import { BuilderAsset, DeploymentResult } from '../shared/apis/SceneStateStorageController/types'
 import { QuestForRenderer } from '@dcl/ecs-quests/@dcl/types'
 import { profileToRendererFormat } from 'shared/profiles/transformations/profileToRendererFormat'
 import { WearableV2 } from 'shared/catalogs/types'
@@ -433,6 +433,10 @@ export class UnityInterface {
 
   public SendBuilderCatalogHeaders(headers: Record<string, string>) {
     this.SendMessageToUnity('Main', 'BuilderInWorldCatalogHeaders', JSON.stringify(headers))
+  }
+
+  public SendSceneAssets(assets: BuilderAsset[]) {
+    this.SendMessageToUnity('Main', 'AddAssets', JSON.stringify(assets))
   }
 
   public SetENSOwnerQueryResult(searchInput: string, profiles: Profile[] | undefined) {


### PR DESCRIPTION
# What? 

This PR sends the assets from the builder manifest to the Unity Renderer, this way we enable the retro compatibility of the assets that are no longer in the catalog so the scene still know where to look for the mappings

# Why?

Right now, since the catalog has been reuploaded, the assets ids of the old assets doesn't match any item in the catalog, this way we can still use those assets in the old scenes and load them as normal

