### PR TITLE
fix: Show warning notification for not recommended browsers (only Kernel side)

### DIFF
--- a/kernel/packages/shared/comms/browser.ts
+++ b/kernel/packages/shared/comms/browser.ts
@@ -1,6 +1,21 @@
+export const recommendedBrowsers: string[] = [
+  "Chrome",
+  "Firefox"
+]
+
 export function isWebGLCompatible() {
   // Create canvas element. The canvas is not added to the document itself, so it is never displayed in the browser window.
   var canvas = <HTMLCanvasElement>document.createElement("canvas");
   var gl = canvas.getContext("webgl2")
   return gl && gl instanceof WebGL2RenderingContext
+}
+
+export function isRecommendedBrowser() {
+  for (let i = 0; i < recommendedBrowsers.length; i++) {
+    if (navigator.userAgent.indexOf(recommendedBrowsers[i]) != -1) {
+      return true
+    }
+  }
+
+  return false
 }


### PR DESCRIPTION
# What does this PR fix?
Fix https://github.com/decentraland/unity-renderer/pull/708

We have decided not to have a "black list" of prohibited browsers and only deny browsers due to technical limitations such as not supporting WebGL2. If an user enters with a browser that is compatible with WebGL2 but not recommended by us (any browser different to Firefox or any not chromium-based browser), we will show him a warning in the landing page indicating it but we won't cut his entrance to the world.