### PR TITLE
feat: Added functionality to ban addresses from voice chat and chat

### DIFF
--- a/kernel/packages/shared/comms/index.ts
+++ b/kernel/packages/shared/comms/index.ts
@@ -79,7 +79,7 @@ import { realmToString } from '../dao/utils/realmToString'
 import { trackEvent } from 'shared/analytics'
 import { messageReceived } from '../chat/actions'
 import { arrayEquals } from 'atomicHelpers/arrayEquals'
-import { getCommsConfig, isVoiceChatEnabledFor } from 'shared/meta/selectors'
+import { getBannedUsers, getCommsConfig, isVoiceChatEnabledFor } from 'shared/meta/selectors'
 import { ensureMetaConfigurationInitialized } from 'shared/meta/index'
 import {
   BringDownClientAndShowError,
@@ -112,6 +112,7 @@ import Html from 'shared/Html'
 import { isFeatureToggleEnabled } from 'shared/selectors'
 import * as qs from 'query-string'
 import { MinPeerData, Position3D } from '@dcl/catalyst-peer'
+import { BannedUsers } from 'shared/meta/types'
 
 export type CommsVersion = 'v1' | 'v2'
 export type CommsMode = CommsV1Mode | CommsV2Mode
@@ -455,7 +456,7 @@ function processChatMessage(context: Context, fromAlias: string, message: Packag
           timestamp: parseInt(timestamp, 10)
         })
       } else {
-        if (profile && user.userId && !isBlocked(profile, user.userId)) {
+        if (profile && user.userId && !isBlockedOrBanned(profile, getBannedUsers(store.getState()), user.userId)) {
           const messageEntry: InternalChatMessage = {
             messageType: ChatMessageType.PUBLIC,
             messageId: msgId,
@@ -493,7 +494,7 @@ function shouldPlayVoice(profile: Profile, voiceUserId: string) {
   const myAddress = getIdentity()?.address
   return (
     isVoiceAllowedByPolicy(profile, voiceUserId) &&
-    !isBlocked(profile, voiceUserId) &&
+    !isBlockedOrBanned(profile, getBannedUsers(store.getState()), voiceUserId) &&
     !isMuted(profile, voiceUserId) &&
     !hasBlockedMe(myAddress, voiceUserId) &&
     isVoiceChatAllowedByCurrentScene()
@@ -531,28 +532,28 @@ function processProfileRequest(context: Context, fromAlias: string, message: Pac
   if (context.sendingProfileResponse) return
 
   context.sendingProfileResponse = true
-  ;(async () => {
-    const timeSinceLastProfile = Date.now() - context.lastProfileResponseTime
+    ; (async () => {
+      const timeSinceLastProfile = Date.now() - context.lastProfileResponseTime
 
-    // We don't want to send profile responses too frequently, so we delay the response to send a maximum of 1 per TIME_BETWEEN_PROFILE_RESPONSES
-    if (timeSinceLastProfile < TIME_BETWEEN_PROFILE_RESPONSES) {
-      await sleep(TIME_BETWEEN_PROFILE_RESPONSES - timeSinceLastProfile)
-    }
+      // We don't want to send profile responses too frequently, so we delay the response to send a maximum of 1 per TIME_BETWEEN_PROFILE_RESPONSES
+      if (timeSinceLastProfile < TIME_BETWEEN_PROFILE_RESPONSES) {
+        await sleep(TIME_BETWEEN_PROFILE_RESPONSES - timeSinceLastProfile)
+      }
 
-    const profile = await ProfileAsPromise(
-      myAddress,
-      message.data.version ? parseInt(message.data.version, 10) : undefined,
-      getProfileType(myIdentity)
-    )
+      const profile = await ProfileAsPromise(
+        myAddress,
+        message.data.version ? parseInt(message.data.version, 10) : undefined,
+        getProfileType(myIdentity)
+      )
 
-    if (context.currentPosition) {
-      context.worldInstanceConnection?.sendProfileResponse(context.currentPosition, stripSnapshots(profile))
-    }
+      if (context.currentPosition) {
+        context.worldInstanceConnection?.sendProfileResponse(context.currentPosition, stripSnapshots(profile))
+      }
 
-    context.lastProfileResponseTime = Date.now()
-  })()
-    .finally(() => (context.sendingProfileResponse = false))
-    .catch((e) => defaultLogger.error('Error getting profile for responding request to comms', e))
+      context.lastProfileResponseTime = Date.now()
+    })()
+      .finally(() => (context.sendingProfileResponse = false))
+      .catch((e) => defaultLogger.error('Error getting profile for responding request to comms', e))
 }
 
 function processProfileResponse(context: Context, fromAlias: string, message: Package<ProfileResponse>) {
@@ -569,6 +570,15 @@ function processProfileResponse(context: Context, fromAlias: string, message: Pa
     // If we received an unexpected profile, maybe the profile saga can use this preemptively
     store.dispatch(localProfileReceived(profile.userId, profile))
   }
+}
+
+function isBlockedOrBanned(profile: Profile, bannedUsers: BannedUsers, userId: string): boolean {
+  return isBlocked(profile, userId) || isBannedFromChat(bannedUsers, userId)
+}
+
+function isBannedFromChat(bannedUsers: BannedUsers, userId: string): boolean {
+  const bannedUser = bannedUsers[userId]
+  return bannedUser && bannedUser.some(it => it.type === 'VOICE_CHAT_AND_CHAT' && it.expiration > Date.now())
 }
 
 function isBlocked(profile: Profile, userId: string): boolean {
@@ -1217,7 +1227,7 @@ async function doStartCommunications(context: Context) {
       voiceCommunicator.addStreamRecordingListener((recording) => {
         store.dispatch(voiceRecordingUpdate(recording))
       })
-      ;(globalThis as any).__DEBUG_VOICE_COMMUNICATOR = voiceCommunicator
+        ; (globalThis as any).__DEBUG_VOICE_COMMUNICATOR = voiceCommunicator
     }
   } catch (e) {
     throw new ConnectionEstablishmentError(e.message)

--- a/kernel/packages/shared/meta/sagas.ts
+++ b/kernel/packages/shared/meta/sagas.ts
@@ -3,7 +3,7 @@ import { FORCE_RENDERING_STYLE, getDefaultAssetBundlesBaseUrl, getServerConfigur
 import { META_CONFIGURATION_INITIALIZED, metaConfigurationInitialized, metaUpdateMessageOfTheDay } from './actions'
 import defaultLogger from '../logger'
 import { buildNumber } from './env'
-import { MetaConfiguration, USE_UNITY_INDEXED_DB_CACHE, WorldConfig } from './types'
+import { BannedUsers, MetaConfiguration, USE_UNITY_INDEXED_DB_CACHE, WorldConfig } from './types'
 import { isMetaConfigurationInitiazed } from './selectors'
 import { USER_AUTHENTIFIED } from '../session/actions'
 import { getUserId } from '../session/selectors'
@@ -19,6 +19,7 @@ const DEFAULT_META_CONFIGURATION: MetaConfiguration = {
     denied: [],
     contentWhitelist: []
   },
+  bannedUsers: {},
   synapseUrl: 'https://chat.decentraland.zone',
   world: {
     pois: []
@@ -29,12 +30,24 @@ const DEFAULT_META_CONFIGURATION: MetaConfiguration = {
   }
 }
 
+function bannedUsersFromVariants(variants: Record<string, any> | undefined): BannedUsers | undefined {
+  const variant = variants?.["explorer-banned_users"]
+  if (variant && variant.enabled) {
+    try {
+      return JSON.parse(variant.payload.value)
+    } catch (e) {
+      defaultLogger.warn("Couldn't parse banned users from variants. The variants response was: ", variants)
+    }
+  }
+}
+
 export function* metaSaga(): any {
   const config: Partial<MetaConfiguration> = yield call(fetchMetaConfiguration)
-  const featureFlags: Record<string, boolean> | undefined = yield call(fetchFeatureFlags)
+  const flagsAndVariants: { flags: Record<string, boolean>, variants: Record<string, any> } | undefined = yield call(fetchFeatureFlagsAndVariants)
   const merge: Partial<MetaConfiguration> = {
     ...config,
-    featureFlags
+    featureFlags: flagsAndVariants?.flags,
+    bannedUsers: bannedUsersFromVariants(flagsAndVariants?.variants)
   }
 
   if (FORCE_RENDERING_STYLE) {
@@ -107,15 +120,14 @@ function checkExplorerVersion(config: Partial<MetaConfiguration>) {
   }
 }
 
-async function fetchFeatureFlags(): Promise<Record<string, boolean> | undefined> {
+async function fetchFeatureFlagsAndVariants(): Promise<Record<string, boolean> | undefined> {
   const featureFlagsEndpoint = getServerConfigurations().explorerFeatureFlags
   try {
     const response = await fetch(featureFlagsEndpoint, {
       credentials: 'include'
     })
     if (response.ok) {
-      const { flags } = await response.json()
-      return flags
+      return response.json()
     }
   } catch (e) {
     defaultLogger.warn(`Error while fetching feature flags from '${featureFlagsEndpoint}'. Using default config`)

--- a/kernel/packages/shared/meta/selectors.ts
+++ b/kernel/packages/shared/meta/selectors.ts
@@ -1,4 +1,4 @@
-import { CommsConfig, FeatureFlags, MessageOfTheDayConfig, RootMetaState } from './types'
+import { BannedUsers, CommsConfig, FeatureFlags, MessageOfTheDayConfig, RootMetaState } from './types'
 import { Vector2Component } from 'atomicHelpers/landHelpers'
 import { getCatalystNodesDefaultURL, VOICE_CHAT_DISABLED_FLAG, WORLD_EXPLORER } from 'config'
 
@@ -33,6 +33,8 @@ export const isMetaConfigurationInitiazed = (store: RootMetaState): boolean => s
 export const getPois = (store: RootMetaState): Vector2Component[] => store.meta.config.world?.pois || []
 
 export const getCommsConfig = (store: RootMetaState): CommsConfig => store.meta.config.comms ?? {}
+
+export const getBannedUsers = (store: RootMetaState): BannedUsers => store.meta.config.bannedUsers ?? {}
 
 export const isMOTDInitialized = (store: RootMetaState): boolean =>
   store.meta.config.world ? store.meta.config.world?.messageOfTheDayInit || false : false

--- a/kernel/packages/shared/meta/types.ts
+++ b/kernel/packages/shared/meta/types.ts
@@ -17,11 +17,19 @@ export type MetaConfiguration = {
     contentWhitelist: string[]
     catalystsNodesEndpoint?: string
   }
+  bannedUsers: BannedUsers
   synapseUrl: string
   world: WorldConfig
   comms: CommsConfig
   minCatalystVersion?: string
   featureFlags?: Record<string, boolean>
+}
+
+export type BannedUsers = Record<string, Ban[]>
+
+export type Ban = {
+  type: "VOICE_CHAT_AND_CHAT" // For now we only handle one ban type
+  expiration: number // Timestamp
 }
 
 export type WorldConfig = {


### PR DESCRIPTION
Closes #2519 

This allows the configuration of addresses to be banned from voice chat and chat. This is intended as a temporary solution to comply with DAO requests, like this one: https://governance.decentraland.org/proposal/?id=7d29f610-e656-11eb-89c8-f9c6d1f05e5b, until we come up with an automatic and decentralized solution. See: https://github.com/decentraland/catalyst/issues/601
