### PR TITLE
fix: Revert "fix: Quests default url was using the wrong TLD (#2530)"

### DIFF
--- a/kernel/packages/config/index.ts
+++ b/kernel/packages/config/index.ts
@@ -294,7 +294,7 @@ export function getServerConfigurations() {
   const metaFeatureFlagsBaseUrl = `https://feature-flags.decentraland.${notToday}/explorer.json`
 
   const QUESTS_SERVER_URL =
-    ensureSingleString(qs.QUESTS_SERVER_URL) ?? `https://quests-api.decentraland.${notToday === 'org' ? 'co' : 'io'}`
+    ensureSingleString(qs.QUESTS_SERVER_URL) ?? `https://quests-api.decentraland.${notToday === 'org' ? 'org' : 'io'}`
 
   return {
     wearablesApi: `https://${WEARABLE_API_DOMAIN}/${WEARABLE_API_PATH_PREFIX}`,


### PR DESCRIPTION
It was the correct url all along